### PR TITLE
Name changes and indentation fix

### DIFF
--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -1,8 +1,9 @@
 use apint::{ApInt};
+use apint::utils::DataAccessMut;
 use apint::utils::ZipDataAccessMut::{Inl, Ext};
 use traits::{Width};
 use errors::{DivOp, Error, Result};
-use digit::{Digit, DigitRepr};
+use digit::{Digit, DoubleDigit, DigitRepr};
 use ll;
 use utils::{try_forward_bin_mut_impl, forward_mut_impl};
 
@@ -19,6 +20,39 @@ use std::ops::{
 /// # Arithmetic Operations
 impl ApInt {
 
+	/// Increments this `ApInt` by one inplace and returns the result
+	/// 
+	/// **Note:** This will **not** allocate memory.
+	pub fn into_wrapping_inc(self) -> ApInt {
+		forward_mut_impl(self, ApInt::wrapping_inc)
+	}
+
+	/// Increments this `ApInt` by one inplace and returns the result
+	/// 
+	/// **Note:** This will **not** allocate memory
+	pub fn wrapping_inc(&mut self) {
+		match self.access_data_mut() {
+			DataAccessMut::Inl(x) => {
+				*x = x.wrapping_add(Digit::one());
+			}
+			DataAccessMut::Ext(x) => {
+				for i in 0..x.len() {
+					match x[i].repr().overflowing_add(1) {
+						(v,false) => {
+							x[i] = Digit(v);
+							break;
+						}
+						(v,true) => {
+							//if the ApInt was relatively random this should rarely happen
+							x[i] = Digit(v);
+						}
+					}
+				}
+			}
+		}
+		self.clear_unused_bits();
+	}
+
 	/// Negates this `ApInt` inplace and returns the result.
 	/// 
 	/// **Note:** This will **not** allocate memory.
@@ -30,16 +64,9 @@ impl ApInt {
 	/// 
 	/// **Note:** This will **not** allocate memory.
 	pub fn negate(&mut self) {
-		let width = self.width();
 		self.bitnot();
-		// self.increment_by(1); // This is not implemented, yet.
-		                         // Replace `self.checked_add_assign(..)` with this
-		                         // as soon as possible for avoiding temporary
-		                         // expensive copies of `self`.
-		self.checked_add_assign(&ApInt::one(width))
-			.expect("This operation cannot fail since the temporary `ApInt`\
-			         and `self` are ensured to always have the same bit width.");
-		self.clear_unused_bits();
+		self.wrapping_inc();
+		//`wrapping_inc` handles clearing the unused bits
 	}
 
 	/// Adds `rhs` to `self` and returns the result.
@@ -148,16 +175,232 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
+	/// 
+	/// # Performance
+	/// 
+	/// If the function detects a large string of zeros in front of the most significant 1 bit,
+	/// it will apply optimizations so that wasted multiplications and additions of zero are avoided.
+	/// This function is designed to efficiently handle 5 common kinds of multiplication.
+	/// Small here means both small ApInt size and/or small numerical significance 
+	/// 	- multiplication of zero by any size integer (no allocation)
+	/// 	- multiplication of small (<= 64 bits) integers (no allocation)
+	/// 	- wrapping multiplication of medium size (<= 512 bits) integers
+	/// 	- multiplication of medium size integers that will not overflow
+	/// 	- multiplication of small integers by large integers
+	/// 	  (or large integers multiplied by small integers) (no allocation)
+	/// Currently, Karatsuba multiplication is not implemented, so large integer multiplication 
+	/// may be very slow compared to other algorithms.
 	pub fn checked_mul_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		match self.zip_access_data_mut(rhs)? {
 			Inl(lhs, rhs) => {
-				let lval = lhs.repr();
-				let rval = rhs.repr();
-				let result = lval.wrapping_mul(rval);
-				*lhs = Digit(result);
+				*lhs = lhs.wrapping_mul(rhs);
 			}
-			Ext(_lhs, _rhs) => {
-				unimplemented!()
+			//NOTE: this part assumes that an Ext ApInt will always have at least 2 digits
+			Ext(lhs, rhs) => {
+				//wrapping long multiplication, in the future we could have karatsuba multiplication for larger ints (wikipedia says 320-640 bits is about where karatsuba multiplication algorithms become faster)
+
+				//finds the most significant nonzero digit (for later optimizations) and handles early return of multiplication by zero.
+
+				let rhs_sig_nonzero: usize = match rhs.iter().rposition(|x| x != &Digit::zero()) {
+					Some(x) => x,
+					None => {
+						for x in lhs.iter_mut() {
+							x.unset_all()
+						}
+						return Ok(());
+					}
+				};
+				let lhs_sig_nonzero: usize = match lhs.iter().rposition(|x| x != &Digit::zero()) {
+					Some(x) => x,
+					None => {
+						for x in lhs.iter_mut() {
+							x.unset_all()
+						}
+						return Ok(());
+					}
+				};
+				//for several routines below there was a nested loop that had its first and last iterations unrolled (and the unrolled loops had their first and last iterations unrolled), and then some if statements are added for overflow checks.
+				//This is done because the compiler probably cannot properly unroll the carry system, overflow system, and figure out that only digit multiplications were needed instead of doubledigit mults in some places.
+				match (lhs_sig_nonzero == 0, rhs_sig_nonzero == 0) {
+					(false, false) => {
+						if lhs_sig_nonzero + rhs_sig_nonzero + 2 <= lhs.len() {
+							//no possibility of overflow
+							//first digit of first row
+							let mult = lhs[0];
+							let temp = mult.carrying_mul(rhs[0]);
+							//middle digits of first row
+							//the goal here with `sum` is to allocate and initialize it only once here.
+							let mut sum = Vec::with_capacity(lhs_sig_nonzero + rhs_sig_nonzero + 2);
+							sum.push(temp.0);
+							let mut mul_carry = temp.1;
+							for rhs_i in 1..rhs_sig_nonzero {
+								let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+								sum.push(temp.0);
+								mul_carry = temp.1;
+							}
+							let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+							sum.push(temp.0);
+							sum.push(temp.1);
+							//middle rows
+							for lhs_i in 1..lhs_sig_nonzero {
+								let mult = lhs[lhs_i];
+								//first digit of this row
+								let temp0 = mult.carrying_mul(rhs[0]);
+								let mut mul_carry = temp0.1;
+								let temp1 = sum[lhs_i].carrying_add(temp0.0);
+								sum[lhs_i] = temp1.0;
+								let mut add_carry = temp1.1;
+								//middle digits of this row
+								for rhs_i in 1..rhs_sig_nonzero {
+									let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+									mul_carry = temp0.1;
+									let temp1: DoubleDigit = sum[lhs_i + rhs_i]
+										.dd()
+										.wrapping_add(temp0.0.dd())
+										.wrapping_add(add_carry.dd());
+									sum[lhs_i + rhs_i] = temp1.lo();
+									add_carry = temp1.hi();
+								}
+								//final digits of this row
+								let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero],mul_carry);
+								let temp1: DoubleDigit = sum[lhs_i + rhs_sig_nonzero]
+									.dd()
+									.wrapping_add(temp0.0.dd())
+									.wrapping_add(add_carry.dd());
+								sum[lhs_i + rhs_sig_nonzero] = temp1.lo();
+								sum.push(temp1.hi().wrapping_add(temp0.1));
+							}
+							let mult = lhs[lhs_sig_nonzero];
+							//first digit of final row
+							let temp0 = mult.carrying_mul(rhs[0]);
+							let mut mul_carry = temp0.1;
+							let temp1 = sum[lhs_sig_nonzero].carrying_add(temp0.0);
+							sum[lhs_sig_nonzero] = temp1.0;
+							let mut add_carry = temp1.1;
+							//middle digits of final row
+							println!("{:?}",sum);
+							for rhs_i in 1..rhs_sig_nonzero {
+								let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+								mul_carry = temp0.1;
+								let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_i]
+									.dd()
+									.wrapping_add(temp0.0.dd())
+									.wrapping_add(add_carry.dd());
+								sum[lhs_sig_nonzero + rhs_i] = temp1.lo();
+								add_carry = temp1.hi();
+							}
+							let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+							let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_sig_nonzero]
+								.dd()
+								.wrapping_add(temp0.0.dd())
+								.wrapping_add(add_carry.dd());
+							sum[lhs_sig_nonzero + rhs_sig_nonzero] = temp1.lo();
+							sum.push(temp1.hi().wrapping_add(temp0.1));
+							for i in 0..sum.len() {
+								lhs[i] = sum[i];
+							}
+							return Ok(())
+						} else {
+							//wrapping (modular) multiplication
+							let sig_nonzero = lhs.len() - 1;
+							//first digit done and carry
+							let temp = lhs[0].carrying_mul(rhs[0]);
+							//the goal here with `sum` is to allocate and initialize it only once here.
+							//first row
+							let mut sum = Vec::with_capacity(lhs.len());
+							sum.push(temp.0);
+							let mut mul_carry = temp.1;
+							for rhs_i in 1..sig_nonzero {
+								let temp = lhs[0].carrying_mul_add(rhs[rhs_i], mul_carry);
+								sum.push(temp.0);
+								mul_carry = temp.1;
+							}
+							//final digit of first row
+							sum.push(lhs[0].wrapping_mul_add(rhs[sig_nonzero], mul_carry));
+							//middle rows
+							for lhs_i in 1..sig_nonzero {
+								//first digit of this row
+								let temp0 = lhs[lhs_i].carrying_mul(rhs[0]);
+								mul_carry = temp0.1;
+								let temp1 = sum[lhs_i].carrying_add(temp0.0);
+								//sum[lhs_i] does not need to be used again
+								sum[lhs_i] = temp1.0;
+								let mut add_carry = temp1.1;
+								//as we get to the higher lhs digits, the higher rhs digits do not need to be considered
+								let rhs_i_upper = sig_nonzero.wrapping_sub(lhs_i);
+								//middle digits of this row
+								for rhs_i in 1..rhs_i_upper {
+									let temp0 = lhs[lhs_i].carrying_mul_add(rhs[rhs_i], mul_carry);
+									mul_carry = temp0.1;
+									let temp1: DoubleDigit = sum[lhs_i + rhs_i]
+										.dd()
+										.wrapping_add(temp0.0.dd())
+										.wrapping_add(add_carry.dd());
+									sum[lhs_i + rhs_i] = temp1.lo();
+									add_carry = temp1.hi();
+									}
+								//final digit of this row
+								sum[sig_nonzero] = lhs[lhs_i]
+									.wrapping_mul(rhs[rhs_i_upper])
+									.wrapping_add(mul_carry)
+									.wrapping_add(sum[sig_nonzero])
+									.wrapping_add(add_carry);
+							}
+							for i in 0..sig_nonzero {
+								lhs[i] = sum[i];
+							}
+							//final digit (the only one in its row)
+							lhs[sig_nonzero] = lhs[sig_nonzero].wrapping_mul_add(rhs[0], sum[sig_nonzero]);
+							return Ok(())
+						}
+					},
+					(true, false) => {
+						let mult = lhs[0];
+						//first digit done and carry
+						let temp = mult.carrying_mul(rhs[0]);
+						lhs[0] = temp.0;
+						let mut mul_carry = temp.1;
+						//middle of row
+						for rhs_i in 1..rhs_sig_nonzero {
+							let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+							lhs[rhs_i] = temp.0;
+							mul_carry = temp.1;
+						}
+						//final digit
+						if rhs_sig_nonzero == lhs.len() - 1 {
+							lhs[rhs_sig_nonzero] = mult.wrapping_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+						} else {
+							let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+							lhs[rhs_sig_nonzero] = temp.0;
+							lhs[rhs_sig_nonzero + 1] = temp.1;
+						}
+					},
+					(false, true) => {
+						//first digit done and carry
+						let temp = rhs[0].carrying_mul(lhs[0]);
+						lhs[0] = temp.0;
+						let mut mul_carry = temp.1;
+						//middle of row
+						for lhs_i in 1..lhs_sig_nonzero {
+							let temp = rhs[0].carrying_mul_add(lhs[lhs_i], mul_carry);
+							lhs[lhs_i] = temp.0;
+							mul_carry = temp.1;
+						}
+						//final digit
+						if lhs_sig_nonzero == lhs.len() - 1 {
+							lhs[lhs_sig_nonzero] = rhs[0].wrapping_mul_add(lhs[lhs_sig_nonzero], mul_carry);
+						} else {
+							let temp = rhs[0].carrying_mul_add(lhs[lhs_sig_nonzero], mul_carry);
+							lhs[lhs_sig_nonzero] = temp.0;
+							lhs[lhs_sig_nonzero + 1] = temp.1;
+						}
+					},
+					(true, true) => {
+						let temp0 = lhs[0].carrying_mul(rhs[0]);
+						lhs[0] = temp0.0;
+						lhs[1] = temp0.1;
+					}
+				}
 			}
 		}
 		self.clear_unused_bits();
@@ -478,9 +721,26 @@ impl<'a> MulAssign<&'a ApInt> for ApInt {
 mod tests {
 	use super::*;
 
+	mod inc {
+		use super::*;
+		use std::u64;
+
+		#[test]
+		fn test() {
+			assert_eq!(ApInt::from(14u8).into_wrapping_inc(),ApInt::from(15u8));
+			assert_eq!(ApInt::from(15u8).into_wrapping_inc(),ApInt::from(16u8));
+			assert_eq!(ApInt::from(16u8).into_wrapping_inc(),ApInt::from(17u8));
+			assert_eq!(ApInt::from(17u8).into_wrapping_inc(),ApInt::from(18u8));
+			assert_eq!(ApInt::from([0u64,0,0]).into_wrapping_inc(),ApInt::from([0u64,0,1]));			
+			assert_eq!(ApInt::from([0,7,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,8,0]));
+			assert_eq!(ApInt::from([u64::MAX,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,0]));
+			assert_eq!(ApInt::from([0,u64::MAX,u64::MAX - 1]).into_wrapping_inc(),ApInt::from([0,u64::MAX,u64::MAX]));
+			assert_eq!(ApInt::from([0,u64::MAX,0]).into_wrapping_inc(),ApInt::from([0,u64::MAX,1]));	
+		}
+	}
+
 	mod negate {
 		use super::*;
-
 		use bitwidth::{BitWidth};
 
 		fn assert_symmetry(input: ApInt, expected: ApInt) {
@@ -513,13 +773,149 @@ mod tests {
 
 	mod mul {
 		use super::*;
+		use bitwidth::BitWidth;
+		use std::{u8,u64};
 
 		#[test]
-		fn simple() {
-			let lhs = ApInt::from(11_u32);
-			let rhs = ApInt::from(5_u32);
-			let result = lhs.into_checked_mul(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(55_u32));
+		fn rigorous() {
+			//there are many special case and size optimization paths, so this test must be very rigorous.
+
+			//multiplication of apints composed of only u8::MAX in their least significant digits
+			//only works for num_u8 > 1
+			fn nine_test(num_u8: usize) {
+				let mut lhs;
+				let mut rhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+				let nine =
+					ApInt::from(u8::MAX).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+				for rhs_nine in 1..=num_u8 {
+					rhs.checked_shl_assign(8).unwrap();
+					rhs |= &nine;
+					lhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+					'outer: for lhs_nine in 1..=num_u8 {
+						lhs.checked_shl_assign(8).unwrap();
+						lhs |= &nine;
+						//imagine multiplying a string of base 10 nines together.
+						//It will produce things like 998001, 8991, 98901, 9989001.
+						//this uses a formula for the number of nines, eights, and zeros except here nine is u8::MAX, eight is u8::MAX - 1, and zero is 0u8
+						let mut zeros_after_one = if lhs_nine < rhs_nine {
+							lhs_nine - 1
+						} else {
+							rhs_nine - 1
+						};
+						let mut nines_before_eight = if lhs_nine > rhs_nine {
+							lhs_nine - rhs_nine
+						} else {
+							rhs_nine - lhs_nine
+						};
+						let mut nines_after_eight = if lhs_nine < rhs_nine {
+							lhs_nine - 1
+						} else {
+							rhs_nine - 1
+						};
+						let mut result = lhs.clone().into_checked_mul(&rhs).unwrap();
+						assert_eq!(result.clone().resize_to_u8(), 1u8);
+						for i in 0..zeros_after_one {
+							if i >= num_u8 - 1 {
+								continue 'outer;
+							}
+							result.checked_lshr_assign(8).unwrap();
+							let temp = result.clone().resize_to_u8();
+							if temp != 0 {
+								panic!(
+									"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+									lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+								);
+							}
+						}
+						for i in 0..nines_before_eight {
+							if zeros_after_one + i >= num_u8 - 1 {
+								continue 'outer;
+							}
+							result.checked_lshr_assign(8).unwrap();
+							assert_eq!(result.clone().resize_to_u8(), u8::MAX);
+						}
+						if zeros_after_one + nines_before_eight >= num_u8 - 1 {
+							continue 'outer;
+						}
+						result.checked_lshr_assign(8).unwrap();
+						let temp = result.clone().resize_to_u8();
+						if temp != u8::MAX - 1 {
+							panic!(
+								"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+								lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+							);
+						}
+						for i in 0..nines_after_eight {
+							if 1 + zeros_after_one + nines_before_eight + i >= num_u8 - 1 {
+								continue 'outer;
+							}
+							result.checked_lshr_assign(8).unwrap();
+							if result.clone().resize_to_u8() != u8::MAX {
+								panic!(
+									"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+									lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+								);
+							}
+						}
+					}
+				}
+			}
+			//test inl apints
+			assert_eq!(
+				ApInt::from(u8::MAX)
+					.into_checked_mul(&ApInt::from(u8::MAX))
+					.unwrap(),
+				ApInt::from(1u8)
+			);
+			nine_test(2);
+			nine_test(3);
+			nine_test(4);
+			nine_test(7);
+			nine_test(8);
+			//test ext apints
+			nine_test(9);
+			nine_test(16);
+			//5 digits wide
+			nine_test(40);
+			nine_test(63);
+			//non overflowing test
+			let resize = [
+				7usize, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 137, 200, 255,
+				256, 700, 907, 1024, 2018, 2019,
+			];
+			let lhs_shl = [
+				0usize, 1, 0, 1, 4, 7, 4, 10, 13, 0, 31, 25, 7, 17, 32, 50, 0, 64, 249, 8, 777, 0,
+				1000, 0,
+			];
+			let rhs_shl = [
+				0usize, 0, 1, 1, 3, 6, 4, 14, 10, 0, 0, 25, 0, 18, 32, 49, 100, 64, 0, 256, 64,
+				900, 1000, 0,
+			];
+			for (i, _) in resize.iter().enumerate() {
+				let mut lhs = ApInt::from(5u8)
+					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
+					.into_checked_shl(lhs_shl[i])
+					.unwrap();
+				let mut rhs = ApInt::from(11u8)
+					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
+					.into_checked_shl(rhs_shl[i])
+					.unwrap();
+				let mut zero = ApInt::from(0u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
+				let mut one = ApInt::from(1u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
+				let mut expected = ApInt::from(55u8)
+					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
+					.into_checked_shl(rhs_shl[i] + lhs_shl[i])
+					.unwrap();
+				assert_eq!(lhs.clone().into_checked_mul(&zero).unwrap(), zero);
+				assert_eq!(zero.clone().into_checked_mul(&rhs).unwrap(), zero);
+				assert_eq!(lhs.clone().into_checked_mul(&one).unwrap(), lhs);
+				assert_eq!(one.clone().into_checked_mul(&rhs).unwrap(), rhs);
+				assert_eq!(lhs.clone().into_checked_mul(&rhs).unwrap(), expected);
+			}
+			assert_eq!(
+				ApInt::from([0,0,0,0,u64::MAX,0,u64::MAX,u64::MAX])
+				.into_checked_mul(&ApInt::from([0,0,0,0,u64::MAX,u64::MAX,0,u64::MAX])).unwrap()
+				,ApInt::from([u64::MAX,0,1,u64::MAX - 3,1,u64::MAX,u64::MAX,1]));
 		}
 	}
 

--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -56,14 +56,14 @@ impl ApInt {
 	/// Negates this `ApInt` inplace and returns the result.
 	/// 
 	/// **Note:** This will **not** allocate memory.
-	pub fn into_negate(self) -> ApInt {
-		forward_mut_impl(self, ApInt::negate)
+	pub fn into_wrapping_neg(self) -> ApInt {
+		forward_mut_impl(self, ApInt::wrapping_neg)
 	}
 
 	/// Negates this `ApInt` inplace.
 	/// 
 	/// **Note:** This will **not** allocate memory.
-	pub fn negate(&mut self) {
+	pub fn wrapping_neg(&mut self) {
 		self.bitnot();
 		self.wrapping_inc();
 		//`wrapping_inc` handles clearing the unused bits
@@ -76,8 +76,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_add(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_add_assign)
+	pub fn into_wrapping_add(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_add_assign)
 	}
 
 	/// Add-assigns `rhs` to `self` inplace.
@@ -87,7 +87,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_add_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_add_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		match self.zip_access_data_mut(rhs)? {
 			Inl(lhs, rhs) => {
 				let lval = lhs.repr();
@@ -117,8 +117,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_sub(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_sub_assign)
+	pub fn into_wrapping_sub(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sub_assign)
 	}
 
 	/// Subtract-assigns `rhs` from `self` inplace.
@@ -131,7 +131,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_sub_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_sub_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		match self.zip_access_data_mut(rhs)? {
 			Inl(lhs, rhs) => {
 				let lval = lhs.repr();
@@ -161,8 +161,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_mul(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_mul_assign)
+	pub fn into_wrapping_mul(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_mul_assign)
 	}
 
 	/// Multiply-assigns `rhs` to `self` inplace.
@@ -190,7 +190,7 @@ impl ApInt {
 	/// 	  (or large integers multiplied by small integers) (no allocation)
 	/// Currently, Karatsuba multiplication is not implemented, so large integer multiplication 
 	/// may be very slow compared to other algorithms.
-	pub fn checked_mul_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_mul_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		match self.zip_access_data_mut(rhs)? {
 			Inl(lhs, rhs) => {
 				*lhs = lhs.wrapping_mul(rhs);
@@ -418,8 +418,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_udiv(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_udiv_assign)
+	pub fn into_wrapping_udiv(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_udiv_assign)
 	}
 
 	/// Assignes `self` to the division of `self` by `rhs` using **unsigned**
@@ -434,7 +434,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_udiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_udiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		if rhs.is_zero() {
 			return Err(Error::division_by_zero(DivOp::UnsignedDiv, self.clone()))
 		}
@@ -463,8 +463,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_sdiv(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_sdiv_assign)
+	pub fn into_wrapping_sdiv(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sdiv_assign)
 	}
 
 	/// Assignes `self` to the division of `self` by `rhs` using **signed**
@@ -479,7 +479,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_sdiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_sdiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		if rhs.is_zero() {
 			return Err(Error::division_by_zero(DivOp::SignedDiv, self.clone()))
 		}
@@ -514,8 +514,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_urem(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_urem_assign)
+	pub fn into_wrapping_urem(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_urem_assign)
 	}
 
 	/// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
@@ -529,7 +529,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_urem_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_urem_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		if rhs.is_zero() {
 			return Err(Error::division_by_zero(DivOp::UnsignedRem, self.clone()))
 		}
@@ -558,8 +558,8 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_srem(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_srem_assign)
+	pub fn into_wrapping_srem(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_srem_assign)
 	}
 
 	/// Assignes `self` to the **signed** remainder of `self` by `rhs`.
@@ -573,7 +573,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_srem_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn wrapping_srem_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		if rhs.is_zero() {
 			return Err(Error::division_by_zero(DivOp::SignedRem, self.clone()))
 		}
@@ -618,7 +618,7 @@ impl Neg for ApInt {
 	type Output = ApInt;
 
 	fn neg(self) -> Self::Output {
-		self.into_negate()
+		self.into_wrapping_neg()
 	}
 }
 
@@ -626,7 +626,7 @@ impl<'a> Neg for &'a ApInt {
 	type Output = ApInt;
 
 	fn neg(self) -> Self::Output {
-		self.clone().into_negate()
+		self.clone().into_wrapping_neg()
 	}
 }
 
@@ -634,7 +634,7 @@ impl<'a> Neg for &'a mut ApInt {
 	type Output = &'a mut ApInt;
 
 	fn neg(self) -> Self::Output {
-		self.negate();
+		self.wrapping_neg();
 		self
 	}
 }
@@ -647,7 +647,7 @@ impl<'a> Add<&'a ApInt> for ApInt {
 	type Output = ApInt;
 
 	fn add(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_checked_add(rhs).unwrap()
+		self.into_wrapping_add(rhs).unwrap()
 	}
 }
 
@@ -655,13 +655,13 @@ impl<'a, 'b> Add<&'a ApInt> for &'b ApInt {
 	type Output = ApInt;
 
 	fn add(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_checked_add(rhs).unwrap()
+		self.clone().into_wrapping_add(rhs).unwrap()
 	}
 }
 
 impl<'a> AddAssign<&'a ApInt> for ApInt {
 	fn add_assign(&mut self, rhs: &'a ApInt) {
-		self.checked_add_assign(rhs).unwrap()
+		self.wrapping_add_assign(rhs).unwrap()
 	}
 }
 
@@ -673,7 +673,7 @@ impl<'a> Sub<&'a ApInt> for ApInt {
 	type Output = ApInt;
 
 	fn sub(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_checked_sub(rhs).unwrap()
+		self.into_wrapping_sub(rhs).unwrap()
 	}
 }
 
@@ -681,13 +681,13 @@ impl<'a, 'b> Sub<&'a ApInt> for &'b ApInt {
 	type Output = ApInt;
 
 	fn sub(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_checked_sub(rhs).unwrap()
+		self.clone().into_wrapping_sub(rhs).unwrap()
 	}
 }
 
 impl<'a> SubAssign<&'a ApInt> for ApInt {
 	fn sub_assign(&mut self, rhs: &'a ApInt) {
-		self.checked_sub_assign(rhs).unwrap()
+		self.wrapping_sub_assign(rhs).unwrap()
 	}
 }
 
@@ -699,7 +699,7 @@ impl<'a> Mul<&'a ApInt> for ApInt {
 	type Output = ApInt;
 
 	fn mul(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_checked_mul(rhs).unwrap()
+		self.into_wrapping_mul(rhs).unwrap()
 	}
 }
 
@@ -707,13 +707,13 @@ impl<'a, 'b> Mul<&'a ApInt> for &'b ApInt {
 	type Output = ApInt;
 
 	fn mul(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_checked_mul(rhs).unwrap()
+		self.clone().into_wrapping_mul(rhs).unwrap()
 	}
 }
 
 impl<'a> MulAssign<&'a ApInt> for ApInt {
 	fn mul_assign(&mut self, rhs: &'a ApInt) {
-		self.checked_mul_assign(rhs).unwrap();
+		self.wrapping_mul_assign(rhs).unwrap();
 	}
 }
 
@@ -739,13 +739,13 @@ mod tests {
 		}
 	}
 
-	mod negate {
+	mod wrapping_neg {
 		use super::*;
 		use bitwidth::{BitWidth};
 
 		fn assert_symmetry(input: ApInt, expected: ApInt) {
-			assert_eq!(input.clone().into_negate(), expected.clone());
-			assert_eq!(expected.into_negate(), input);
+			assert_eq!(input.clone().into_wrapping_neg(), expected.clone());
+			assert_eq!(expected.into_wrapping_neg(), input);
 		}
 
 		fn test_vals() -> impl Iterator<Item = i128> {
@@ -788,11 +788,11 @@ mod tests {
 				let nine =
 					ApInt::from(u8::MAX).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
 				for rhs_nine in 1..=num_u8 {
-					rhs.checked_shl_assign(8).unwrap();
+					rhs.wrapping_shl_assign(8).unwrap();
 					rhs |= &nine;
 					lhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
 					'outer: for lhs_nine in 1..=num_u8 {
-						lhs.checked_shl_assign(8).unwrap();
+						lhs.wrapping_shl_assign(8).unwrap();
 						lhs |= &nine;
 						//imagine multiplying a string of base 10 nines together.
 						//It will produce things like 998001, 8991, 98901, 9989001.
@@ -812,13 +812,13 @@ mod tests {
 						} else {
 							rhs_nine - 1
 						};
-						let mut result = lhs.clone().into_checked_mul(&rhs).unwrap();
+						let mut result = lhs.clone().into_wrapping_mul(&rhs).unwrap();
 						assert_eq!(result.clone().resize_to_u8(), 1u8);
 						for i in 0..zeros_after_one {
 							if i >= num_u8 - 1 {
 								continue 'outer;
 							}
-							result.checked_lshr_assign(8).unwrap();
+							result.wrapping_lshr_assign(8).unwrap();
 							let temp = result.clone().resize_to_u8();
 							if temp != 0 {
 								panic!(
@@ -831,13 +831,13 @@ mod tests {
 							if zeros_after_one + i >= num_u8 - 1 {
 								continue 'outer;
 							}
-							result.checked_lshr_assign(8).unwrap();
+							result.wrapping_lshr_assign(8).unwrap();
 							assert_eq!(result.clone().resize_to_u8(), u8::MAX);
 						}
 						if zeros_after_one + nines_before_eight >= num_u8 - 1 {
 							continue 'outer;
 						}
-						result.checked_lshr_assign(8).unwrap();
+						result.wrapping_lshr_assign(8).unwrap();
 						let temp = result.clone().resize_to_u8();
 						if temp != u8::MAX - 1 {
 							panic!(
@@ -849,7 +849,7 @@ mod tests {
 							if 1 + zeros_after_one + nines_before_eight + i >= num_u8 - 1 {
 								continue 'outer;
 							}
-							result.checked_lshr_assign(8).unwrap();
+							result.wrapping_lshr_assign(8).unwrap();
 							if result.clone().resize_to_u8() != u8::MAX {
 								panic!(
 									"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
@@ -863,7 +863,7 @@ mod tests {
 			//test inl apints
 			assert_eq!(
 				ApInt::from(u8::MAX)
-					.into_checked_mul(&ApInt::from(u8::MAX))
+					.into_wrapping_mul(&ApInt::from(u8::MAX))
 					.unwrap(),
 				ApInt::from(1u8)
 			);
@@ -894,27 +894,27 @@ mod tests {
 			for (i, _) in resize.iter().enumerate() {
 				let mut lhs = ApInt::from(5u8)
 					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_checked_shl(lhs_shl[i])
+					.into_wrapping_shl(lhs_shl[i])
 					.unwrap();
 				let mut rhs = ApInt::from(11u8)
 					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_checked_shl(rhs_shl[i])
+					.into_wrapping_shl(rhs_shl[i])
 					.unwrap();
 				let mut zero = ApInt::from(0u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
 				let mut one = ApInt::from(1u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
 				let mut expected = ApInt::from(55u8)
 					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_checked_shl(rhs_shl[i] + lhs_shl[i])
+					.into_wrapping_shl(rhs_shl[i] + lhs_shl[i])
 					.unwrap();
-				assert_eq!(lhs.clone().into_checked_mul(&zero).unwrap(), zero);
-				assert_eq!(zero.clone().into_checked_mul(&rhs).unwrap(), zero);
-				assert_eq!(lhs.clone().into_checked_mul(&one).unwrap(), lhs);
-				assert_eq!(one.clone().into_checked_mul(&rhs).unwrap(), rhs);
-				assert_eq!(lhs.clone().into_checked_mul(&rhs).unwrap(), expected);
+				assert_eq!(lhs.clone().into_wrapping_mul(&zero).unwrap(), zero);
+				assert_eq!(zero.clone().into_wrapping_mul(&rhs).unwrap(), zero);
+				assert_eq!(lhs.clone().into_wrapping_mul(&one).unwrap(), lhs);
+				assert_eq!(one.clone().into_wrapping_mul(&rhs).unwrap(), rhs);
+				assert_eq!(lhs.clone().into_wrapping_mul(&rhs).unwrap(), expected);
 			}
 			assert_eq!(
 				ApInt::from([0,0,0,0,u64::MAX,0,u64::MAX,u64::MAX])
-				.into_checked_mul(&ApInt::from([0,0,0,0,u64::MAX,u64::MAX,0,u64::MAX])).unwrap()
+				.into_wrapping_mul(&ApInt::from([0,0,0,0,u64::MAX,u64::MAX,0,u64::MAX])).unwrap()
 				,ApInt::from([u64::MAX,0,1,u64::MAX - 3,1,u64::MAX,u64::MAX,1]));
 		}
 	}
@@ -926,7 +926,7 @@ mod tests {
 		fn simple() {
 			let lhs = ApInt::from(56_u32);
 			let rhs = ApInt::from(7_u32);
-			let result = lhs.into_checked_udiv(&rhs).unwrap();
+			let result = lhs.into_wrapping_udiv(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(8_u32));
 		}
 	}
@@ -938,7 +938,7 @@ mod tests {
 		fn simple() {
 			let lhs = ApInt::from(72_i32);
 			let rhs = ApInt::from(12_i32);
-			let result = lhs.into_checked_sdiv(&rhs).unwrap();
+			let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(6_u32));
 		}
 
@@ -946,7 +946,7 @@ mod tests {
 		fn with_neg() {
 			let lhs = ApInt::from(72_i32);
 			let rhs = ApInt::from(-12_i32);
-			let result = lhs.into_checked_sdiv(&rhs).unwrap();
+			let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(-6_i32));
 		}
 	}
@@ -958,7 +958,7 @@ mod tests {
 		fn simple() {
 			let lhs = ApInt::from(15_u32);
 			let rhs = ApInt::from(4_u32);
-			let result = lhs.into_checked_urem(&rhs).unwrap();
+			let result = lhs.into_wrapping_urem(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(3_u32));
 		}
 	}
@@ -970,7 +970,7 @@ mod tests {
 		fn simple() {
 			let lhs = ApInt::from(23_i32);
 			let rhs = ApInt::from(7_i32);
-			let result = lhs.into_checked_srem(&rhs).unwrap();
+			let result = lhs.into_wrapping_srem(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(2_u32));
 		}
 
@@ -978,7 +978,7 @@ mod tests {
 		fn with_neg() {
 			let lhs = ApInt::from(-23_i32);
 			let rhs = ApInt::from(7_i32);
-			let result = lhs.into_checked_srem(&rhs).unwrap();
+			let result = lhs.into_wrapping_srem(&rhs).unwrap();
 			assert_eq!(result, ApInt::from(-2_i32));
 		}
 	}

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -37,14 +37,11 @@ impl ApInt {
 	/// Tries to bit-and assign this `ApInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitand`](struct.ApInt.html#method.checked_bitand).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitand(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_bitand_assign)
+	pub fn into_bitand(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::bitand_assign)
 	}
 
 	/// Bit-and assigns all bits of this `ApInt` with the bits of `rhs`.
@@ -54,21 +51,18 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitand_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn bitand_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		self.modify_zipped_digits(rhs, |l, r| *l &= r)
 	}
 
 	/// Tries to bit-and assign this `ApInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitor`](struct.ApInt.html#method.checked_bitor).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitor(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_bitor_assign)
+	pub fn into_bitor(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::bitor_assign)
 	}
 
 	/// Bit-or assigns all bits of this `ApInt` with the bits of `rhs`.
@@ -78,21 +72,18 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitor_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn bitor_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		self.modify_zipped_digits(rhs, |l, r| *l |= r)
 	}
 
 	/// Tries to bit-xor assign this `ApInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitxor`](struct.ApInt.html#method.checked_bitxor).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitxor(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::checked_bitxor_assign)
+	pub fn into_bitxor(self, rhs: &ApInt) -> Result<ApInt> {
+		try_forward_bin_mut_impl(self, rhs, ApInt::bitxor_assign)
 	}
 
 	/// Bit-xor assigns all bits of this `ApInt` with the bits of `rhs`.
@@ -102,7 +93,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitxor_assign(&mut self, rhs: &ApInt) -> Result<()> {
+	pub fn bitxor_assign(&mut self, rhs: &ApInt) -> Result<()> {
 		self.modify_zipped_digits(rhs, |l, r| *l ^= r)
 	}
 }
@@ -224,7 +215,7 @@ impl ApInt {
 
 	/// Flips all bits of this `ApInt`.
 	pub fn flip_all(&mut self) {
-		// TODO: remove since equal to ApInt::checked_bitnot_assign
+		// TODO: remove since equal to ApInt::bitnot_assign
 		self.modify_digits(|digit| digit.flip_all());
 		self.clear_unused_bits();
 	}
@@ -339,7 +330,7 @@ impl<'a> BitAnd<&'a ApInt> for ApInt {
     type Output = ApInt;
 
     fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_checked_bitand(rhs).unwrap()
+        self.into_bitand(rhs).unwrap()
     }
 }
 
@@ -347,7 +338,7 @@ impl<'a, 'b> BitAnd<&'a ApInt> for &'b ApInt {
     type Output = ApInt;
 
     fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitand(rhs).unwrap()
+        self.clone().into_bitand(rhs).unwrap()
     }
 }
 
@@ -355,7 +346,7 @@ impl<'a, 'b> BitAnd<&'a ApInt> for &'b mut ApInt {
     type Output = ApInt;
 
     fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitand(rhs).unwrap()
+        self.clone().into_bitand(rhs).unwrap()
     }
 }
 
@@ -367,7 +358,7 @@ impl<'a> BitOr<&'a ApInt> for ApInt {
     type Output = ApInt;
 
     fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_checked_bitor(rhs).unwrap()
+        self.into_bitor(rhs).unwrap()
     }
 }
 
@@ -375,7 +366,7 @@ impl<'a, 'b> BitOr<&'a ApInt> for &'b ApInt {
     type Output = ApInt;
 
     fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitor(rhs).unwrap()
+        self.clone().into_bitor(rhs).unwrap()
     }
 }
 
@@ -383,7 +374,7 @@ impl<'a, 'b> BitOr<&'a ApInt> for &'b mut ApInt {
     type Output = ApInt;
 
     fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitor(rhs).unwrap()
+        self.clone().into_bitor(rhs).unwrap()
     }
 }
 
@@ -395,7 +386,7 @@ impl<'a> BitXor<&'a ApInt> for ApInt {
     type Output = ApInt;
 
     fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_checked_bitxor(rhs).unwrap()
+        self.into_bitxor(rhs).unwrap()
     }
 }
 
@@ -403,7 +394,7 @@ impl<'a, 'b> BitXor<&'a ApInt> for &'b ApInt {
     type Output = ApInt;
 
     fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitxor(rhs).unwrap()
+        self.clone().into_bitxor(rhs).unwrap()
     }
 }
 
@@ -411,7 +402,7 @@ impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
     type Output = ApInt;
 
     fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_checked_bitxor(rhs).unwrap()
+        self.clone().into_bitxor(rhs).unwrap()
     }
 }
 
@@ -421,19 +412,19 @@ impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
 
 impl<'a> BitAndAssign<&'a ApInt> for ApInt {
     fn bitand_assign(&mut self, rhs: &'a ApInt) {
-        self.checked_bitand_assign(rhs).unwrap();
+        self.bitand_assign(rhs).unwrap();
     }
 }
 
 impl<'a> BitOrAssign<&'a ApInt> for ApInt {
     fn bitor_assign(&mut self, rhs: &'a ApInt) {
-        self.checked_bitor_assign(rhs).unwrap();
+        self.bitor_assign(rhs).unwrap();
     }
 }
 
 impl<'a> BitXorAssign<&'a ApInt> for ApInt {
     fn bitxor_assign(&mut self, rhs: &'a ApInt) {
-        self.checked_bitxor_assign(rhs).unwrap();
+        self.bitxor_assign(rhs).unwrap();
     }
 }
 

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -231,16 +231,16 @@ impl ApInt {
 	pub fn set_sign_bit(&mut self) {
 		let sign_bit_pos = self.width().sign_bit_pos();
 		self.set_bit_at(sign_bit_pos)
-		    .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-			         for usage in the associated `ApInt` for operating on bits.")
+			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+					 for usage in the associated `ApInt` for operating on bits.")
 	}
 
 	/// Sets the sign bit of this `ApInt` to zero (`0`).
 	pub fn unset_sign_bit(&mut self) {
 		let sign_bit_pos = self.width().sign_bit_pos();
 		self.unset_bit_at(sign_bit_pos)
-		    .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-			         for usage in the associated `ApInt` for operating on bits.")
+			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+					 for usage in the associated `ApInt` for operating on bits.")
 	}
 
 	/// Flips the sign bit of this `ApInt`.
@@ -253,8 +253,8 @@ impl ApInt {
 	pub fn flip_sign_bit(&mut self) {
 		let sign_bit_pos = self.width().sign_bit_pos();
 		self.flip_bit_at(sign_bit_pos)
-		    .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-			         for usage in the associated `ApInt` for operating on bits.")
+			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+					 for usage in the associated `ApInt` for operating on bits.")
 	}
 }
 
@@ -263,16 +263,16 @@ impl ApInt {
 	/// Returns the number of ones in the binary representation of this `ApInt`.
 	pub fn count_ones(&self) -> usize {
 		self.as_digit_slice()
-		    .into_iter()
-		    .map(|d| d.repr().count_ones() as usize)
-		    .sum::<usize>()
+			.into_iter()
+			.map(|d| d.repr().count_ones() as usize)
+			.sum::<usize>()
 	}
 
 	/// Returns the number of zeros in the binary representation of this `ApInt`.
 	pub fn count_zeros(&self) -> usize {
 		let zeros = self.as_digit_slice()
 			.into_iter()
-		    .map(|d| d.repr().count_zeros() as usize)
+			.map(|d| d.repr().count_zeros() as usize)
 			.sum::<usize>();
 		// Since `ApInt` instances with width's that are no powers of two
 		// have unused excess bits that are always zero we need to cut them off
@@ -327,27 +327,27 @@ impl Not for ApInt {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a ApInt> for ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+		self.into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a ApInt> for &'b ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a ApInt> for &'b mut ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -355,27 +355,27 @@ impl<'a, 'b> BitAnd<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a ApInt> for ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+		self.into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a ApInt> for &'b ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a ApInt> for &'b mut ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -383,27 +383,27 @@ impl<'a, 'b> BitOr<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a ApInt> for ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+		self.into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a ApInt> for &'b ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
-    type Output = ApInt;
+	type Output = ApInt;
 
-    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -411,21 +411,21 @@ impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a ApInt> for ApInt {
-    fn bitand_assign(&mut self, rhs: &'a ApInt) {
-        self.bitand_assign(rhs).unwrap();
-    }
+	fn bitand_assign(&mut self, rhs: &'a ApInt) {
+		self.bitand_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitOrAssign<&'a ApInt> for ApInt {
-    fn bitor_assign(&mut self, rhs: &'a ApInt) {
-        self.bitor_assign(rhs).unwrap();
-    }
+	fn bitor_assign(&mut self, rhs: &'a ApInt) {
+		self.bitor_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitXorAssign<&'a ApInt> for ApInt {
-    fn bitxor_assign(&mut self, rhs: &'a ApInt) {
-        self.bitxor_assign(rhs).unwrap();
-    }
+	fn bitxor_assign(&mut self, rhs: &'a ApInt) {
+		self.bitxor_assign(rhs).unwrap();
+	}
 }
 
 #[cfg(test)]

--- a/src/apint/relational.rs
+++ b/src/apint/relational.rs
@@ -10,6 +10,7 @@ use digit::{Bit};
 use std::cmp::Ordering;
 use std::ops::Not;
 
+/// If `self` and `other` have unmatching bit widths, `false` will be returned.
 impl PartialEq for ApInt {
 	fn eq(&self, other: &ApInt) -> bool {
 		if self.len_bits() != other.len_bits() {
@@ -28,6 +29,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self < rhs`.
 	/// - Interprets both `ApInt` instances as **unsigned** values.
 	/// 
@@ -66,6 +68,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self <= rhs`.
 	/// - Interprets both `ApInt` instances as **unsigned** values.
 	/// 
@@ -87,6 +90,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self > rhs`.
 	/// - Interprets both `ApInt` instances as **unsigned** values.
 	/// 
@@ -108,6 +112,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self >= rhs`.
 	/// - Interprets both `ApInt` instances as **unsigned** values.
 	/// 
@@ -129,6 +134,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self < rhs`.
 	/// - Interprets both `ApInt` instances as **signed** values.
 	/// 
@@ -167,6 +173,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self <= rhs`.
 	/// - Interprets both `ApInt` instances as **signed** values.
 	/// 
@@ -188,6 +195,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self > rhs`.
 	/// - Interprets both `ApInt` instances as **signed** values.
 	/// 
@@ -209,6 +217,7 @@ impl ApInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self >= rhs`.
 	/// - Interprets both `ApInt` instances as **signed** values.
 	/// 

--- a/src/apint/relational.rs
+++ b/src/apint/relational.rs
@@ -51,7 +51,7 @@ impl ApInt {
 			}
 			ZipDataAccess::Ext(lhs, rhs) => {
 				for (l, r) in lhs.into_iter().rev()
-				                 .zip(rhs.into_iter().rev())
+								 .zip(rhs.into_iter().rev())
 				{
 					match l.cmp(r) {
 						Ordering::Less    => return Ok(true),

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -290,7 +290,7 @@ impl ApInt {
 /// =======================================================================
 impl ApInt {
 	/// Returns a `String` representation of the binary encoded `ApInt` for the given `Radix`.
-	pub fn as_string_with_radix<R>(&self, radix: R) -> String
+	pub fn to_string_radix<R>(&self, radix: R) -> String
 		where R: Into<Radix>
 	{
 		let _radix = radix.into();

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -72,7 +72,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn checked_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
+	pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
 		where S: Into<ShiftAmount>
 	{
 		let shift_amount = shift_amount.into();
@@ -120,10 +120,10 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_checked_shl<S>(self, shift_amount: S) -> Result<ApInt>
+	pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<ApInt>
 		where S: Into<ShiftAmount>
 	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::checked_shl_assign)
+		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_shl_assign)
 	}
 
 	/// Logically right-shifts this `ApInt` by the given `shift_amount` bits.
@@ -133,7 +133,7 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn checked_lshr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+	pub fn wrapping_lshr_assign<S>(&mut self, shift_amount: S) -> Result<()>
 		where S: Into<ShiftAmount>
 	{
 		let shift_amount = shift_amount.into();
@@ -174,10 +174,10 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_checked_lshr<S>(self, shift_amount: S) -> Result<ApInt>
+	pub fn into_wrapping_lshr<S>(self, shift_amount: S) -> Result<ApInt>
 		where S: Into<ShiftAmount>
 	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::checked_lshr_assign)
+		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_lshr_assign)
 	}
 
 	/// Arithmetically right-shifts this `ApInt` by the given `shift_amount` bits.
@@ -191,11 +191,11 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn checked_ashr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+	pub fn wrapping_ashr_assign<S>(&mut self, shift_amount: S) -> Result<()>
 		where S: Into<ShiftAmount>
 	{
 		if self.sign_bit() == Bit::Unset {
-			return self.checked_lshr_assign(shift_amount)
+			return self.wrapping_lshr_assign(shift_amount)
 		}
 		let shift_amount = shift_amount.into();
 		checks::verify_shift_amount(self, shift_amount)?;
@@ -245,10 +245,10 @@ impl ApInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_checked_ashr<S>(self, shift_amount: S) -> Result<ApInt>
+	pub fn into_wrapping_ashr<S>(self, shift_amount: S) -> Result<ApInt>
 		where S: Into<ShiftAmount>
 	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::checked_ashr_assign)
+		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_ashr_assign)
 	}
 }
 
@@ -298,7 +298,7 @@ mod tests {
 			for repr in test_reprs_w64() {
 				for shamt in 0..64 {
 					let mut result = ApInt::from_u64(repr);
-					result.checked_shl_assign(shamt).unwrap();
+					result.wrapping_shl_assign(shamt).unwrap();
 					let expected = ApInt::from_u64(repr << shamt);
 					assert_eq!(result, expected);
 				}
@@ -310,7 +310,7 @@ mod tests {
 			for repr in test_reprs_w128() {
 				for shamt in 0..128 {
 					let mut result = ApInt::from_u128(repr);
-					result.checked_shl_assign(shamt).unwrap();
+					result.wrapping_shl_assign(shamt).unwrap();
 					let expected = ApInt::from_u128(repr << shamt);
 					assert_eq!(result, expected);
 				}
@@ -332,7 +332,7 @@ mod tests {
 				assert_eq!(digit_steps, 1);
 				assert_eq!(bit_steps, 36);
 				let result = ApInt::from(input)
-					.into_checked_shl(shamt)
+					.into_wrapping_shl(shamt)
 					.unwrap();
 				let expected: [u64; 4] = [
 					(d1 << bit_steps) | (d2 >> (digit::BITS - bit_steps)),
@@ -350,7 +350,7 @@ mod tests {
 				assert_eq!(digit_steps, 2);
 				assert_eq!(bit_steps, 22);
 				let result = ApInt::from(input)
-					.into_checked_shl(shamt)
+					.into_wrapping_shl(shamt)
 					.unwrap();
 				let expected: [u64; 4] = [
 					(d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
@@ -368,7 +368,7 @@ mod tests {
 				assert_eq!(digit_steps, 3);
 				assert_eq!(bit_steps, 8);
 				let result = ApInt::from(input)
-					.into_checked_shl(shamt)
+					.into_wrapping_shl(shamt)
 					.unwrap();
 				let expected: [u64; 4] = [
 					(d3 << bit_steps),
@@ -384,14 +384,14 @@ mod tests {
 		#[test]
 		fn assign_small_fail() {
 			for mut apint in test_apints_w64() {
-				assert!(apint.checked_shl_assign(64).is_err())
+				assert!(apint.wrapping_shl_assign(64).is_err())
 			}
 		}
 
 		#[test]
 		fn assign_large_fail() {
 			for mut apint in test_apints_w128() {
-				assert!(apint.checked_shl_assign(128).is_err())
+				assert!(apint.wrapping_shl_assign(128).is_err())
 			}
 		}
 
@@ -401,8 +401,8 @@ mod tests {
 				for shamt in 0..64 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_shl_assign(shamt).unwrap();
-					let y = y.into_checked_shl(shamt).unwrap();
+					x.wrapping_shl_assign(shamt).unwrap();
+					let y = y.into_wrapping_shl(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}
@@ -414,8 +414,8 @@ mod tests {
 				for shamt in 0..128 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_shl_assign(shamt).unwrap();
-					let y = y.into_checked_shl(shamt).unwrap();
+					x.wrapping_shl_assign(shamt).unwrap();
+					let y = y.into_wrapping_shl(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}
@@ -430,7 +430,7 @@ mod tests {
 			for repr in test_reprs_w64() {
 				for shamt in 0..64 {
 					let mut result = ApInt::from_u64(repr);
-					result.checked_lshr_assign(shamt).unwrap();
+					result.wrapping_lshr_assign(shamt).unwrap();
 					let expected = ApInt::from_u64(repr >> shamt);
 					assert_eq!(result, expected);
 				}
@@ -442,7 +442,7 @@ mod tests {
 			for repr in test_reprs_w128() {
 				for shamt in 0..128 {
 					let mut result = ApInt::from_u128(repr);
-					result.checked_lshr_assign(shamt).unwrap();
+					result.wrapping_lshr_assign(shamt).unwrap();
 					let expected = ApInt::from_u128(repr >> shamt);
 					assert_eq!(result, expected);
 				}
@@ -452,14 +452,14 @@ mod tests {
 		#[test]
 		fn assign_small_fail() {
 			for mut apint in test_apints_w64() {
-				assert!(apint.checked_lshr_assign(64).is_err())
+				assert!(apint.wrapping_lshr_assign(64).is_err())
 			}
 		}
 
 		#[test]
 		fn assign_large_fail() {
 			for mut apint in test_apints_w128() {
-				assert!(apint.checked_lshr_assign(128).is_err())
+				assert!(apint.wrapping_lshr_assign(128).is_err())
 			}
 		}
 
@@ -469,8 +469,8 @@ mod tests {
 				for shamt in 0..64 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_lshr_assign(shamt).unwrap();
-					let y = y.into_checked_lshr(shamt).unwrap();
+					x.wrapping_lshr_assign(shamt).unwrap();
+					let y = y.into_wrapping_lshr(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}
@@ -482,8 +482,8 @@ mod tests {
 				for shamt in 0..128 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_lshr_assign(shamt).unwrap();
-					let y = y.into_checked_lshr(shamt).unwrap();
+					x.wrapping_lshr_assign(shamt).unwrap();
+					let y = y.into_wrapping_lshr(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}
@@ -497,7 +497,7 @@ mod tests {
 		fn regression_stevia_01() {
 			let input = ApInt::from_i32(-8);
 			let expected = ApInt::from_u32(0x_FFFF_FFFE);
-			assert_eq!(input.into_checked_ashr(ShiftAmount::from(2)).unwrap(), expected);
+			assert_eq!(input.into_wrapping_ashr(ShiftAmount::from(2)).unwrap(), expected);
 		}
 
 		#[test]
@@ -505,7 +505,7 @@ mod tests {
 			for repr in test_reprs_w64() {
 				for shamt in 0..64 {
 					let mut result = ApInt::from_u64(repr);
-					result.checked_ashr_assign(shamt).unwrap();
+					result.wrapping_ashr_assign(shamt).unwrap();
 					let expected = ApInt::from_i64((repr as i64) >> shamt);
 					assert_eq!(result, expected);
 				}
@@ -517,7 +517,7 @@ mod tests {
 			for repr in test_reprs_w128() {
 				for shamt in 0..128 {
 					let mut result = ApInt::from_u128(repr);
-					result.checked_ashr_assign(shamt).unwrap();
+					result.wrapping_ashr_assign(shamt).unwrap();
 					let expected = ApInt::from_i128((repr as i128) >> shamt);
 					assert_eq!(result, expected);
 				}
@@ -527,14 +527,14 @@ mod tests {
 		#[test]
 		fn assign_small_fail() {
 			for mut apint in test_apints_w64() {
-				assert!(apint.checked_ashr_assign(64).is_err())
+				assert!(apint.wrapping_ashr_assign(64).is_err())
 			}
 		}
 
 		#[test]
 		fn assign_large_fail() {
 			for mut apint in test_apints_w128() {
-				assert!(apint.checked_ashr_assign(128).is_err())
+				assert!(apint.wrapping_ashr_assign(128).is_err())
 			}
 		}
 
@@ -544,8 +544,8 @@ mod tests {
 				for shamt in 0..64 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_ashr_assign(shamt).unwrap();
-					let y = y.into_checked_ashr(shamt).unwrap();
+					x.wrapping_ashr_assign(shamt).unwrap();
+					let y = y.into_wrapping_ashr(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}
@@ -557,8 +557,8 @@ mod tests {
 				for shamt in 0..128 {
 					let mut x = apint.clone();
 					let     y = apint.clone();
-					x.checked_ashr_assign(shamt).unwrap();
-					let y = y.into_checked_ashr(shamt).unwrap();
+					x.wrapping_ashr_assign(shamt).unwrap();
+					let y = y.into_wrapping_ashr(shamt).unwrap();
 					assert_eq!(x, y);
 				}
 			}

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -94,7 +94,7 @@ impl ApInt {
 						}
 					}
 					digits.iter_mut()
-					      .take(digit_steps)
+						  .take(digit_steps)
 						  .for_each(|d| *d = Digit::zero());
 				}
 				let bit_steps = shift_amount.bit_steps();
@@ -147,8 +147,8 @@ impl ApInt {
 				if digit_steps != 0 {
 					digits.rotate_left(digit_steps);
 					digits.iter_mut()
-					      .rev()
-					      .take(digit_steps)
+						  .rev()
+						  .take(digit_steps)
 						  .for_each(|d| *d = Digit::zero());
 				}
 				let bit_steps = shift_amount.bit_steps();
@@ -213,8 +213,8 @@ impl ApInt {
 				if digit_steps != 0 {
 					digits.rotate_left(digit_steps);
 					digits.iter_mut()
-					      .rev()
-					      .take(digit_steps)
+						  .rev()
+						  .take(digit_steps)
 						  .for_each(|d| *d = Digit::all_set());
 				}
 				let bit_steps = shift_amount.bit_steps();

--- a/src/apint/to_primitive.rs
+++ b/src/apint/to_primitive.rs
@@ -58,21 +58,21 @@ impl PrimitiveTy {
 		}
 	}
 
-    /// Returns `true` if the given `value` is a valid double-digit
-    /// representation for this `PrimitiveTy`.
-    /// 
-    /// # Example
-    /// 
-    /// If this `PrimitiveTy` was `U8` then `200` is a valid representation
-    /// but `256` is not since it is not representable by `8` bits. Only
-    /// unsigned values are considered in this regard.
-    /// 
-    /// # Note
-    /// 
-    /// This functionality is currently only used by local unit tests.
-    #[inline]
-    #[cfg(test)]
-    pub(crate) fn is_valid_dd(self, value: u128) -> bool {
+	/// Returns `true` if the given `value` is a valid double-digit
+	/// representation for this `PrimitiveTy`.
+	/// 
+	/// # Example
+	/// 
+	/// If this `PrimitiveTy` was `U8` then `200` is a valid representation
+	/// but `256` is not since it is not representable by `8` bits. Only
+	/// unsigned values are considered in this regard.
+	/// 
+	/// # Note
+	/// 
+	/// This functionality is currently only used by local unit tests.
+	#[inline]
+	#[cfg(test)]
+	pub(crate) fn is_valid_dd(self, value: u128) -> bool {
 		use self::PrimitiveTy::*;
 		match self {
 			Bool        => (value == 0) || (value == 1),
@@ -80,987 +80,987 @@ impl PrimitiveTy {
 			I16 | U16   => value < (0x1 << 16),
 			I32 | U32   => value < (0x1 << 32),
 			I64 | U64   => value < (0x1 << 64),
-            I128 | U128 => true
+			I128 | U128 => true
 		}
 	}
 
-    /// Returns `true` if this `PrimitiveTy` can represent signedness.
-    #[inline]
-    pub(crate) fn is_signed(self) -> bool {
+	/// Returns `true` if this `PrimitiveTy` can represent signedness.
+	#[inline]
+	pub(crate) fn is_signed(self) -> bool {
 		use self::PrimitiveTy::*;
-        match self {
-            I8   |
-            I16  |
-            I32  |
-            I64  |
-            I128 => true,
-            _    => false
-        }
-    }
+		match self {
+			I8   |
+			I16  |
+			I32  |
+			I64  |
+			I128 => true,
+			_    => false
+		}
+	}
 
-    /// Returns the associated `BitWidth` to this `PrimitiveTy`.
-    /// 
-    /// # Example
-    /// 
-    /// For `i32` the associated `BitWidth` is `32 bits` and for
-    /// `u64` it is `64 bits`.
-    #[inline]
-    pub(crate) fn associated_width(self) -> BitWidth {
-        use self::PrimitiveTy::*;
-        match self {
-            Bool => BitWidth::w1(),
-            I8 | U8 => BitWidth::w8(),
-            I16 | U16 => BitWidth::w16(),
-            I32 | U32 => BitWidth::w32(),
-            I64 | U64 => BitWidth::w64(),
-            I128 | U128 => BitWidth::w128(),
-        }
-    }
+	/// Returns the associated `BitWidth` to this `PrimitiveTy`.
+	/// 
+	/// # Example
+	/// 
+	/// For `i32` the associated `BitWidth` is `32 bits` and for
+	/// `u64` it is `64 bits`.
+	#[inline]
+	pub(crate) fn associated_width(self) -> BitWidth {
+		use self::PrimitiveTy::*;
+		match self {
+			Bool => BitWidth::w1(),
+			I8 | U8 => BitWidth::w8(),
+			I16 | U16 => BitWidth::w16(),
+			I32 | U32 => BitWidth::w32(),
+			I64 | U64 => BitWidth::w64(),
+			I128 | U128 => BitWidth::w128(),
+		}
+	}
 }
 
 /// # Operations to lossful cast to primitive number types.
 impl ApInt {
 
-    /// Resizes the given `ApInt` to the given `PrimitiveTy`.
-    /// 
-    /// This will truncate the bits of the `ApInt` if it has a greater bit
-    /// width than the target bit width or will sign-extend the bits of the
-    /// `ApInt` if its bit width is less than the target bit width.
-    /// 
-    /// This operation cannot fail and is the generic foundation for the
-    /// greater part of the `ApInt::resize_to_*` methods.
-    fn resize_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Digit {
-        debug_assert_ne!(prim_ty, PrimitiveTy::U128);
-        debug_assert_ne!(prim_ty, PrimitiveTy::I128);
-        let mut lsd = self.least_significant_digit();
-        let actual_width = self.width();
-        let target_width = prim_ty.associated_width();
-        if prim_ty.is_signed() {
-            if actual_width < target_width {
-                lsd.sign_extend_from(actual_width)
-                   .expect("We already asserted that `actual_width` < `target_width` \
-                            and since `target_width` is always less than or equal to \
-                            `64` bits calling `Digit::sign_extend_from` is safe for it.");
-            }
-        }
-        if target_width < BitWidth::w64() {
-            lsd.truncate_to(target_width)
-                .expect("Since `target_width` is always less than or equal to \
-                        `64` bits calling `Digit::sign_extend_from` is safe for it.");
-        }
-        lsd
-    }
+	/// Resizes the given `ApInt` to the given `PrimitiveTy`.
+	/// 
+	/// This will truncate the bits of the `ApInt` if it has a greater bit
+	/// width than the target bit width or will sign-extend the bits of the
+	/// `ApInt` if its bit width is less than the target bit width.
+	/// 
+	/// This operation cannot fail and is the generic foundation for the
+	/// greater part of the `ApInt::resize_to_*` methods.
+	fn resize_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Digit {
+		debug_assert_ne!(prim_ty, PrimitiveTy::U128);
+		debug_assert_ne!(prim_ty, PrimitiveTy::I128);
+		let mut lsd = self.least_significant_digit();
+		let actual_width = self.width();
+		let target_width = prim_ty.associated_width();
+		if prim_ty.is_signed() {
+			if actual_width < target_width {
+				lsd.sign_extend_from(actual_width)
+				   .expect("We already asserted that `actual_width` < `target_width` \
+							and since `target_width` is always less than or equal to \
+							`64` bits calling `Digit::sign_extend_from` is safe for it.");
+			}
+		}
+		if target_width < BitWidth::w64() {
+			lsd.truncate_to(target_width)
+				.expect("Since `target_width` is always less than or equal to \
+						`64` bits calling `Digit::sign_extend_from` is safe for it.");
+		}
+		lsd
+	}
 
-    /// Resizes this `ApInt` to a `bool` primitive type.
-    /// 
-    /// Bits in this `ApInt` that are not within the bounds
-    /// of the `bool` are being ignored.
-    /// 
-    /// # Note
-    /// 
-    /// - Basically this returns `true` if the least significant
-    ///   bit of this `ApInt` is `1` and `false` otherwise.
-    pub fn resize_to_bool(&self) -> bool {
-        match self.resize_to_primitive_ty(PrimitiveTy::Bool) {
-            Digit(0) => false,
-            Digit(1) => true,
-            _ => unreachable!()
-        }
-    }
+	/// Resizes this `ApInt` to a `bool` primitive type.
+	/// 
+	/// Bits in this `ApInt` that are not within the bounds
+	/// of the `bool` are being ignored.
+	/// 
+	/// # Note
+	/// 
+	/// - Basically this returns `true` if the least significant
+	///   bit of this `ApInt` is `1` and `false` otherwise.
+	pub fn resize_to_bool(&self) -> bool {
+		match self.resize_to_primitive_ty(PrimitiveTy::Bool) {
+			Digit(0) => false,
+			Digit(1) => true,
+			_ => unreachable!()
+		}
+	}
 
-    /// Resizes this `ApInt` to a `i8` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `8` bits the value is
-    ///   sign extended to the target bit width.
-    /// - All bits but the least significant `8` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i8(&self) -> i8 {
-        self.resize_to_primitive_ty(PrimitiveTy::I8).repr() as i8
-    }
+	/// Resizes this `ApInt` to a `i8` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `8` bits the value is
+	///   sign extended to the target bit width.
+	/// - All bits but the least significant `8` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i8(&self) -> i8 {
+		self.resize_to_primitive_ty(PrimitiveTy::I8).repr() as i8
+	}
 
-    /// Resizes this `ApInt` to a `u8` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - All bits but the least significant `8` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u8(&self) -> u8 {
-        self.resize_to_primitive_ty(PrimitiveTy::U8).repr() as u8
-    }
+	/// Resizes this `ApInt` to a `u8` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - All bits but the least significant `8` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u8(&self) -> u8 {
+		self.resize_to_primitive_ty(PrimitiveTy::U8).repr() as u8
+	}
 
-    /// Resizes this `ApInt` to a `i16` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `16` bits the value is
-    ///   sign extended to the target bit width.
-    /// - All bits but the least significant `16` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i16(&self) -> i16 {
-        self.resize_to_primitive_ty(PrimitiveTy::I16).repr() as i16
-    }
+	/// Resizes this `ApInt` to a `i16` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `16` bits the value is
+	///   sign extended to the target bit width.
+	/// - All bits but the least significant `16` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i16(&self) -> i16 {
+		self.resize_to_primitive_ty(PrimitiveTy::I16).repr() as i16
+	}
 
-    /// Resizes this `ApInt` to a `u16` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - All bits but the least significant `16` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u16(&self) -> u16 {
-        self.resize_to_primitive_ty(PrimitiveTy::U16).repr() as u16
-    }
+	/// Resizes this `ApInt` to a `u16` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - All bits but the least significant `16` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u16(&self) -> u16 {
+		self.resize_to_primitive_ty(PrimitiveTy::U16).repr() as u16
+	}
 
-    /// Resizes this `ApInt` to a `i32` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `32` bits the value is
-    ///   sign extended to the target bit width.
-    /// - All bits but the least significant `32` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i32(&self) -> i32 {
-        self.resize_to_primitive_ty(PrimitiveTy::I32).repr() as i32
-    }
+	/// Resizes this `ApInt` to a `i32` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `32` bits the value is
+	///   sign extended to the target bit width.
+	/// - All bits but the least significant `32` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i32(&self) -> i32 {
+		self.resize_to_primitive_ty(PrimitiveTy::I32).repr() as i32
+	}
 
-    /// Resizes this `ApInt` to a `u32` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - All bits but the least significant `32` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u32(&self) -> u32 {
-        self.resize_to_primitive_ty(PrimitiveTy::U32).repr() as u32
-    }
+	/// Resizes this `ApInt` to a `u32` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - All bits but the least significant `32` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u32(&self) -> u32 {
+		self.resize_to_primitive_ty(PrimitiveTy::U32).repr() as u32
+	}
 
-    /// Resizes this `ApInt` to a `i64` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `64` bits the value is
-    ///   sign extended to the target bit width.
-    /// - All bits but the least significant `64` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i64(&self) -> i64 {
-        self.resize_to_primitive_ty(PrimitiveTy::I64).repr() as i64
-    }
+	/// Resizes this `ApInt` to a `i64` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `64` bits the value is
+	///   sign extended to the target bit width.
+	/// - All bits but the least significant `64` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i64(&self) -> i64 {
+		self.resize_to_primitive_ty(PrimitiveTy::I64).repr() as i64
+	}
 
-    /// Resizes this `ApInt` to a `u64` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - All bits but the least significant `64` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u64(&self) -> u64 {
-        self.resize_to_primitive_ty(PrimitiveTy::U64).repr() as u64
-    }
+	/// Resizes this `ApInt` to a `u64` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - All bits but the least significant `64` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u64(&self) -> u64 {
+		self.resize_to_primitive_ty(PrimitiveTy::U64).repr() as u64
+	}
 
-    /// Resizes this `ApInt` to a `i128` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `128` bits the value is
-    ///   sign extended to the target bit width.
-    /// - All bits but the least significant `128` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i128(&self) -> i128 {
-        let ( lsd_0, rest) = self.split_least_significant_digit();
-        let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
-        let mut result: i128 =
-            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
-        let actual_width = self.width();
-        let target_width = BitWidth::w128();
+	/// Resizes this `ApInt` to a `i128` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `128` bits the value is
+	///   sign extended to the target bit width.
+	/// - All bits but the least significant `128` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i128(&self) -> i128 {
+		let ( lsd_0, rest) = self.split_least_significant_digit();
+		let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
+		let mut result: i128 =
+			(i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+		let actual_width = self.width();
+		let target_width = BitWidth::w128();
 
-        if actual_width < target_width {
-            // Sign extend the `i128`. Fill up with `1` up to `128` bits 
-            // starting from the sign bit position.
-            let b = actual_width.to_usize(); // Number of bits representing the number in x.
-            let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
-            result = (result ^ m) - m;       // Resulting sign-extended number.
-        }
+		if actual_width < target_width {
+			// Sign extend the `i128`. Fill up with `1` up to `128` bits 
+			// starting from the sign bit position.
+			let b = actual_width.to_usize(); // Number of bits representing the number in x.
+			let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
+			result = (result ^ m) - m;       // Resulting sign-extended number.
+		}
 
-        result
-    }
+		result
+	}
 
-    /// Resizes this `ApInt` to a `u128` primitive type.
-    /// 
-    /// # Note
-    /// 
-    /// - All bits but the least significant `128` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u128(&self) -> u128 {
-        let ( lsd_0, rest) = self.split_least_significant_digit();
-        let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
-        let result: u128 =
-            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
-        result
-    }
+	/// Resizes this `ApInt` to a `u128` primitive type.
+	/// 
+	/// # Note
+	/// 
+	/// - All bits but the least significant `128` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u128(&self) -> u128 {
+		let ( lsd_0, rest) = self.split_least_significant_digit();
+		let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
+		let result: u128 =
+			(u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+		result
+	}
 }
 
 /// # Operations to lossless cast to primitive number types.
 impl ApInt {
-    /// Verifies if this `ApInt` can be casted into the given primitive type
-    /// without loss of information and returns the least significant `Digit`
-    /// of this `ApInt` upon success.
-    /// 
-    /// # Note
-    /// 
-    /// If the given `PrimitiveTy` represents a signed integer type the 
-    /// returned `Digit` is also sign extended accordingly. 
-    /// This sign extension behaves equal to how in Rust a negative signed
-    /// `i32` is extended to an `i64` and correctly preserves the negative value.
-    /// 
-    /// # Errors
-    /// 
-    /// If it is not possible to cast this `ApInt` without loss of information.
-    fn try_cast_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Result<Digit> {
-        debug_assert_ne!(prim_ty, PrimitiveTy::U128);
-        debug_assert_ne!(prim_ty, PrimitiveTy::I128);
-        let (mut lsd, rest) = self.split_least_significant_digit();
-        if !prim_ty.is_valid_repr(lsd.repr())
-           || rest.into_iter().any(|d| d.repr() != 0)
-        {
-            return Error::encountered_unrepresentable_value(
-                self.clone(), prim_ty).into()
-        }
-        if prim_ty.is_signed() {
-            let actual_width = self.width();
-            let target_width = prim_ty.associated_width();
-            if actual_width < target_width {
-                lsd.sign_extend_from(actual_width)
-                   .expect("We already asserted that `actual_width` < `target_width` \
-                            and since `target_width` is always less than or equal to \
-                            `64` bits calling `Digit::sign_extend_from` is safe for it.");
-                if target_width < BitWidth::w64() {
-                    lsd.truncate_to(target_width)
-                        .expect("Since `target_width` is always less than or equal to \
-                                `64` bits calling `Digit::sign_extend_from` is safe for it.");
-                }
-            }
-        }
-        Ok(lsd)
-    }
+	/// Verifies if this `ApInt` can be casted into the given primitive type
+	/// without loss of information and returns the least significant `Digit`
+	/// of this `ApInt` upon success.
+	/// 
+	/// # Note
+	/// 
+	/// If the given `PrimitiveTy` represents a signed integer type the 
+	/// returned `Digit` is also sign extended accordingly. 
+	/// This sign extension behaves equal to how in Rust a negative signed
+	/// `i32` is extended to an `i64` and correctly preserves the negative value.
+	/// 
+	/// # Errors
+	/// 
+	/// If it is not possible to cast this `ApInt` without loss of information.
+	fn try_cast_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Result<Digit> {
+		debug_assert_ne!(prim_ty, PrimitiveTy::U128);
+		debug_assert_ne!(prim_ty, PrimitiveTy::I128);
+		let (mut lsd, rest) = self.split_least_significant_digit();
+		if !prim_ty.is_valid_repr(lsd.repr())
+		   || rest.into_iter().any(|d| d.repr() != 0)
+		{
+			return Error::encountered_unrepresentable_value(
+				self.clone(), prim_ty).into()
+		}
+		if prim_ty.is_signed() {
+			let actual_width = self.width();
+			let target_width = prim_ty.associated_width();
+			if actual_width < target_width {
+				lsd.sign_extend_from(actual_width)
+				   .expect("We already asserted that `actual_width` < `target_width` \
+							and since `target_width` is always less than or equal to \
+							`64` bits calling `Digit::sign_extend_from` is safe for it.");
+				if target_width < BitWidth::w64() {
+					lsd.truncate_to(target_width)
+						.expect("Since `target_width` is always less than or equal to \
+								`64` bits calling `Digit::sign_extend_from` is safe for it.");
+				}
+			}
+		}
+		Ok(lsd)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `bool`.
-    /// 
-    /// # Note
-    /// 
-    /// This returns `true` if the value represented by this `ApInt`
-    /// is `1`, returns `false` if the value represented by this
-    /// `ApInt` is `0` and returns an error otherwise.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `bool`.
-    pub fn try_to_bool(&self) -> Result<bool> {
-        match self.try_cast_to_primitive_ty(PrimitiveTy::Bool)? {
-            Digit(0) => Ok(false),
-            Digit(1) => Ok(true),
-           _ => unreachable!()
-        }
-    }
+	/// Tries to represent the value of this `ApInt` as a `bool`.
+	/// 
+	/// # Note
+	/// 
+	/// This returns `true` if the value represented by this `ApInt`
+	/// is `1`, returns `false` if the value represented by this
+	/// `ApInt` is `0` and returns an error otherwise.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `bool`.
+	pub fn try_to_bool(&self) -> Result<bool> {
+		match self.try_cast_to_primitive_ty(PrimitiveTy::Bool)? {
+			Digit(0) => Ok(false),
+			Digit(1) => Ok(true),
+		   _ => unreachable!()
+		}
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `i8`.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `8` bits the value is
-    ///   sign extended to the target bit width.
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u8`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `i8`.
-    pub fn try_to_i8(&self) -> Result<i8> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::I8).map(|d| d.repr() as i8)
-    }
+	/// Tries to represent the value of this `ApInt` as a `i8`.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `8` bits the value is
+	///   sign extended to the target bit width.
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u8`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `i8`.
+	pub fn try_to_i8(&self) -> Result<i8> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::I8).map(|d| d.repr() as i8)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `u8`.
-    /// 
-    /// # Note
-    /// 
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u8`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `u8`.
-    pub fn try_to_u8(&self) -> Result<u8> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::U8).map(|d| d.repr() as u8)
-    }
+	/// Tries to represent the value of this `ApInt` as a `u8`.
+	/// 
+	/// # Note
+	/// 
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u8`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `u8`.
+	pub fn try_to_u8(&self) -> Result<u8> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::U8).map(|d| d.repr() as u8)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `i16`.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `16` bits the value is
-    ///   sign extended to the target bit width.
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u16`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `i16`.
-    pub fn try_to_i16(&self) -> Result<i16> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::I16).map(|d| d.repr() as i16)
-    }
+	/// Tries to represent the value of this `ApInt` as a `i16`.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `16` bits the value is
+	///   sign extended to the target bit width.
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u16`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `i16`.
+	pub fn try_to_i16(&self) -> Result<i16> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::I16).map(|d| d.repr() as i16)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `u16`.
-    /// 
-    /// # Note
-    /// 
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u16`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `u16`.
-    pub fn try_to_u16(&self) -> Result<u16> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::U16).map(|d| d.repr() as u16)
-    }
+	/// Tries to represent the value of this `ApInt` as a `u16`.
+	/// 
+	/// # Note
+	/// 
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u16`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `u16`.
+	pub fn try_to_u16(&self) -> Result<u16> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::U16).map(|d| d.repr() as u16)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `i32`.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `32` bits the value is
-    ///   sign extended to the target bit width.
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u32`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `i32`.
-    pub fn try_to_i32(&self) -> Result<i32> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::I32).map(|d| d.repr() as i32)
-    }
+	/// Tries to represent the value of this `ApInt` as a `i32`.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `32` bits the value is
+	///   sign extended to the target bit width.
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u32`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `i32`.
+	pub fn try_to_i32(&self) -> Result<i32> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::I32).map(|d| d.repr() as i32)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `u32`.
-    /// 
-    /// # Note
-    /// 
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u32`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `u32`.
-    pub fn try_to_u32(&self) -> Result<u32> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::U32).map(|d| d.repr() as u32)
-    }
+	/// Tries to represent the value of this `ApInt` as a `u32`.
+	/// 
+	/// # Note
+	/// 
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u32`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `u32`.
+	pub fn try_to_u32(&self) -> Result<u32> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::U32).map(|d| d.repr() as u32)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `i64`.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `64` bits the value is
-    ///   sign extended to the target bit width.
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u64`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `i64`.
-    pub fn try_to_i64(&self) -> Result<i64> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::I64).map(|d| d.repr() as i64)
-    }
+	/// Tries to represent the value of this `ApInt` as a `i64`.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `64` bits the value is
+	///   sign extended to the target bit width.
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u64`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `i64`.
+	pub fn try_to_i64(&self) -> Result<i64> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::I64).map(|d| d.repr() as i64)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `u64`.
-    /// 
-    /// # Note
-    /// 
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u64`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `u64`.
-    pub fn try_to_u64(&self) -> Result<u64> {
-        self.try_cast_to_primitive_ty(PrimitiveTy::U64).map(|d| d.repr() as u64)
-    }
+	/// Tries to represent the value of this `ApInt` as a `u64`.
+	/// 
+	/// # Note
+	/// 
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u64`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `u64`.
+	pub fn try_to_u64(&self) -> Result<u64> {
+		self.try_cast_to_primitive_ty(PrimitiveTy::U64).map(|d| d.repr() as u64)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `i128`.
-    /// 
-    /// # Note
-    /// 
-    /// - This operation will conserve the signedness of the
-    ///   value. This means that for `ApInt` instances with
-    ///   a `BitWidth` less than `128` bits the value is
-    ///   sign extended to the target bit width.
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u128`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `i128`.
-    pub fn try_to_i128(&self) -> Result<i128> {
-        let ( lsd_0, rest) = self.split_least_significant_digit();
-        let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
-        if rest.into_iter().any(|d| d.repr() != 0) {
-            return Error::encountered_unrepresentable_value(
-                self.clone(), PrimitiveTy::I128).into()
-        }
-        let mut result: i128 =
-            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+	/// Tries to represent the value of this `ApInt` as a `i128`.
+	/// 
+	/// # Note
+	/// 
+	/// - This operation will conserve the signedness of the
+	///   value. This means that for `ApInt` instances with
+	///   a `BitWidth` less than `128` bits the value is
+	///   sign extended to the target bit width.
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u128`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `i128`.
+	pub fn try_to_i128(&self) -> Result<i128> {
+		let ( lsd_0, rest) = self.split_least_significant_digit();
+		let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
+		if rest.into_iter().any(|d| d.repr() != 0) {
+			return Error::encountered_unrepresentable_value(
+				self.clone(), PrimitiveTy::I128).into()
+		}
+		let mut result: i128 =
+			(i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
 
-        let actual_width = self.width();
-        let target_width = BitWidth::w128();
-        if actual_width < target_width {
-            // Sign extend the `i128`. Fill up with `1` up to `128` bits 
-            // starting from the sign bit position.
-            let b = actual_width.to_usize(); // Number of bits representing the number in x.
-            let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
-            result = (result ^ m).wrapping_sub(m);       // Resulting sign-extended number.
-        }
+		let actual_width = self.width();
+		let target_width = BitWidth::w128();
+		if actual_width < target_width {
+			// Sign extend the `i128`. Fill up with `1` up to `128` bits 
+			// starting from the sign bit position.
+			let b = actual_width.to_usize(); // Number of bits representing the number in x.
+			let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
+			result = (result ^ m).wrapping_sub(m);       // Resulting sign-extended number.
+		}
 
-        Ok(result)
-    }
+		Ok(result)
+	}
 
-    /// Tries to represent the value of this `ApInt` as a `u128`.
-    /// 
-    /// # Note
-    /// 
-    /// - This conversion is possible as long as the value represented
-    ///   by this `ApInt` does not exceed the maximum value of `u128`.
-    /// 
-    /// # Complexity
-    /// 
-    /// - 𝒪(n) where n is the number of digits of this `ApInt`.
-    /// 
-    /// # Errors
-    /// 
-    /// - If the value represented by this `ApInt` can not be
-    ///   represented by a `u128`.
-    pub fn try_to_u128(&self) -> Result<u128> {
-        let ( lsd_0, rest) = self.split_least_significant_digit();
-        let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
-        if rest.into_iter().any(|d| d.repr() != 0) {
-            return Error::encountered_unrepresentable_value(
-                self.clone(), PrimitiveTy::U128).into()
-        }
-        let result: u128 =
-            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
-        Ok(result)
-    }
+	/// Tries to represent the value of this `ApInt` as a `u128`.
+	/// 
+	/// # Note
+	/// 
+	/// - This conversion is possible as long as the value represented
+	///   by this `ApInt` does not exceed the maximum value of `u128`.
+	/// 
+	/// # Complexity
+	/// 
+	/// - 𝒪(n) where n is the number of digits of this `ApInt`.
+	/// 
+	/// # Errors
+	/// 
+	/// - If the value represented by this `ApInt` can not be
+	///   represented by a `u128`.
+	pub fn try_to_u128(&self) -> Result<u128> {
+		let ( lsd_0, rest) = self.split_least_significant_digit();
+		let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
+		if rest.into_iter().any(|d| d.repr() != 0) {
+			return Error::encountered_unrepresentable_value(
+				self.clone(), PrimitiveTy::U128).into()
+		}
+		let result: u128 =
+			(u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+		Ok(result)
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    use itertools::Itertools;
+	use itertools::Itertools;
 
-    /// Returns a bunch of interesting test values for the
-    /// `to_primitive` method tests.
-    fn unsigned_test_values() -> impl Iterator<Item = i64> {
-        vec![
-            0_u64, 1, 2, 3, 5, 7, 10, 11, 13, 42, 63, 64, 65,
-            100, 127, 128, 129, 254, 255, 256, 257,
-            1337, 2047, 2048, 2049, 8001, 9999,
-            0xFEDC_BA98_7654_3210, 0xF0F0_F0F0_F0F0_F0F0,
-            0x8000_0000_0000_0000, 0x1010_1010_1010_1010,
-            0xFFFF_FFFF_0000_0000, 0x0000_FFFF_FFFF_0000,
-            0xFFFF_0000_0000_FFFF, 0xFFFF_0000_FFFF_0000,
-            0x0000_FFFF_0000_FFFF
-        ].into_iter().map(|v| v as i64)
-    }
+	/// Returns a bunch of interesting test values for the
+	/// `to_primitive` method tests.
+	fn unsigned_test_values() -> impl Iterator<Item = i64> {
+		vec![
+			0_u64, 1, 2, 3, 5, 7, 10, 11, 13, 42, 63, 64, 65,
+			100, 127, 128, 129, 254, 255, 256, 257,
+			1337, 2047, 2048, 2049, 8001, 9999,
+			0xFEDC_BA98_7654_3210, 0xF0F0_F0F0_F0F0_F0F0,
+			0x8000_0000_0000_0000, 0x1010_1010_1010_1010,
+			0xFFFF_FFFF_0000_0000, 0x0000_FFFF_FFFF_0000,
+			0xFFFF_0000_0000_FFFF, 0xFFFF_0000_FFFF_0000,
+			0x0000_FFFF_0000_FFFF
+		].into_iter().map(|v| v as i64)
+	}
 
-    /// Returns negated mirror values of `unsigned_test_values` thus doubeling
-    /// the test values count.
-    fn signed_test_values() -> impl Iterator<Item = i64> {
-        unsigned_test_values().map(|v| v.wrapping_neg())
-    }
+	/// Returns negated mirror values of `unsigned_test_values` thus doubeling
+	/// the test values count.
+	fn signed_test_values() -> impl Iterator<Item = i64> {
+		unsigned_test_values().map(|v| v.wrapping_neg())
+	}
 
-    /// Unifies signed and unsigned test values into a single iterator.
-    fn test_values() -> impl Iterator<Item = i64> {
-        unsigned_test_values().chain(signed_test_values())
-    }
+	/// Unifies signed and unsigned test values into a single iterator.
+	fn test_values() -> impl Iterator<Item = i64> {
+		unsigned_test_values().chain(signed_test_values())
+	}
 
-    /// Which `PrimitiveTy` instances shall be tested. Basically we test all
-    /// if no problems occure.
-    fn test_primitive_tys() -> impl Iterator<Item = PrimitiveTy> + Clone {
-        use self::PrimitiveTy::*;
-        vec![
-            Bool,
-            I8,
-            U8,
-            I16,
-            U16,
-            I32,
-            U32,
-            I64,
-            U64,
-            I128,
-            U128
-        ].into_iter()
-    }
+	/// Which `PrimitiveTy` instances shall be tested. Basically we test all
+	/// if no problems occure.
+	fn test_primitive_tys() -> impl Iterator<Item = PrimitiveTy> + Clone {
+		use self::PrimitiveTy::*;
+		vec![
+			Bool,
+			I8,
+			U8,
+			I16,
+			U16,
+			I32,
+			U32,
+			I64,
+			U64,
+			I128,
+			U128
+		].into_iter()
+	}
 
-    /// Uses `test_values` to iterate over already constructed `ApInt` instances.
-    fn test_vals_and_apints() -> impl Iterator<Item = (u128, ApInt)> {
-        test_values()
-            .cartesian_product(test_primitive_tys())
-            .map(|(val, prim_ty)| {
-                use self::PrimitiveTy::*;
-                match prim_ty {
-                    Bool => {
-                        let val = val != 0;
-                        (val as u128, ApInt::from_bit(val))
-                    }
-                    I8 => {
-                        let val = val as i8;
-                        (val as u8 as u128, ApInt::from_i8(val))
-                    }
-                    U8 => {
-                        let val = val as u8;
-                        (val as u128, ApInt::from_u8(val))
-                    }
-                    I16 => {
-                        let val = val as i16;
-                        (val as u16 as u128, ApInt::from_i16(val))
-                    }
-                    U16 => {
-                        let val = val as u16;
-                        (val as u128, ApInt::from_u16(val))
-                    }
-                    I32 => {
-                        let val = val as i32;
-                        (val as u32 as u128, ApInt::from_i32(val))
-                    }
-                    U32 => {
-                        let val = val as u32;
-                        (val as u128, ApInt::from_u32(val))
-                    }
-                    I64 => {
-                        let val = val as i64;
-                        (val as u64 as u128, ApInt::from_i64(val))
-                    }
-                    U64 => {
-                        let val = val as u64;
-                        (val as u128, ApInt::from_u64(val))
-                    }
-                    I128 => {
-                        let val = val as i128;
-                        (val as u128, ApInt::from_i128(val))
-                    }
-                    U128 => {
-                        let val = val as u128;
-                        (val, ApInt::from_u128(val))
-                    }
-                }
-            })
-    }
+	/// Uses `test_values` to iterate over already constructed `ApInt` instances.
+	fn test_vals_and_apints() -> impl Iterator<Item = (u128, ApInt)> {
+		test_values()
+			.cartesian_product(test_primitive_tys())
+			.map(|(val, prim_ty)| {
+				use self::PrimitiveTy::*;
+				match prim_ty {
+					Bool => {
+						let val = val != 0;
+						(val as u128, ApInt::from_bit(val))
+					}
+					I8 => {
+						let val = val as i8;
+						(val as u8 as u128, ApInt::from_i8(val))
+					}
+					U8 => {
+						let val = val as u8;
+						(val as u128, ApInt::from_u8(val))
+					}
+					I16 => {
+						let val = val as i16;
+						(val as u16 as u128, ApInt::from_i16(val))
+					}
+					U16 => {
+						let val = val as u16;
+						(val as u128, ApInt::from_u16(val))
+					}
+					I32 => {
+						let val = val as i32;
+						(val as u32 as u128, ApInt::from_i32(val))
+					}
+					U32 => {
+						let val = val as u32;
+						(val as u128, ApInt::from_u32(val))
+					}
+					I64 => {
+						let val = val as i64;
+						(val as u64 as u128, ApInt::from_i64(val))
+					}
+					U64 => {
+						let val = val as u64;
+						(val as u128, ApInt::from_u64(val))
+					}
+					I128 => {
+						let val = val as i128;
+						(val as u128, ApInt::from_i128(val))
+					}
+					U128 => {
+						let val = val as u128;
+						(val, ApInt::from_u128(val))
+					}
+				}
+			})
+	}
 
-    mod resize {
-        use super::*;
+	mod resize {
+		use super::*;
 
-        #[test]
-        fn count_test_apints() {
-            assert_eq!(test_vals_and_apints().count(), 792);
-        }
+		#[test]
+		fn count_test_apints() {
+			assert_eq!(test_vals_and_apints().count(), 792);
+		}
 
-        #[test]
-        fn to_bool_true() {
-            assert_eq!(ApInt::from(true).resize_to_bool(), true);
-            assert_eq!(ApInt::from(1_u8).resize_to_bool(), true);
-            assert_eq!(ApInt::from(1_u16).resize_to_bool(), true);
-            assert_eq!(ApInt::from(1_u32).resize_to_bool(), true);
-            assert_eq!(ApInt::from(1_u64).resize_to_bool(), true);
-            assert_eq!(ApInt::from(1_u128).resize_to_bool(), true);
-        }
+		#[test]
+		fn to_bool_true() {
+			assert_eq!(ApInt::from(true).resize_to_bool(), true);
+			assert_eq!(ApInt::from(1_u8).resize_to_bool(), true);
+			assert_eq!(ApInt::from(1_u16).resize_to_bool(), true);
+			assert_eq!(ApInt::from(1_u32).resize_to_bool(), true);
+			assert_eq!(ApInt::from(1_u64).resize_to_bool(), true);
+			assert_eq!(ApInt::from(1_u128).resize_to_bool(), true);
+		}
 
-        #[test]
-        fn to_bool_odd() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(val % 2 == 0, apint.is_even());
-                assert_eq!(val % 2 != 0, apint.is_odd());
-                assert_eq!(apint.resize_to_bool(), apint.is_odd())
-            }
-        }
+		#[test]
+		fn to_bool_odd() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(val % 2 == 0, apint.is_even());
+				assert_eq!(val % 2 != 0, apint.is_odd());
+				assert_eq!(apint.resize_to_bool(), apint.is_odd())
+			}
+		}
 
-        #[test]
-        fn to_i8() {
-            for (val, apint) in test_vals_and_apints() {
-                let actual_width = apint.width();
-                let target_width = PrimitiveTy::I8.associated_width();
-                if actual_width < target_width {
-                    let mut digit = Digit(val as u64);
-                    digit.sign_extend_from(actual_width).unwrap();
-                    digit.truncate_to(target_width).unwrap();
-                    assert_eq!(apint.resize_to_i8(), digit.repr() as i8);
-                }
-                else {
-                    assert_eq!(apint.resize_to_i8(), val as i8)
-                }
-            }
-        }
+		#[test]
+		fn to_i8() {
+			for (val, apint) in test_vals_and_apints() {
+				let actual_width = apint.width();
+				let target_width = PrimitiveTy::I8.associated_width();
+				if actual_width < target_width {
+					let mut digit = Digit(val as u64);
+					digit.sign_extend_from(actual_width).unwrap();
+					digit.truncate_to(target_width).unwrap();
+					assert_eq!(apint.resize_to_i8(), digit.repr() as i8);
+				}
+				else {
+					assert_eq!(apint.resize_to_i8(), val as i8)
+				}
+			}
+		}
 
-        #[test]
-        fn to_u8() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(apint.resize_to_u8(), val as u8)
-            }
-        }
+		#[test]
+		fn to_u8() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(apint.resize_to_u8(), val as u8)
+			}
+		}
 
-        #[test]
-        fn to_i16() {
-            for (val, apint) in test_vals_and_apints() {
-                let actual_width = apint.width();
-                let target_width = PrimitiveTy::I16.associated_width();
-                if actual_width < target_width {
-                    let mut digit = Digit(val as u64);
-                    digit.sign_extend_from(actual_width).unwrap();
-                    digit.truncate_to(target_width).unwrap();
-                    assert_eq!(apint.resize_to_i16(), digit.repr() as i16);
-                }
-                else {
-                    assert_eq!(apint.resize_to_i16(), val as i16)
-                }
-            }
-        }
+		#[test]
+		fn to_i16() {
+			for (val, apint) in test_vals_and_apints() {
+				let actual_width = apint.width();
+				let target_width = PrimitiveTy::I16.associated_width();
+				if actual_width < target_width {
+					let mut digit = Digit(val as u64);
+					digit.sign_extend_from(actual_width).unwrap();
+					digit.truncate_to(target_width).unwrap();
+					assert_eq!(apint.resize_to_i16(), digit.repr() as i16);
+				}
+				else {
+					assert_eq!(apint.resize_to_i16(), val as i16)
+				}
+			}
+		}
 
-        #[test]
-        fn to_u16() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(apint.resize_to_u16(), val as u16)
-            }
-        }
+		#[test]
+		fn to_u16() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(apint.resize_to_u16(), val as u16)
+			}
+		}
 
-        #[test]
-        fn to_i32() {
-            for (val, apint) in test_vals_and_apints() {
-                let actual_width = apint.width();
-                let target_width = PrimitiveTy::I32.associated_width();
-                if actual_width < target_width {
-                    let mut digit = Digit(val as u64);
-                    digit.sign_extend_from(actual_width).unwrap();
-                    digit.truncate_to(target_width).unwrap();
-                    assert_eq!(apint.resize_to_i32(), digit.repr() as i32);
-                }
-                else {
-                    assert_eq!(apint.resize_to_i32(), val as i32)
-                }
-            }
-        }
+		#[test]
+		fn to_i32() {
+			for (val, apint) in test_vals_and_apints() {
+				let actual_width = apint.width();
+				let target_width = PrimitiveTy::I32.associated_width();
+				if actual_width < target_width {
+					let mut digit = Digit(val as u64);
+					digit.sign_extend_from(actual_width).unwrap();
+					digit.truncate_to(target_width).unwrap();
+					assert_eq!(apint.resize_to_i32(), digit.repr() as i32);
+				}
+				else {
+					assert_eq!(apint.resize_to_i32(), val as i32)
+				}
+			}
+		}
 
-        #[test]
-        fn to_u32() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(apint.resize_to_u32(), val as u32)
-            }
-        }
+		#[test]
+		fn to_u32() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(apint.resize_to_u32(), val as u32)
+			}
+		}
 
-        #[test]
-        fn to_i64() {
-            for (val, apint) in test_vals_and_apints() {
-                let actual_width = apint.width();
-                let target_width = PrimitiveTy::I64.associated_width();
-                if actual_width < target_width {
-                    let mut digit = Digit(val as u64);
-                    digit.sign_extend_from(actual_width).unwrap();
-                    assert_eq!(apint.resize_to_i64(), digit.repr() as i64);
-                }
-                else {
-                    assert_eq!(apint.resize_to_i64(), val as i64)
-                }
-            }
-        }
+		#[test]
+		fn to_i64() {
+			for (val, apint) in test_vals_and_apints() {
+				let actual_width = apint.width();
+				let target_width = PrimitiveTy::I64.associated_width();
+				if actual_width < target_width {
+					let mut digit = Digit(val as u64);
+					digit.sign_extend_from(actual_width).unwrap();
+					assert_eq!(apint.resize_to_i64(), digit.repr() as i64);
+				}
+				else {
+					assert_eq!(apint.resize_to_i64(), val as i64)
+				}
+			}
+		}
 
-        #[test]
-        fn to_u64() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(apint.resize_to_u64(), val as u64)
-            }
-        }
+		#[test]
+		fn to_u64() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(apint.resize_to_u64(), val as u64)
+			}
+		}
 
-        #[test]
-        fn to_i128() {
-            for (val, apint) in test_vals_and_apints() {
-                let actual_width = apint.width();
-                let target_width = PrimitiveTy::I128.associated_width();
-                if actual_width < target_width {
-                    let mut digit = Digit(val as u64);
-                    digit.sign_extend_from(actual_width).unwrap();
-                    assert_eq!(apint.resize_to_i128(), digit.repr() as i64 as i128);
-                }
-                else {
-                    assert_eq!(apint.resize_to_i128(), val as i128)
-                }
-            }
-        }
+		#[test]
+		fn to_i128() {
+			for (val, apint) in test_vals_and_apints() {
+				let actual_width = apint.width();
+				let target_width = PrimitiveTy::I128.associated_width();
+				if actual_width < target_width {
+					let mut digit = Digit(val as u64);
+					digit.sign_extend_from(actual_width).unwrap();
+					assert_eq!(apint.resize_to_i128(), digit.repr() as i64 as i128);
+				}
+				else {
+					assert_eq!(apint.resize_to_i128(), val as i128)
+				}
+			}
+		}
 
-        #[test]
-        fn to_u128() {
-            for (val, apint) in test_vals_and_apints() {
-                assert_eq!(apint.resize_to_u128(), val)
-            }
-        }
+		#[test]
+		fn to_u128() {
+			for (val, apint) in test_vals_and_apints() {
+				assert_eq!(apint.resize_to_u128(), val)
+			}
+		}
 
-        #[test]
-        fn one_to_i8() {
-            assert_eq!(ApInt::from(true).resize_to_i8(), -1);
+		#[test]
+		fn one_to_i8() {
+			assert_eq!(ApInt::from(true).resize_to_i8(), -1);
 
-            assert_eq!(ApInt::from(1_u8).resize_to_i8(), 1);
-            assert_eq!(ApInt::from(1_u16).resize_to_i8(), 1);
-            assert_eq!(ApInt::from(1_u32).resize_to_i8(), 1);
-            assert_eq!(ApInt::from(1_u64).resize_to_i8(), 1);
-            assert_eq!(ApInt::from(1_u128).resize_to_i8(), 1);
+			assert_eq!(ApInt::from(1_u8).resize_to_i8(), 1);
+			assert_eq!(ApInt::from(1_u16).resize_to_i8(), 1);
+			assert_eq!(ApInt::from(1_u32).resize_to_i8(), 1);
+			assert_eq!(ApInt::from(1_u64).resize_to_i8(), 1);
+			assert_eq!(ApInt::from(1_u128).resize_to_i8(), 1);
 
-            assert_eq!(ApInt::from(-1_i8).resize_to_i8(), -1);
-            assert_eq!(ApInt::from(-1_i16).resize_to_i8(), -1);
-            assert_eq!(ApInt::from(-1_i32).resize_to_i8(), -1);
-            assert_eq!(ApInt::from(-1_i64).resize_to_i8(), -1);
-            assert_eq!(ApInt::from(-1_i128).resize_to_i8(), -1);
-        }
-    }
+			assert_eq!(ApInt::from(-1_i8).resize_to_i8(), -1);
+			assert_eq!(ApInt::from(-1_i16).resize_to_i8(), -1);
+			assert_eq!(ApInt::from(-1_i32).resize_to_i8(), -1);
+			assert_eq!(ApInt::from(-1_i64).resize_to_i8(), -1);
+			assert_eq!(ApInt::from(-1_i128).resize_to_i8(), -1);
+		}
+	}
 
-    mod try {
-        use super::*;
+	mod try {
+		use super::*;
 
-        #[test]
-        fn to_bool_true() {
-            assert_eq!(ApInt::from(true).try_to_bool(), Ok(true));
-            assert_eq!(ApInt::from(1_u8).try_to_bool(), Ok(true));
-            assert_eq!(ApInt::from(1_u16).try_to_bool(), Ok(true));
-            assert_eq!(ApInt::from(1_u32).try_to_bool(), Ok(true));
-            assert_eq!(ApInt::from(1_u64).try_to_bool(), Ok(true));
-            assert_eq!(ApInt::from(1_u128).try_to_bool(), Ok(true));
-        }
+		#[test]
+		fn to_bool_true() {
+			assert_eq!(ApInt::from(true).try_to_bool(), Ok(true));
+			assert_eq!(ApInt::from(1_u8).try_to_bool(), Ok(true));
+			assert_eq!(ApInt::from(1_u16).try_to_bool(), Ok(true));
+			assert_eq!(ApInt::from(1_u32).try_to_bool(), Ok(true));
+			assert_eq!(ApInt::from(1_u64).try_to_bool(), Ok(true));
+			assert_eq!(ApInt::from(1_u128).try_to_bool(), Ok(true));
+		}
 
-        #[test]
-        fn to_bool_false() {
-            assert_eq!(ApInt::from(false).try_to_bool(), Ok(false));
-            assert_eq!(ApInt::from(0_u8).try_to_bool(), Ok(false));
-            assert_eq!(ApInt::from(0_u16).try_to_bool(), Ok(false));
-            assert_eq!(ApInt::from(0_u32).try_to_bool(), Ok(false));
-            assert_eq!(ApInt::from(0_u64).try_to_bool(), Ok(false));
-            assert_eq!(ApInt::from(0_u128).try_to_bool(), Ok(false));
-        }
+		#[test]
+		fn to_bool_false() {
+			assert_eq!(ApInt::from(false).try_to_bool(), Ok(false));
+			assert_eq!(ApInt::from(0_u8).try_to_bool(), Ok(false));
+			assert_eq!(ApInt::from(0_u16).try_to_bool(), Ok(false));
+			assert_eq!(ApInt::from(0_u32).try_to_bool(), Ok(false));
+			assert_eq!(ApInt::from(0_u64).try_to_bool(), Ok(false));
+			assert_eq!(ApInt::from(0_u128).try_to_bool(), Ok(false));
+		}
 
-        #[test]
-        fn to_bool_fail() {
-            assert!(ApInt::from(2_u8).try_to_bool().is_err());
-            assert!(ApInt::from(-1_i16).try_to_bool().is_err());
-            assert!(ApInt::from(42_u32).try_to_bool().is_err());
-            assert!(ApInt::from(1337_u64).try_to_bool().is_err());
-            assert!(ApInt::from(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_u128)
-                .try_to_bool()
-                .is_err()
-            );
-        }
+		#[test]
+		fn to_bool_fail() {
+			assert!(ApInt::from(2_u8).try_to_bool().is_err());
+			assert!(ApInt::from(-1_i16).try_to_bool().is_err());
+			assert!(ApInt::from(42_u32).try_to_bool().is_err());
+			assert!(ApInt::from(1337_u64).try_to_bool().is_err());
+			assert!(ApInt::from(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_u128)
+				.try_to_bool()
+				.is_err()
+			);
+		}
 
-        #[test]
-        fn to_i8() {
-            for (val, apint) in test_vals_and_apints() {
-                if PrimitiveTy::I8.is_valid_dd(val) {
-                    let actual_width = apint.width();
-                    let target_width = PrimitiveTy::I8.associated_width();
-                    if actual_width < target_width {
-                        let mut digit = Digit(val as u64);
-                        digit.sign_extend_from(actual_width).unwrap();
-                        digit.truncate_to(target_width).unwrap();
-                        assert_eq!(apint.try_to_i8(), Ok(digit.repr() as i8));
-                    }
-                    else {
-                        assert_eq!(apint.try_to_i8(), Ok(val as i8))
-                    }
-                }
-                else {
-                    assert!(apint.try_to_i8().is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_i8() {
+			for (val, apint) in test_vals_and_apints() {
+				if PrimitiveTy::I8.is_valid_dd(val) {
+					let actual_width = apint.width();
+					let target_width = PrimitiveTy::I8.associated_width();
+					if actual_width < target_width {
+						let mut digit = Digit(val as u64);
+						digit.sign_extend_from(actual_width).unwrap();
+						digit.truncate_to(target_width).unwrap();
+						assert_eq!(apint.try_to_i8(), Ok(digit.repr() as i8));
+					}
+					else {
+						assert_eq!(apint.try_to_i8(), Ok(val as i8))
+					}
+				}
+				else {
+					assert!(apint.try_to_i8().is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_i16() {
-            for (val, apint) in test_vals_and_apints() {
-                if PrimitiveTy::I16.is_valid_dd(val) {
-                    let actual_width = apint.width();
-                    let target_width = PrimitiveTy::I16.associated_width();
-                    if actual_width < target_width {
-                        let mut digit = Digit(val as u64);
-                        digit.sign_extend_from(actual_width).unwrap();
-                        digit.truncate_to(target_width).unwrap();
-                        assert_eq!(apint.try_to_i16(), Ok(digit.repr() as i16));
-                    }
-                    else {
-                        assert_eq!(apint.try_to_i16(), Ok(val as i16))
-                    }
-                }
-                else {
-                    assert!(apint.try_to_i16().is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_i16() {
+			for (val, apint) in test_vals_and_apints() {
+				if PrimitiveTy::I16.is_valid_dd(val) {
+					let actual_width = apint.width();
+					let target_width = PrimitiveTy::I16.associated_width();
+					if actual_width < target_width {
+						let mut digit = Digit(val as u64);
+						digit.sign_extend_from(actual_width).unwrap();
+						digit.truncate_to(target_width).unwrap();
+						assert_eq!(apint.try_to_i16(), Ok(digit.repr() as i16));
+					}
+					else {
+						assert_eq!(apint.try_to_i16(), Ok(val as i16))
+					}
+				}
+				else {
+					assert!(apint.try_to_i16().is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_i32() {
-            for (val, apint) in test_vals_and_apints() {
-                if PrimitiveTy::I32.is_valid_dd(val) {
-                    let actual_width = apint.width();
-                    let target_width = PrimitiveTy::I32.associated_width();
-                    if actual_width < target_width {
-                        let mut digit = Digit(val as u64);
-                        digit.sign_extend_from(actual_width).unwrap();
-                        digit.truncate_to(target_width).unwrap();
-                        assert_eq!(apint.try_to_i32(), Ok(digit.repr() as i32));
-                    }
-                    else {
-                        assert_eq!(apint.try_to_i32(), Ok(val as i32))
-                    }
-                }
-                else {
-                    assert!(apint.try_to_i32().is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_i32() {
+			for (val, apint) in test_vals_and_apints() {
+				if PrimitiveTy::I32.is_valid_dd(val) {
+					let actual_width = apint.width();
+					let target_width = PrimitiveTy::I32.associated_width();
+					if actual_width < target_width {
+						let mut digit = Digit(val as u64);
+						digit.sign_extend_from(actual_width).unwrap();
+						digit.truncate_to(target_width).unwrap();
+						assert_eq!(apint.try_to_i32(), Ok(digit.repr() as i32));
+					}
+					else {
+						assert_eq!(apint.try_to_i32(), Ok(val as i32))
+					}
+				}
+				else {
+					assert!(apint.try_to_i32().is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_i64() {
-            for (val, apint) in test_vals_and_apints() {
-                if PrimitiveTy::I64.is_valid_dd(val) {
-                    let actual_width = apint.width();
-                    let target_width = PrimitiveTy::I64.associated_width();
-                    if actual_width < target_width {
-                        let mut digit = Digit(val as u64);
-                        digit.sign_extend_from(actual_width).unwrap();
-                        assert_eq!(apint.try_to_i64(), Ok(digit.repr() as i64));
-                    }
-                    else {
-                        assert_eq!(apint.try_to_i64(), Ok(val as i64))
-                    }
-                }
-                else {
-                    assert!(apint.try_to_i64().is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_i64() {
+			for (val, apint) in test_vals_and_apints() {
+				if PrimitiveTy::I64.is_valid_dd(val) {
+					let actual_width = apint.width();
+					let target_width = PrimitiveTy::I64.associated_width();
+					if actual_width < target_width {
+						let mut digit = Digit(val as u64);
+						digit.sign_extend_from(actual_width).unwrap();
+						assert_eq!(apint.try_to_i64(), Ok(digit.repr() as i64));
+					}
+					else {
+						assert_eq!(apint.try_to_i64(), Ok(val as i64))
+					}
+				}
+				else {
+					assert!(apint.try_to_i64().is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_i128() {
-            for (val, apint) in test_vals_and_apints() {
-                if PrimitiveTy::I128.is_valid_dd(val) {
+		#[test]
+		fn to_i128() {
+			for (val, apint) in test_vals_and_apints() {
+				if PrimitiveTy::I128.is_valid_dd(val) {
 
-                    let actual_width = apint.width();
-                    let target_width = BitWidth::w128();
-                    let mut result: i128 = val as i128;
-                    if actual_width < target_width {
-                        // Sign extend the `i128`. Fill up with `1` up to `128` bits 
-                        // starting from the sign bit position.
-                        let b = actual_width.to_usize();       // Number of bits representing the number in x.
-                        let m: i128 = 1 << (b - 1);            // Mask can be pre-computed if b is fixed.
-                        result = (result ^ m).wrapping_sub(m); // Resulting sign-extended number.
-                    }
-                    assert_eq!(apint.try_to_i128(), Ok(result))
-                }
-                else {
-                    assert!(apint.try_to_i128().is_err())
-                }
-            }
-        }
+					let actual_width = apint.width();
+					let target_width = BitWidth::w128();
+					let mut result: i128 = val as i128;
+					if actual_width < target_width {
+						// Sign extend the `i128`. Fill up with `1` up to `128` bits 
+						// starting from the sign bit position.
+						let b = actual_width.to_usize();       // Number of bits representing the number in x.
+						let m: i128 = 1 << (b - 1);            // Mask can be pre-computed if b is fixed.
+						result = (result ^ m).wrapping_sub(m); // Resulting sign-extended number.
+					}
+					assert_eq!(apint.try_to_i128(), Ok(result))
+				}
+				else {
+					assert!(apint.try_to_i128().is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_u8() {
-            for (val, apint) in test_vals_and_apints() {
-                let result = apint.try_to_u8();
-                if PrimitiveTy::U8.is_valid_dd(val) {
-                    assert_eq!(result, Ok(val as u8))
-                }
-                else {
-                    assert!(result.is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_u8() {
+			for (val, apint) in test_vals_and_apints() {
+				let result = apint.try_to_u8();
+				if PrimitiveTy::U8.is_valid_dd(val) {
+					assert_eq!(result, Ok(val as u8))
+				}
+				else {
+					assert!(result.is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_u16() {
-            for (val, apint) in test_vals_and_apints() {
-                let result = apint.try_to_u16();
-                if PrimitiveTy::U16.is_valid_dd(val) {
-                    assert_eq!(result, Ok(val as u16))
-                }
-                else {
-                    assert!(result.is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_u16() {
+			for (val, apint) in test_vals_and_apints() {
+				let result = apint.try_to_u16();
+				if PrimitiveTy::U16.is_valid_dd(val) {
+					assert_eq!(result, Ok(val as u16))
+				}
+				else {
+					assert!(result.is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_u32() {
-            for (val, apint) in test_vals_and_apints() {
-                let result = apint.try_to_u32();
-                if PrimitiveTy::U32.is_valid_dd(val) {
-                    assert_eq!(result, Ok(val as u32))
-                }
-                else {
-                    assert!(result.is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_u32() {
+			for (val, apint) in test_vals_and_apints() {
+				let result = apint.try_to_u32();
+				if PrimitiveTy::U32.is_valid_dd(val) {
+					assert_eq!(result, Ok(val as u32))
+				}
+				else {
+					assert!(result.is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_u64() {
-            for (val, apint) in test_vals_and_apints() {
-                let result = apint.try_to_u64();
-                if PrimitiveTy::U64.is_valid_dd(val) {
-                    assert_eq!(result, Ok(val as u64))
-                }
-                else {
-                    assert!(result.is_err())
-                }
-            }
-        }
+		#[test]
+		fn to_u64() {
+			for (val, apint) in test_vals_and_apints() {
+				let result = apint.try_to_u64();
+				if PrimitiveTy::U64.is_valid_dd(val) {
+					assert_eq!(result, Ok(val as u64))
+				}
+				else {
+					assert!(result.is_err())
+				}
+			}
+		}
 
-        #[test]
-        fn to_u128() {
-            for (val, apint) in test_vals_and_apints() {
-                let result = apint.try_to_u128();
-                if PrimitiveTy::U128.is_valid_dd(val) {
-                    assert_eq!(result, Ok(val as u128))
-                }
-                else {
-                    assert!(result.is_err())
-                }
-            }
-        }
-    }
+		#[test]
+		fn to_u128() {
+			for (val, apint) in test_vals_and_apints() {
+				let result = apint.try_to_u128();
+				if PrimitiveTy::U128.is_valid_dd(val) {
+					assert_eq!(result, Ok(val as u128))
+				}
+				else {
+					assert!(result.is_err())
+				}
+			}
+		}
+	}
 }

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -195,15 +195,15 @@ impl DoubleDigit {
 		DoubleDigit((DoubleDigitRepr::from(hi.repr()) << BITS) | DoubleDigitRepr::from(lo.repr()))
 	}
 
-    #[inline]
-    pub(crate) fn wrapping_add(self, other: DoubleDigit) -> Self {
-        DoubleDigit(self.repr().wrapping_add(other.repr()))
-    }
+	#[inline]
+	pub(crate) fn wrapping_add(self, other: DoubleDigit) -> Self {
+		DoubleDigit(self.repr().wrapping_add(other.repr()))
+	}
 
-    #[inline]
-    pub(crate) fn wrapping_mul(self, other: DoubleDigit) -> Self {
-        DoubleDigit(self.repr().wrapping_mul(other.repr()))
-    }
+	#[inline]
+	pub(crate) fn wrapping_mul(self, other: DoubleDigit) -> Self {
+		DoubleDigit(self.repr().wrapping_mul(other.repr()))
+	}
 }
 
 /// # Constructors
@@ -256,46 +256,46 @@ impl Digit {
 		DoubleDigit(DoubleDigitRepr::from(self.repr()))
 	}
 
-    #[inline]
-    pub(crate) fn wrapping_add(self, other: Digit) -> Self {
-        Digit(self.repr().wrapping_add(other.repr()))
-    }
+	#[inline]
+	pub(crate) fn wrapping_add(self, other: Digit) -> Self {
+		Digit(self.repr().wrapping_add(other.repr()))
+	}
 
-    #[inline]
-    pub(crate) fn wrapping_mul(self, other: Digit) -> Self {
-        Digit(self.repr().wrapping_mul(other.repr()))
-    }
+	#[inline]
+	pub(crate) fn wrapping_mul(self, other: Digit) -> Self {
+		Digit(self.repr().wrapping_mul(other.repr()))
+	}
 
-    #[inline]
-    pub(crate) fn wrapping_mul_add(self, mul: Digit, add: Digit) -> Digit {
-        Digit(
-            self.repr()
-                .wrapping_mul(mul.repr())
-                .wrapping_add(add.repr()),
-        )
-    }
+	#[inline]
+	pub(crate) fn wrapping_mul_add(self, mul: Digit, add: Digit) -> Digit {
+		Digit(
+			self.repr()
+				.wrapping_mul(mul.repr())
+				.wrapping_add(add.repr()),
+		)
+	}
 
-    #[inline]
-    pub(crate) fn carrying_add(self, other: Digit) -> (Digit, Digit) {
-        //this is to make sure that the assembly compiles down to the `adc` function
-        match self.repr().overflowing_add(other.repr()) {
-            (x,false) => (Digit(x),Digit::zero()),
-            (x,true) => (Digit(x),Digit::one()),
-        }
-    }
+	#[inline]
+	pub(crate) fn carrying_add(self, other: Digit) -> (Digit, Digit) {
+		//this is to make sure that the assembly compiles down to the `adc` function
+		match self.repr().overflowing_add(other.repr()) {
+			(x,false) => (Digit(x),Digit::zero()),
+			(x,true) => (Digit(x),Digit::one()),
+		}
+	}
 
-    //TODO if and when `carrying_mul` (rust-lang rfc #2417) is stabilized, this function and others in this crate should use `carrying_mul` as the operation
-    #[inline]
-    pub(crate) fn carrying_mul(self, other: Digit) -> (Digit, Digit) {
-        let temp = self.dd().wrapping_mul(other.dd());
-        (temp.lo(), temp.hi())
-    }
+	//TODO if and when `carrying_mul` (rust-lang rfc #2417) is stabilized, this function and others in this crate should use `carrying_mul` as the operation
+	#[inline]
+	pub(crate) fn carrying_mul(self, other: Digit) -> (Digit, Digit) {
+		let temp = self.dd().wrapping_mul(other.dd());
+		(temp.lo(), temp.hi())
+	}
 
-    #[inline]
-    pub(crate) fn carrying_mul_add(self, mul: Digit, add: Digit) -> (Digit, Digit) {
-        let temp = self.dd().wrapping_mul(mul.dd()).wrapping_add(add.dd());
-        (temp.lo(), temp.hi())
-    }
+	#[inline]
+	pub(crate) fn carrying_mul_add(self, mul: Digit, add: Digit) -> (Digit, Digit) {
+		let temp = self.dd().wrapping_mul(mul.dd()).wrapping_add(add.dd());
+		(temp.lo(), temp.hi())
+	}
 }
 
 impl Digit {
@@ -308,7 +308,7 @@ impl Digit {
 		if width.to_usize() > BITS {
 			return Err(Error::invalid_bitwidth(width.to_usize())
 				.with_annotation(format!("Encountered invalid `BitWidth` for operating \
-				                          on a `Digit`.")))
+										  on a `Digit`.")))
 		}
 		Ok(())
 	}
@@ -357,7 +357,7 @@ impl Digit {
 		let x = self.repr() as i64; // sign extend this b-bit number to r
 		let m: i64 = 1 << (b - 1);       // mask can be pre-computed if b is fixed
 		// x = x & ((1 << b) - 1);  // (Skip this if bits in x above position b are already zero.)
-		                            // We don't need this step since this condition is an invariant of `Digit`.
+									// We don't need this step since this condition is an invariant of `Digit`.
 		let r: i64 = (x ^ m).wrapping_sub(m);   // resulting sign-extended number
 		self.0 = r as u64;
 		Ok(())

--- a/src/int.rs
+++ b/src/int.rs
@@ -24,13 +24,13 @@ use std::ops::{
 	Add,
 	Sub,
 	Mul,
-    Div,
-    Rem,
+	Div,
+	Rem,
 	AddAssign,
 	SubAssign,
 	MulAssign,
-    DivAssign,
-    RemAssign,
+	DivAssign,
+	RemAssign,
 	Shl,
 	ShlAssign,
 	Shr,
@@ -45,103 +45,103 @@ use std::ops::{
 /// `UInt` offers a more elegant and higher-level abstraction interface to the lower-level `ApInt`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Int {
-    value: ApInt,
+	value: ApInt,
 }
 
 impl From<ApInt> for Int {
-    fn from(value: ApInt) -> Int {
-        Int { value }
-    }
+	fn from(value: ApInt) -> Int {
+		Int { value }
+	}
 }
 
 impl Int {
-    /// Transforms this `Int` into an equivalent `ApInt` instance.
-    pub fn into_apint(self) -> ApInt {
-        self.value
-    }
+	/// Transforms this `Int` into an equivalent `ApInt` instance.
+	pub fn into_apint(self) -> ApInt {
+		self.value
+	}
 
-    /// Transforms this `Int` into an equivalent `UInt` instance.
-    pub fn into_unsigned(self) -> UInt {
-        UInt::from(self.value)
-    }
+	/// Transforms this `Int` into an equivalent `UInt` instance.
+	pub fn into_unsigned(self) -> UInt {
+		UInt::from(self.value)
+	}
 }
 
 /// # Constructors
 impl Int {
-    /// Creates a new `Int` from the given `Bit` value with a bit width of `1`.
-    ///
-    /// This function is generic over types that are convertible to `Bit` such as `bool`.
-    pub fn from_bit<B>(bit: B) -> Int
-    where
-        B: Into<Bit>,
-    {
-        Int::from(ApInt::from_bit(bit))
-    }
+	/// Creates a new `Int` from the given `Bit` value with a bit width of `1`.
+	///
+	/// This function is generic over types that are convertible to `Bit` such as `bool`.
+	pub fn from_bit<B>(bit: B) -> Int
+	where
+		B: Into<Bit>,
+	{
+		Int::from(ApInt::from_bit(bit))
+	}
 
-    /// Creates a new `Int` from a given `i8` value with a bit-width of 8.
-    #[inline]
-    pub fn from_i8(val: i8) -> Int {
-        Int::from(ApInt::from_i8(val))
-    }
+	/// Creates a new `Int` from a given `i8` value with a bit-width of 8.
+	#[inline]
+	pub fn from_i8(val: i8) -> Int {
+		Int::from(ApInt::from_i8(val))
+	}
 
-    /// Creates a new `Int` from a given `i16` value with a bit-width of 16.
-    #[inline]
-    pub fn from_i16(val: i16) -> Int {
-        Int::from(ApInt::from_i16(val))
-    }
+	/// Creates a new `Int` from a given `i16` value with a bit-width of 16.
+	#[inline]
+	pub fn from_i16(val: i16) -> Int {
+		Int::from(ApInt::from_i16(val))
+	}
 
-    /// Creates a new `Int` from a given `i32` value with a bit-width of 32.
-    #[inline]
-    pub fn from_i32(val: i32) -> Int {
-        Int::from(ApInt::from_i32(val))
-    }
+	/// Creates a new `Int` from a given `i32` value with a bit-width of 32.
+	#[inline]
+	pub fn from_i32(val: i32) -> Int {
+		Int::from(ApInt::from_i32(val))
+	}
 
-    /// Creates a new `Int` from a given `i64` value with a bit-width of 64.
-    #[inline]
-    pub fn from_i64(val: i64) -> Int {
-        Int::from(ApInt::from_i64(val))
-    }
+	/// Creates a new `Int` from a given `i64` value with a bit-width of 64.
+	#[inline]
+	pub fn from_i64(val: i64) -> Int {
+		Int::from(ApInt::from_i64(val))
+	}
 
-    /// Creates a new `Int` from a given `i64` value with a bit-width of 64.
-    pub fn from_i128(val: i128) -> Int {
-        Int::from(ApInt::from_i128(val))
-    }
+	/// Creates a new `Int` from a given `i64` value with a bit-width of 64.
+	pub fn from_i128(val: i128) -> Int {
+		Int::from(ApInt::from_i128(val))
+	}
 
-    /// Creates a new `Int` with the given bit width that represents zero.
-    pub fn zero(width: BitWidth) -> Int {
-        Int::from(ApInt::zero(width))
-    }
+	/// Creates a new `Int` with the given bit width that represents zero.
+	pub fn zero(width: BitWidth) -> Int {
+		Int::from(ApInt::zero(width))
+	}
 
-    /// Creates a new `Int` with the given bit width that represents one.
-    pub fn one(width: BitWidth) -> Int {
-        Int::from(ApInt::one(width))
-    }
+	/// Creates a new `Int` with the given bit width that represents one.
+	pub fn one(width: BitWidth) -> Int {
+		Int::from(ApInt::one(width))
+	}
 
-    /// Creates a new `Int` with the given bit width that has all bits unset.
-    ///
-    /// **Note:** This is equal to calling `Int::zero` with the given `width`.
-    pub fn all_unset(width: BitWidth) -> Int {
-        Int::zero(width)
-    }
+	/// Creates a new `Int` with the given bit width that has all bits unset.
+	///
+	/// **Note:** This is equal to calling `Int::zero` with the given `width`.
+	pub fn all_unset(width: BitWidth) -> Int {
+		Int::zero(width)
+	}
 
-    /// Creates a new `Int` with the given bit width that has all bits set.
-    ///
-    /// # Note
-    ///
-    /// - This is equal to minus one on any twos-complement machine.
-    pub fn all_set(width: BitWidth) -> Int {
-        Int::from(ApInt::all_set(width))
-    }
+	/// Creates a new `Int` with the given bit width that has all bits set.
+	///
+	/// # Note
+	///
+	/// - This is equal to minus one on any twos-complement machine.
+	pub fn all_set(width: BitWidth) -> Int {
+		Int::from(ApInt::all_set(width))
+	}
 
-    /// Returns the smallest `Int` that can be represented by the given `BitWidth`.
-    pub fn min_value(width: BitWidth) -> Int {
-        Int::from(ApInt::signed_min_value(width))
-    }
+	/// Returns the smallest `Int` that can be represented by the given `BitWidth`.
+	pub fn min_value(width: BitWidth) -> Int {
+		Int::from(ApInt::signed_min_value(width))
+	}
 
-    /// Returns the largest `Int` that can be represented by the given `BitWidth`.
-    pub fn max_value(width: BitWidth) -> Int {
-        Int::from(ApInt::signed_max_value(width))
-    }
+	/// Returns the largest `Int` that can be represented by the given `BitWidth`.
+	pub fn max_value(width: BitWidth) -> Int {
+		Int::from(ApInt::signed_max_value(width))
+	}
 }
 
 impl<B> From<B> for Int
@@ -149,38 +149,38 @@ impl<B> From<B> for Int
 {
 	#[inline]
 	fn from(bit: B) -> Int {
-        Int::from_bit(bit)
+		Int::from_bit(bit)
 	}
 }
 
 impl From<i8> for Int {
-    fn from(val: i8) -> Int {
-        Int::from_i8(val)
-    }
+	fn from(val: i8) -> Int {
+		Int::from_i8(val)
+	}
 }
 
 impl From<i16> for Int {
-    fn from(val: i16) -> Int {
-        Int::from_i16(val)
-    }
+	fn from(val: i16) -> Int {
+		Int::from_i16(val)
+	}
 }
 
 impl From<i32> for Int {
-    fn from(val: i32) -> Int {
-        Int::from_i32(val)
-    }
+	fn from(val: i32) -> Int {
+		Int::from_i32(val)
+	}
 }
 
 impl From<i64> for Int {
-    fn from(val: i64) -> Int {
-        Int::from_i64(val)
-    }
+	fn from(val: i64) -> Int {
+		Int::from_i64(val)
+	}
 }
 
 impl From<i128> for Int {
-    fn from(val: i128) -> Int {
-        Int::from_i128(val)
-    }
+	fn from(val: i128) -> Int {
+		Int::from_i128(val)
+	}
 }
 
 macro_rules! impl_from_array_for_Int {
@@ -205,37 +205,37 @@ impl_from_array_for_Int!(32); // 2048 bits
 
 /// # Utilities
 impl Int {
-    /// Returns `true` if this `Int` represents the value zero (`0`).
-    ///
-    /// # Note
-    ///
-    /// - Zero (`0`) is also called the additive neutral element.
-    /// - This operation is more efficient than comparing two instances
-    ///   of `Int` for the same reason.
-    pub fn is_zero(&self) -> bool {
-        self.value.is_zero()
-    }
-
-    /// Returns `true` if this `Int` represents the value one (`1`).
-    ///
-    /// # Note
-    ///
-    /// - One (`1`) is also called the multiplicative neutral element.
-    /// - This operation is more efficient than comparing two instances
-    ///   of `Int` for the same reason.
-    pub fn is_one(&self) -> bool {
-        self.value.is_one()
+	/// Returns `true` if this `Int` represents the value zero (`0`).
+	///
+	/// # Note
+	///
+	/// - Zero (`0`) is also called the additive neutral element.
+	/// - This operation is more efficient than comparing two instances
+	///   of `Int` for the same reason.
+	pub fn is_zero(&self) -> bool {
+		self.value.is_zero()
 	}
 
-    /// Returns `true` if this `Int` represents an even number.
-    pub fn is_even(&self) -> bool {
-        self.value.is_even()
-    }
+	/// Returns `true` if this `Int` represents the value one (`1`).
+	///
+	/// # Note
+	///
+	/// - One (`1`) is also called the multiplicative neutral element.
+	/// - This operation is more efficient than comparing two instances
+	///   of `Int` for the same reason.
+	pub fn is_one(&self) -> bool {
+		self.value.is_one()
+	}
 
-    /// Returns `true` if this `Int` represents an odd number.
-    pub fn is_odd(&self) -> bool {
-        self.value.is_odd()
-    }
+	/// Returns `true` if this `Int` represents an even number.
+	pub fn is_even(&self) -> bool {
+		self.value.is_even()
+	}
+
+	/// Returns `true` if this `Int` represents an odd number.
+	pub fn is_odd(&self) -> bool {
+		self.value.is_odd()
+	}
 
 	/// Returns `true` if the value of this `Int` is positive.
 	pub fn is_positive(&self) -> bool {
@@ -353,203 +353,203 @@ impl Int {
 /// If `self` and `rhs` have unmatching bit widths, `None` will be returned for `partial_cmp`
 /// and `false` will be returned for the rest of the `PartialOrd` methods.
 impl PartialOrd for Int {
-    fn partial_cmp(&self, rhs: &Int) -> Option<Ordering> {
-        if self.value.width() != rhs.value.width() {
-            return None;
-        }
-        if self.checked_lt(rhs).unwrap() {
-            return Some(Ordering::Less);
-        }
-        if self.value == rhs.value {
-            return Some(Ordering::Equal);
-        }
-        Some(Ordering::Greater)
-    }
+	fn partial_cmp(&self, rhs: &Int) -> Option<Ordering> {
+		if self.value.width() != rhs.value.width() {
+			return None;
+		}
+		if self.checked_lt(rhs).unwrap() {
+			return Some(Ordering::Less);
+		}
+		if self.value == rhs.value {
+			return Some(Ordering::Equal);
+		}
+		Some(Ordering::Greater)
+	}
 
-    fn lt(&self, rhs: &Int) -> bool {
-        self.checked_lt(rhs).unwrap_or(false)
-    }
+	fn lt(&self, rhs: &Int) -> bool {
+		self.checked_lt(rhs).unwrap_or(false)
+	}
 
-    fn le(&self, rhs: &Int) -> bool {
-        self.checked_le(rhs).unwrap_or(false)
-    }
+	fn le(&self, rhs: &Int) -> bool {
+		self.checked_le(rhs).unwrap_or(false)
+	}
 
-    fn gt(&self, rhs: &Int) -> bool {
-        self.checked_gt(rhs).unwrap_or(false)
-    }
+	fn gt(&self, rhs: &Int) -> bool {
+		self.checked_gt(rhs).unwrap_or(false)
+	}
 
-    fn ge(&self, rhs: &Int) -> bool {
-        self.checked_ge(rhs).unwrap_or(false)
-    }
+	fn ge(&self, rhs: &Int) -> bool {
+		self.checked_ge(rhs).unwrap_or(false)
+	}
 }
 
 /// # To Primitive (Resize)
 impl Int {
-    /// Resizes this `Int` to a `bool` primitive type.
-    ///
-    /// Bits in this `Int` that are not within the bounds
-    /// of the `bool` are being ignored.
-    ///
-    /// # Note
-    ///
-    /// - Basically this returns `true` if the least significant
-    ///   bit of this `Int` is `1` and `false` otherwise.
-    pub fn resize_to_bool(&self) -> bool {
-        self.value.resize_to_bool()
-    }
+	/// Resizes this `Int` to a `bool` primitive type.
+	///
+	/// Bits in this `Int` that are not within the bounds
+	/// of the `bool` are being ignored.
+	///
+	/// # Note
+	///
+	/// - Basically this returns `true` if the least significant
+	///   bit of this `Int` is `1` and `false` otherwise.
+	pub fn resize_to_bool(&self) -> bool {
+		self.value.resize_to_bool()
+	}
 
-    /// Resizes this `Int` to a `i8` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `8` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i8(&self) -> i8 {
-        self.value.resize_to_i8()
-    }
+	/// Resizes this `Int` to a `i8` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `8` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i8(&self) -> i8 {
+		self.value.resize_to_i8()
+	}
 
-    /// Resizes this `Int` to a `i16` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `16` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i16(&self) -> i16 {
-        self.value.resize_to_i16()
-    }
+	/// Resizes this `Int` to a `i16` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `16` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i16(&self) -> i16 {
+		self.value.resize_to_i16()
+	}
 
-    /// Resizes this `Int` to a `i32` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `32` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i32(&self) -> i32 {
-        self.value.resize_to_i32()
-    }
+	/// Resizes this `Int` to a `i32` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `32` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i32(&self) -> i32 {
+		self.value.resize_to_i32()
+	}
 
-    /// Resizes this `Int` to a `i64` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `64` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i64(&self) -> i64 {
-        self.value.resize_to_i64()
-    }
+	/// Resizes this `Int` to a `i64` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `64` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i64(&self) -> i64 {
+		self.value.resize_to_i64()
+	}
 
-    /// Resizes this `Int` to a `i128` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `128` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_i128(&self) -> i128 {
-        self.value.resize_to_i128()
-    }
+	/// Resizes this `Int` to a `i128` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `128` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_i128(&self) -> i128 {
+		self.value.resize_to_i128()
+	}
 }
 
 /// # To Primitive (Try-Cast)
 impl Int {
-    /// Tries to represent the value of this `Int` as a `bool`.
-    ///
-    /// # Note
-    ///
-    /// This returns `true` if the value represented by this `Int`
-    /// is `1`, returns `false` if the value represented by this
-    /// `Int` is `0` and returns an error otherwise.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `bool`.
-    pub fn try_to_bool(&self) -> Result<bool> {
-        self.value.try_to_bool()
-    }
+	/// Tries to represent the value of this `Int` as a `bool`.
+	///
+	/// # Note
+	///
+	/// This returns `true` if the value represented by this `Int`
+	/// is `1`, returns `false` if the value represented by this
+	/// `Int` is `0` and returns an error otherwise.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `bool`.
+	pub fn try_to_bool(&self) -> Result<bool> {
+		self.value.try_to_bool()
+	}
 
-    /// Tries to represent the value of this `Int` as a `i8`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `Int` does not exceed the maximum value of `i8`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `u8`.
-    pub fn try_to_i8(&self) -> Result<i8> {
-        self.value.try_to_i8()
-    }
+	/// Tries to represent the value of this `Int` as a `i8`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `Int` does not exceed the maximum value of `i8`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `u8`.
+	pub fn try_to_i8(&self) -> Result<i8> {
+		self.value.try_to_i8()
+	}
 
-    /// Tries to represent the value of this `Int` as a `i16`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `Int` does not exceed the maximum value of `i16`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `i16`.
-    pub fn try_to_i16(&self) -> Result<i16> {
-        self.value.try_to_i16()
-    }
+	/// Tries to represent the value of this `Int` as a `i16`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `Int` does not exceed the maximum value of `i16`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `i16`.
+	pub fn try_to_i16(&self) -> Result<i16> {
+		self.value.try_to_i16()
+	}
 
-    /// Tries to represent the value of this `Int` as a `i32`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `Int` does not exceed the maximum value of `i32`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `i32`.
-    pub fn try_to_i32(&self) -> Result<i32> {
-        self.value.try_to_i32()
-    }
+	/// Tries to represent the value of this `Int` as a `i32`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `Int` does not exceed the maximum value of `i32`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `i32`.
+	pub fn try_to_i32(&self) -> Result<i32> {
+		self.value.try_to_i32()
+	}
 
-    /// Tries to represent the value of this `Int` as a `i64`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `Int` does not exceed the maximum value of `i64`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `i64`.
-    pub fn try_to_i64(&self) -> Result<i64> {
-        self.value.try_to_i64()
-    }
+	/// Tries to represent the value of this `Int` as a `i64`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `Int` does not exceed the maximum value of `i64`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `i64`.
+	pub fn try_to_i64(&self) -> Result<i64> {
+		self.value.try_to_i64()
+	}
 
-    /// Tries to represent the value of this `Int` as a `i128`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `Int` does not exceed the maximum value of `i128`.
-    ///
-    /// # Complexity
-    ///
-    /// - 𝒪(n) where n is the number of digits of this `Int`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `Int` can not be
-    ///   represented by a `i128`.
-    pub fn try_to_i128(&self) -> Result<i128> {
-        self.value.try_to_i128()
-    }
+	/// Tries to represent the value of this `Int` as a `i128`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `Int` does not exceed the maximum value of `i128`.
+	///
+	/// # Complexity
+	///
+	/// - 𝒪(n) where n is the number of digits of this `Int`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `Int` can not be
+	///   represented by a `i128`.
+	pub fn try_to_i128(&self) -> Result<i128> {
+		self.value.try_to_i128()
+	}
 }
 
 /// # Shifts
@@ -609,39 +609,39 @@ impl Int {
 }
 
 impl<S> Shl<S> for Int
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    type Output = Int;
+	type Output = Int;
 
-    fn shl(self, shift_amount: S) -> Self::Output {
-        self.into_wrapping_shl(shift_amount).unwrap()
-    }
+	fn shl(self, shift_amount: S) -> Self::Output {
+		self.into_wrapping_shl(shift_amount).unwrap()
+	}
 }
 
 impl<S> Shr<S> for Int
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    type Output = Int;
+	type Output = Int;
 
-    fn shr(self, shift_amount: S) -> Self::Output {
-        self.into_wrapping_shr(shift_amount).unwrap()
-    }
+	fn shr(self, shift_amount: S) -> Self::Output {
+		self.into_wrapping_shr(shift_amount).unwrap()
+	}
 }
 
 impl<S> ShlAssign<S> for Int
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    fn shl_assign(&mut self, shift_amount: S) {
-        self.wrapping_shl_assign(shift_amount).unwrap()
-    }
+	fn shl_assign(&mut self, shift_amount: S) {
+		self.wrapping_shl_assign(shift_amount).unwrap()
+	}
 }
 
 impl<S> ShrAssign<S> for Int
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    fn shr_assign(&mut self, shift_amount: S) {
-        self.wrapping_shr_assign(shift_amount).unwrap()
-    }
+	fn shr_assign(&mut self, shift_amount: S) {
+		self.wrapping_shr_assign(shift_amount).unwrap()
+	}
 }
 
 /// # Random Utilities using `rand` crate.
@@ -653,31 +653,31 @@ impl Int {
 	}
 
 	/// Creates a new `Int` with the given `BitWidth` and random `Digit`s
-    /// using the given random number generator.
-    /// 
-    /// **Note:** This is useful for cryptographic or testing purposes.
-    pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> Int
-        where R: rand::Rng
-    {
-        Int::from(ApInt::random_with_width_using(width, rng))
-    }
+	/// using the given random number generator.
+	/// 
+	/// **Note:** This is useful for cryptographic or testing purposes.
+	pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> Int
+		where R: rand::Rng
+	{
+		Int::from(ApInt::random_with_width_using(width, rng))
+	}
 
-    /// Randomizes the digits of this `Int` inplace.
-    /// 
-    /// This won't change its `BitWidth`.
-    pub fn randomize(&mut self) {
-        self.value.randomize()
-    }
+	/// Randomizes the digits of this `Int` inplace.
+	/// 
+	/// This won't change its `BitWidth`.
+	pub fn randomize(&mut self) {
+		self.value.randomize()
+	}
 
-    /// Randomizes the digits of this `Int` inplace using the given
-    /// random number generator.
-    /// 
-    /// This won't change its `BitWidth`.
-    pub fn randomize_using<R>(&mut self, rng: &mut R)
-        where R: rand::Rng
-    {
-        self.value.randomize_using(rng)
-    }
+	/// Randomizes the digits of this `Int` inplace using the given
+	/// random number generator.
+	/// 
+	/// This won't change its `BitWidth`.
+	pub fn randomize_using<R>(&mut self, rng: &mut R)
+		where R: rand::Rng
+	{
+		self.value.randomize_using(rng)
+	}
 }
 
 impl Int {
@@ -1041,27 +1041,27 @@ impl Not for Int {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a Int> for Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitand(self, rhs: &'a Int) -> Self::Output {
-        self.into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a Int) -> Self::Output {
+		self.into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a Int> for &'b Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitand(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a Int> for &'b mut Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitand(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -1069,27 +1069,27 @@ impl<'a, 'b> BitAnd<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a Int> for Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitor(self, rhs: &'a Int) -> Self::Output {
-        self.into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a Int) -> Self::Output {
+		self.into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a Int> for &'b Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitor(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a Int> for &'b mut Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitor(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -1097,27 +1097,27 @@ impl<'a, 'b> BitOr<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a Int> for Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitxor(self, rhs: &'a Int) -> Self::Output {
-        self.into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a Int) -> Self::Output {
+		self.into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a Int> for &'b Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitxor(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a Int> for &'b mut Int {
-    type Output = Int;
+	type Output = Int;
 
-    fn bitxor(self, rhs: &'a Int) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a Int) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -1125,21 +1125,21 @@ impl<'a, 'b> BitXor<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a Int> for Int {
-    fn bitand_assign(&mut self, rhs: &'a Int) {
-        self.bitand_assign(rhs).unwrap();
-    }
+	fn bitand_assign(&mut self, rhs: &'a Int) {
+		self.bitand_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitOrAssign<&'a Int> for Int {
-    fn bitor_assign(&mut self, rhs: &'a Int) {
-        self.bitor_assign(rhs).unwrap();
-    }
+	fn bitor_assign(&mut self, rhs: &'a Int) {
+		self.bitor_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitXorAssign<&'a Int> for Int {
-    fn bitxor_assign(&mut self, rhs: &'a Int) {
-        self.bitxor_assign(rhs).unwrap();
-    }
+	fn bitxor_assign(&mut self, rhs: &'a Int) {
+		self.bitxor_assign(rhs).unwrap();
+	}
 }
 
 /// # Arithmetic Operations

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -239,6 +239,7 @@ impl UInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self < rhs`.
 	/// - Interprets both `UInt` instances as **unsigned** values.
 	/// 
@@ -253,6 +254,7 @@ impl UInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self <= rhs`.
 	/// - Interprets both `UInt` instances as **unsigned** values.
 	/// 
@@ -268,6 +270,7 @@ impl UInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self > rhs`.
 	/// - Interprets both `UInt` instances as **unsigned** values.
 	/// 
@@ -283,6 +286,7 @@ impl UInt {
 	/// 
 	/// # Note
 	/// 
+	/// - `checked_` for this function means that it checks the bit widths
 	/// - Returns `Ok(true)` if `self >= rhs`.
 	/// - Interprets both `UInt` instances as **unsigned** values.
 	/// 
@@ -295,6 +299,8 @@ impl UInt {
 	}
 }
 
+/// If `self` and `rhs` have unmatching bit widths, `None` will be returned for `partial_cmp`
+/// and `false` will be returned for the rest of the `PartialOrd` methods.
 impl PartialOrd for UInt {
     fn partial_cmp(&self, rhs: &UInt) -> Option<Ordering> {
         if self.value.width() != rhs.value.width() {
@@ -504,10 +510,10 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn checked_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
+	pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
 		where S: Into<ShiftAmount>
 	{
-		self.value.checked_shl_assign(shift_amount)
+		self.value.wrapping_shl_assign(shift_amount)
 	}
 
 	/// Shift this `UInt` left by the given `shift_amount` bits and returns the result.
@@ -517,10 +523,10 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn into_checked_shl<S>(self, shift_amount: S) -> Result<UInt>
+	pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<UInt>
 		where S: Into<ShiftAmount>
 	{
-		self.value.into_checked_shl(shift_amount).map(UInt::from)
+		self.value.into_wrapping_shl(shift_amount).map(UInt::from)
 	}
 
 	/// Right-shifts this `UInt` by the given `shift_amount` bits.
@@ -530,10 +536,10 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn checked_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+	pub fn wrapping_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
 		where S: Into<ShiftAmount>
 	{
-		self.value.checked_lshr_assign(shift_amount)
+		self.value.wrapping_lshr_assign(shift_amount)
 	}
 
 	/// Right-shifts this `UInt` by the given `shift_amount` bits
@@ -544,10 +550,10 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn into_checked_shr<S>(self, shift_amount: S) -> Result<UInt>
+	pub fn into_wrapping_shr<S>(self, shift_amount: S) -> Result<UInt>
 		where S: Into<ShiftAmount>
 	{
-		self.value.into_checked_lshr(shift_amount).map(UInt::from)
+		self.value.into_wrapping_lshr(shift_amount).map(UInt::from)
 	}
 }
 
@@ -559,7 +565,7 @@ impl<S> Shl<S> for UInt
     type Output = UInt;
 
     fn shl(self, shift_amount: S) -> Self::Output {
-        self.into_checked_shl(shift_amount).unwrap()
+        self.into_wrapping_shl(shift_amount).unwrap()
     }
 }
 
@@ -569,7 +575,7 @@ impl<S> Shr<S> for UInt
     type Output = UInt;
 
     fn shr(self, shift_amount: S) -> Self::Output {
-        self.into_checked_shr(shift_amount).unwrap()
+        self.into_wrapping_shr(shift_amount).unwrap()
     }
 }
 
@@ -577,7 +583,7 @@ impl<S> ShlAssign<S> for UInt
     where S: Into<ShiftAmount>
 {
     fn shl_assign(&mut self, shift_amount: S) {
-        self.checked_shl_assign(shift_amount).unwrap()
+        self.wrapping_shl_assign(shift_amount).unwrap()
     }
 }
 
@@ -585,7 +591,7 @@ impl<S> ShrAssign<S> for UInt
     where S: Into<ShiftAmount>
 {
     fn shr_assign(&mut self, shift_amount: S) {
-        self.checked_shr_assign(shift_amount).unwrap()
+        self.wrapping_shr_assign(shift_amount).unwrap()
     }
 }
 
@@ -775,14 +781,11 @@ impl UInt {
 	/// Tries to bit-and assign this `UInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitand`](struct.UInt.html#method.checked_bitand).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitand(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_bitand_assign)
+	pub fn into_bitand(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::bitand_assign)
 	}
 
 	/// Bit-and assigns all bits of this `UInt` with the bits of `rhs`.
@@ -792,21 +795,18 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitand_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_bitand_assign(&rhs.value)
+	pub fn bitand_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.bitand_assign(&rhs.value)
 	}
 
 	/// Tries to bit-and assign this `UInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitor`](struct.UInt.html#method.checked_bitor).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitor(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_bitor_assign)
+	pub fn into_bitor(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::bitor_assign)
 	}
 
 	/// Bit-or assigns all bits of this `UInt` with the bits of `rhs`.
@@ -816,21 +816,18 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitor_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_bitor_assign(&rhs.value)
+	pub fn bitor_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.bitor_assign(&rhs.value)
 	}
 
 	/// Tries to bit-xor assign this `UInt` inplace to `rhs`
 	/// and returns the result.
 	/// 
-	/// **Note:** This forwards to
-	/// [`checked_bitxor`](struct.UInt.html#method.checked_bitxor).
-	/// 
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_bitxor(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_bitxor_assign)
+	pub fn into_bitxor(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::bitxor_assign)
 	}
 
 	/// Bit-xor assigns all bits of this `UInt` with the bits of `rhs`.
@@ -840,8 +837,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_bitxor_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_bitxor_assign(&rhs.value)
+	pub fn bitxor_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.bitxor_assign(&rhs.value)
 	}
 }
 
@@ -970,7 +967,7 @@ impl<'a> BitAnd<&'a UInt> for UInt {
     type Output = UInt;
 
     fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.into_checked_bitand(rhs).unwrap()
+        self.into_bitand(rhs).unwrap()
     }
 }
 
@@ -978,7 +975,7 @@ impl<'a, 'b> BitAnd<&'a UInt> for &'b UInt {
     type Output = UInt;
 
     fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitand(rhs).unwrap()
+        self.clone().into_bitand(rhs).unwrap()
     }
 }
 
@@ -986,7 +983,7 @@ impl<'a, 'b> BitAnd<&'a UInt> for &'b mut UInt {
     type Output = UInt;
 
     fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitand(rhs).unwrap()
+        self.clone().into_bitand(rhs).unwrap()
     }
 }
 
@@ -998,7 +995,7 @@ impl<'a> BitOr<&'a UInt> for UInt {
     type Output = UInt;
 
     fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.into_checked_bitor(rhs).unwrap()
+        self.into_bitor(rhs).unwrap()
     }
 }
 
@@ -1006,7 +1003,7 @@ impl<'a, 'b> BitOr<&'a UInt> for &'b UInt {
     type Output = UInt;
 
     fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitor(rhs).unwrap()
+        self.clone().into_bitor(rhs).unwrap()
     }
 }
 
@@ -1014,7 +1011,7 @@ impl<'a, 'b> BitOr<&'a UInt> for &'b mut UInt {
     type Output = UInt;
 
     fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitor(rhs).unwrap()
+        self.clone().into_bitor(rhs).unwrap()
     }
 }
 
@@ -1026,7 +1023,7 @@ impl<'a> BitXor<&'a UInt> for UInt {
     type Output = UInt;
 
     fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.into_checked_bitxor(rhs).unwrap()
+        self.into_bitxor(rhs).unwrap()
     }
 }
 
@@ -1034,7 +1031,7 @@ impl<'a, 'b> BitXor<&'a UInt> for &'b UInt {
     type Output = UInt;
 
     fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitxor(rhs).unwrap()
+        self.clone().into_bitxor(rhs).unwrap()
     }
 }
 
@@ -1042,7 +1039,7 @@ impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
     type Output = UInt;
 
     fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_checked_bitxor(rhs).unwrap()
+        self.clone().into_bitxor(rhs).unwrap()
     }
 }
 
@@ -1052,19 +1049,19 @@ impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
 
 impl<'a> BitAndAssign<&'a UInt> for UInt {
     fn bitand_assign(&mut self, rhs: &'a UInt) {
-        self.checked_bitand_assign(rhs).unwrap();
+        self.bitand_assign(rhs).unwrap();
     }
 }
 
 impl<'a> BitOrAssign<&'a UInt> for UInt {
     fn bitor_assign(&mut self, rhs: &'a UInt) {
-        self.checked_bitor_assign(rhs).unwrap();
+        self.bitor_assign(rhs).unwrap();
     }
 }
 
 impl<'a> BitXorAssign<&'a UInt> for UInt {
     fn bitxor_assign(&mut self, rhs: &'a UInt) {
-        self.checked_bitxor_assign(rhs).unwrap();
+        self.bitxor_assign(rhs).unwrap();
     }
 }
 
@@ -1077,8 +1074,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_add(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_add_assign)
+	pub fn into_wrapping_add(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_add_assign)
 	}
 
 	/// Add-assigns `rhs` to `self` inplace.
@@ -1088,8 +1085,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_add_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_add_assign(&rhs.value)
+	pub fn wrapping_add_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.wrapping_add_assign(&rhs.value)
 	}
 
 	/// Subtracts `rhs` from `self` and returns the result.
@@ -1102,8 +1099,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_sub(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_sub_assign)
+	pub fn into_wrapping_sub(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_sub_assign)
 	}
 
 	/// Subtract-assigns `rhs` from `self` inplace.
@@ -1116,8 +1113,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_sub_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_sub_assign(&rhs.value)
+	pub fn wrapping_sub_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.wrapping_sub_assign(&rhs.value)
 	}
 
 	/// Subtracts `rhs` from `self` and returns the result.
@@ -1130,8 +1127,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_mul(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_mul_assign)
+	pub fn into_wrapping_mul(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_mul_assign)
 	}
 
 	/// Multiply-assigns `rhs` to `self` inplace.
@@ -1144,8 +1141,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_mul_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_mul_assign(&rhs.value)
+	pub fn wrapping_mul_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.wrapping_mul_assign(&rhs.value)
 	}
 
 	/// Divides `self` by `rhs` and returns the result.
@@ -1159,8 +1156,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_div(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_div_assign)
+	pub fn into_wrapping_div(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_div_assign)
 	}
 
 	/// Assignes `self` to the division of `self` by `rhs`.
@@ -1174,8 +1171,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_div_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_udiv_assign(&rhs.value)
+	pub fn wrapping_div_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.wrapping_udiv_assign(&rhs.value)
 	}
 
 	/// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
@@ -1189,8 +1186,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_checked_rem(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::checked_rem_assign)
+	pub fn into_wrapping_rem(self, rhs: &UInt) -> Result<UInt> {
+		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_rem_assign)
 	}
 
 	/// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
@@ -1204,8 +1201,8 @@ impl UInt {
 	/// # Errors
 	/// 
 	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_rem_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.checked_urem_assign(&rhs.value)
+	pub fn wrapping_rem_assign(&mut self, rhs: &UInt) -> Result<()> {
+		self.value.wrapping_urem_assign(&rhs.value)
 	}
 }
 
@@ -1217,7 +1214,7 @@ impl<'a> Add<&'a UInt> for UInt {
 	type Output = UInt;
 
 	fn add(self, rhs: &'a UInt) -> Self::Output {
-		self.into_checked_add(rhs).unwrap()
+		self.into_wrapping_add(rhs).unwrap()
 	}
 }
 
@@ -1225,13 +1222,13 @@ impl<'a, 'b> Add<&'a UInt> for &'b UInt {
 	type Output = UInt;
 
 	fn add(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_checked_add(rhs).unwrap()
+		self.clone().into_wrapping_add(rhs).unwrap()
 	}
 }
 
 impl<'a> AddAssign<&'a UInt> for UInt {
 	fn add_assign(&mut self, rhs: &'a UInt) {
-		self.checked_add_assign(rhs).unwrap()
+		self.wrapping_add_assign(rhs).unwrap()
 	}
 }
 
@@ -1243,7 +1240,7 @@ impl<'a> Sub<&'a UInt> for UInt {
 	type Output = UInt;
 
 	fn sub(self, rhs: &'a UInt) -> Self::Output {
-		self.into_checked_sub(rhs).unwrap()
+		self.into_wrapping_sub(rhs).unwrap()
 	}
 }
 
@@ -1251,13 +1248,13 @@ impl<'a, 'b> Sub<&'a UInt> for &'b UInt {
 	type Output = UInt;
 
 	fn sub(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_checked_sub(rhs).unwrap()
+		self.clone().into_wrapping_sub(rhs).unwrap()
 	}
 }
 
 impl<'a> SubAssign<&'a UInt> for UInt {
 	fn sub_assign(&mut self, rhs: &'a UInt) {
-		self.checked_sub_assign(rhs).unwrap()
+		self.wrapping_sub_assign(rhs).unwrap()
 	}
 }
 
@@ -1269,7 +1266,7 @@ impl<'a> Mul<&'a UInt> for UInt {
 	type Output = UInt;
 
 	fn mul(self, rhs: &'a UInt) -> Self::Output {
-		self.into_checked_mul(rhs).unwrap()
+		self.into_wrapping_mul(rhs).unwrap()
 	}
 }
 
@@ -1277,13 +1274,13 @@ impl<'a, 'b> Mul<&'a UInt> for &'b UInt {
 	type Output = UInt;
 
 	fn mul(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_checked_mul(rhs).unwrap()
+		self.clone().into_wrapping_mul(rhs).unwrap()
 	}
 }
 
 impl<'a> MulAssign<&'a UInt> for UInt {
 	fn mul_assign(&mut self, rhs: &'a UInt) {
-		self.checked_mul_assign(rhs).unwrap();
+		self.wrapping_mul_assign(rhs).unwrap();
 	}
 }
 
@@ -1295,7 +1292,7 @@ impl<'a> Div<&'a UInt> for UInt {
 	type Output = UInt;
 
 	fn div(self, rhs: &'a UInt) -> Self::Output {
-		self.into_checked_div(rhs).unwrap()
+		self.into_wrapping_div(rhs).unwrap()
 	}
 }
 
@@ -1303,13 +1300,13 @@ impl<'a, 'b> Div<&'a UInt> for &'b UInt {
 	type Output = UInt;
 
 	fn div(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_checked_div(rhs).unwrap()
+		self.clone().into_wrapping_div(rhs).unwrap()
 	}
 }
 
 impl<'a> DivAssign<&'a UInt> for UInt {
 	fn div_assign(&mut self, rhs: &'a UInt) {
-		self.checked_div_assign(rhs).unwrap();
+		self.wrapping_div_assign(rhs).unwrap();
 	}
 }
 
@@ -1321,7 +1318,7 @@ impl<'a> Rem<&'a UInt> for UInt {
 	type Output = UInt;
 
 	fn rem(self, rhs: &'a UInt) -> Self::Output {
-		self.into_checked_rem(rhs).unwrap()
+		self.into_wrapping_rem(rhs).unwrap()
 	}
 }
 
@@ -1329,13 +1326,13 @@ impl<'a, 'b> Rem<&'a UInt> for &'b UInt {
 	type Output = UInt;
 
 	fn rem(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_checked_rem(rhs).unwrap()
+		self.clone().into_wrapping_rem(rhs).unwrap()
 	}
 }
 
 impl<'a> RemAssign<&'a UInt> for UInt {
 	fn rem_assign(&mut self, rhs: &'a UInt) {
-		self.checked_rem_assign(rhs).unwrap();
+		self.wrapping_rem_assign(rhs).unwrap();
 	}
 }
 

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -23,13 +23,13 @@ use std::ops::{
 	Add,
 	Sub,
 	Mul,
-    Div,
-    Rem,
+	Div,
+	Rem,
 	AddAssign,
 	SubAssign,
 	MulAssign,
-    DivAssign,
-    RemAssign
+	DivAssign,
+	RemAssign
 };
 
 /// Unsigned machine integer with arbitrary bitwidths and modulo arithmetics.
@@ -40,103 +40,103 @@ use std::ops::{
 /// `Int` offers a more elegant and higher-level abstraction interface to the lower-level `ApInt`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UInt {
-    value: ApInt,
+	value: ApInt,
 }
 
 impl From<ApInt> for UInt {
-    fn from(value: ApInt) -> UInt {
-        UInt { value }
-    }
+	fn from(value: ApInt) -> UInt {
+		UInt { value }
+	}
 }
 
 impl UInt {
-    /// Transforms this `UInt` into an equivalent `ApInt` instance.
-    pub fn into_apint(self) -> ApInt {
-        self.value
-    }
+	/// Transforms this `UInt` into an equivalent `ApInt` instance.
+	pub fn into_apint(self) -> ApInt {
+		self.value
+	}
 
-    /// Transforms this `UInt` into an equivalent `Int` instance.
-    pub fn into_signed(self) -> Int {
-        Int::from(self.value)
-    }
+	/// Transforms this `UInt` into an equivalent `Int` instance.
+	pub fn into_signed(self) -> Int {
+		Int::from(self.value)
+	}
 }
 
 /// # Constructors
 impl UInt {
-    /// Creates a new `UInt` from the given `Bit` value with a bit width of `1`.
-    ///
-    /// This function is generic over types that are convertible to `Bit` such as `bool`.
-    pub fn from_bit<B>(bit: B) -> UInt
-    where
-        B: Into<Bit>,
-    {
-        UInt::from(ApInt::from_bit(bit))
-    }
+	/// Creates a new `UInt` from the given `Bit` value with a bit width of `1`.
+	///
+	/// This function is generic over types that are convertible to `Bit` such as `bool`.
+	pub fn from_bit<B>(bit: B) -> UInt
+	where
+		B: Into<Bit>,
+	{
+		UInt::from(ApInt::from_bit(bit))
+	}
 
-    /// Creates a new `UInt` from a given `u8` value with a bit-width of 8.
-    #[inline]
-    pub fn from_u8(val: u8) -> UInt {
-        UInt::from(ApInt::from_u8(val))
-    }
+	/// Creates a new `UInt` from a given `u8` value with a bit-width of 8.
+	#[inline]
+	pub fn from_u8(val: u8) -> UInt {
+		UInt::from(ApInt::from_u8(val))
+	}
 
-    /// Creates a new `UInt` from a given `u16` value with a bit-width of 16.
-    #[inline]
-    pub fn from_u16(val: u16) -> UInt {
-        UInt::from(ApInt::from_u16(val))
-    }
+	/// Creates a new `UInt` from a given `u16` value with a bit-width of 16.
+	#[inline]
+	pub fn from_u16(val: u16) -> UInt {
+		UInt::from(ApInt::from_u16(val))
+	}
 
-    /// Creates a new `UInt` from a given `u32` value with a bit-width of 32.
-    #[inline]
-    pub fn from_u32(val: u32) -> UInt {
-        UInt::from(ApInt::from_u32(val))
-    }
+	/// Creates a new `UInt` from a given `u32` value with a bit-width of 32.
+	#[inline]
+	pub fn from_u32(val: u32) -> UInt {
+		UInt::from(ApInt::from_u32(val))
+	}
 
-    /// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
-    #[inline]
-    pub fn from_u64(val: u64) -> UInt {
-        UInt::from(ApInt::from_u64(val))
-    }
+	/// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
+	#[inline]
+	pub fn from_u64(val: u64) -> UInt {
+		UInt::from(ApInt::from_u64(val))
+	}
 
-    /// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
-    pub fn from_u128(val: u128) -> UInt {
-        UInt::from(ApInt::from_u128(val))
-    }
+	/// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
+	pub fn from_u128(val: u128) -> UInt {
+		UInt::from(ApInt::from_u128(val))
+	}
 
-    /// Creates a new `UInt` with the given bit width that represents zero.
-    pub fn zero(width: BitWidth) -> UInt {
-        UInt::from(ApInt::zero(width))
-    }
+	/// Creates a new `UInt` with the given bit width that represents zero.
+	pub fn zero(width: BitWidth) -> UInt {
+		UInt::from(ApInt::zero(width))
+	}
 
-    /// Creates a new `UInt` with the given bit width that represents one.
-    pub fn one(width: BitWidth) -> UInt {
-        UInt::from(ApInt::one(width))
-    }
+	/// Creates a new `UInt` with the given bit width that represents one.
+	pub fn one(width: BitWidth) -> UInt {
+		UInt::from(ApInt::one(width))
+	}
 
-    /// Creates a new `UInt` with the given bit width that has all bits unset.
-    ///
-    /// **Note:** This is equal to calling `UInt::zero` with the given `width`.
-    pub fn all_unset(width: BitWidth) -> UInt {
-        UInt::zero(width)
-    }
+	/// Creates a new `UInt` with the given bit width that has all bits unset.
+	///
+	/// **Note:** This is equal to calling `UInt::zero` with the given `width`.
+	pub fn all_unset(width: BitWidth) -> UInt {
+		UInt::zero(width)
+	}
 
-    /// Creates a new `UInt` with the given bit width that has all bits set.
-    ///
-    /// # Note
-    ///
-    /// - This is equal to minus one on any twos-complement machine.
-    pub fn all_set(width: BitWidth) -> UInt {
-        UInt::from(ApInt::all_set(width))
-    }
+	/// Creates a new `UInt` with the given bit width that has all bits set.
+	///
+	/// # Note
+	///
+	/// - This is equal to minus one on any twos-complement machine.
+	pub fn all_set(width: BitWidth) -> UInt {
+		UInt::from(ApInt::all_set(width))
+	}
 
-    /// Returns the smallest `UInt` that can be represented by the given `BitWidth`.
-    pub fn min_value(width: BitWidth) -> UInt {
-        UInt::from(ApInt::unsigned_min_value(width))
-    }
+	/// Returns the smallest `UInt` that can be represented by the given `BitWidth`.
+	pub fn min_value(width: BitWidth) -> UInt {
+		UInt::from(ApInt::unsigned_min_value(width))
+	}
 
-    /// Returns the largest `UInt` that can be represented by the given `BitWidth`.
-    pub fn max_value(width: BitWidth) -> UInt {
-        UInt::from(ApInt::unsigned_max_value(width))
-    }
+	/// Returns the largest `UInt` that can be represented by the given `BitWidth`.
+	pub fn max_value(width: BitWidth) -> UInt {
+		UInt::from(ApInt::unsigned_max_value(width))
+	}
 }
 
 impl<B> From<B> for UInt
@@ -144,38 +144,38 @@ impl<B> From<B> for UInt
 {
 	#[inline]
 	fn from(bit: B) -> UInt {
-        UInt::from_bit(bit)
+		UInt::from_bit(bit)
 	}
 }
 
 impl From<u8> for UInt {
-    fn from(val: u8) -> UInt {
-        UInt::from_u8(val)
-    }
+	fn from(val: u8) -> UInt {
+		UInt::from_u8(val)
+	}
 }
 
 impl From<u16> for UInt {
-    fn from(val: u16) -> UInt {
-        UInt::from_u16(val)
-    }
+	fn from(val: u16) -> UInt {
+		UInt::from_u16(val)
+	}
 }
 
 impl From<u32> for UInt {
-    fn from(val: u32) -> UInt {
-        UInt::from_u32(val)
-    }
+	fn from(val: u32) -> UInt {
+		UInt::from_u32(val)
+	}
 }
 
 impl From<u64> for UInt {
-    fn from(val: u64) -> UInt {
-        UInt::from_u64(val)
-    }
+	fn from(val: u64) -> UInt {
+		UInt::from_u64(val)
+	}
 }
 
 impl From<u128> for UInt {
-    fn from(val: u128) -> UInt {
-        UInt::from_u128(val)
-    }
+	fn from(val: u128) -> UInt {
+		UInt::from_u128(val)
+	}
 }
 
 macro_rules! impl_from_array_for_uint {
@@ -200,37 +200,37 @@ impl_from_array_for_uint!(32); // 2048 bits
 
 /// # Utilities
 impl UInt {
-    /// Returns `true` if this `UInt` represents the value zero (`0`).
-    ///
-    /// # Note
-    ///
-    /// - Zero (`0`) is also called the additive neutral element.
-    /// - This operation is more efficient than comparing two instances
-    ///   of `UInt` for the same reason.
-    pub fn is_zero(&self) -> bool {
-        self.value.is_zero()
-    }
+	/// Returns `true` if this `UInt` represents the value zero (`0`).
+	///
+	/// # Note
+	///
+	/// - Zero (`0`) is also called the additive neutral element.
+	/// - This operation is more efficient than comparing two instances
+	///   of `UInt` for the same reason.
+	pub fn is_zero(&self) -> bool {
+		self.value.is_zero()
+	}
 
-    /// Returns `true` if this `UInt` represents the value one (`1`).
-    ///
-    /// # Note
-    ///
-    /// - One (`1`) is also called the multiplicative neutral element.
-    /// - This operation is more efficient than comparing two instances
-    ///   of `UInt` for the same reason.
-    pub fn is_one(&self) -> bool {
-        self.value.is_one()
-    }
+	/// Returns `true` if this `UInt` represents the value one (`1`).
+	///
+	/// # Note
+	///
+	/// - One (`1`) is also called the multiplicative neutral element.
+	/// - This operation is more efficient than comparing two instances
+	///   of `UInt` for the same reason.
+	pub fn is_one(&self) -> bool {
+		self.value.is_one()
+	}
 
-    /// Returns `true` if this `UInt` represents an even number.
-    pub fn is_even(&self) -> bool {
-        self.value.is_even()
-    }
+	/// Returns `true` if this `UInt` represents an even number.
+	pub fn is_even(&self) -> bool {
+		self.value.is_even()
+	}
 
-    /// Returns `true` if this `UInt` represents an odd number.
-    pub fn is_odd(&self) -> bool {
-        self.value.is_odd()
-    }
+	/// Returns `true` if this `UInt` represents an odd number.
+	pub fn is_odd(&self) -> bool {
+		self.value.is_odd()
+	}
 }
 
 impl UInt {
@@ -302,203 +302,203 @@ impl UInt {
 /// If `self` and `rhs` have unmatching bit widths, `None` will be returned for `partial_cmp`
 /// and `false` will be returned for the rest of the `PartialOrd` methods.
 impl PartialOrd for UInt {
-    fn partial_cmp(&self, rhs: &UInt) -> Option<Ordering> {
-        if self.value.width() != rhs.value.width() {
-            return None;
-        }
-        if self.checked_lt(rhs).unwrap() {
-            return Some(Ordering::Less);
-        }
-        if self.value == rhs.value {
-            return Some(Ordering::Equal);
-        }
-        Some(Ordering::Greater)
-    }
+	fn partial_cmp(&self, rhs: &UInt) -> Option<Ordering> {
+		if self.value.width() != rhs.value.width() {
+			return None;
+		}
+		if self.checked_lt(rhs).unwrap() {
+			return Some(Ordering::Less);
+		}
+		if self.value == rhs.value {
+			return Some(Ordering::Equal);
+		}
+		Some(Ordering::Greater)
+	}
 
-    fn lt(&self, rhs: &UInt) -> bool {
-        self.checked_lt(rhs).unwrap_or(false)
-    }
+	fn lt(&self, rhs: &UInt) -> bool {
+		self.checked_lt(rhs).unwrap_or(false)
+	}
 
-    fn le(&self, rhs: &UInt) -> bool {
-        self.checked_le(rhs).unwrap_or(false)
-    }
+	fn le(&self, rhs: &UInt) -> bool {
+		self.checked_le(rhs).unwrap_or(false)
+	}
 
-    fn gt(&self, rhs: &UInt) -> bool {
-        self.checked_gt(rhs).unwrap_or(false)
-    }
+	fn gt(&self, rhs: &UInt) -> bool {
+		self.checked_gt(rhs).unwrap_or(false)
+	}
 
-    fn ge(&self, rhs: &UInt) -> bool {
-        self.checked_ge(rhs).unwrap_or(false)
-    }
+	fn ge(&self, rhs: &UInt) -> bool {
+		self.checked_ge(rhs).unwrap_or(false)
+	}
 }
 
 /// # To Primitive (Resize)
 impl UInt {
-    /// Resizes this `UInt` to a `bool` primitive type.
-    ///
-    /// Bits in this `UInt` that are not within the bounds
-    /// of the `bool` are being ignored.
-    ///
-    /// # Note
-    ///
-    /// - Basically this returns `true` if the least significant
-    ///   bit of this `UInt` is `1` and `false` otherwise.
-    pub fn resize_to_bool(&self) -> bool {
-        self.value.resize_to_bool()
-    }
+	/// Resizes this `UInt` to a `bool` primitive type.
+	///
+	/// Bits in this `UInt` that are not within the bounds
+	/// of the `bool` are being ignored.
+	///
+	/// # Note
+	///
+	/// - Basically this returns `true` if the least significant
+	///   bit of this `UInt` is `1` and `false` otherwise.
+	pub fn resize_to_bool(&self) -> bool {
+		self.value.resize_to_bool()
+	}
 
-    /// Resizes this `UInt` to a `u8` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `8` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u8(&self) -> u8 {
-        self.value.resize_to_u8()
-    }
+	/// Resizes this `UInt` to a `u8` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `8` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u8(&self) -> u8 {
+		self.value.resize_to_u8()
+	}
 
-    /// Resizes this `UInt` to a `u16` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `16` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u16(&self) -> u16 {
-        self.value.resize_to_u16()
-    }
+	/// Resizes this `UInt` to a `u16` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `16` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u16(&self) -> u16 {
+		self.value.resize_to_u16()
+	}
 
-    /// Resizes this `UInt` to a `u32` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `32` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u32(&self) -> u32 {
-        self.value.resize_to_u32()
-    }
+	/// Resizes this `UInt` to a `u32` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `32` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u32(&self) -> u32 {
+		self.value.resize_to_u32()
+	}
 
-    /// Resizes this `UInt` to a `u64` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `64` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u64(&self) -> u64 {
-        self.value.resize_to_u64()
-    }
+	/// Resizes this `UInt` to a `u64` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `64` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u64(&self) -> u64 {
+		self.value.resize_to_u64()
+	}
 
-    /// Resizes this `UInt` to a `u128` primitive type.
-    ///
-    /// # Note
-    ///
-    /// - All bits but the least significant `128` bits are
-    ///   being ignored by this operation to construct the
-    ///   result.
-    pub fn resize_to_u128(&self) -> u128 {
-        self.value.resize_to_u128()
-    }
+	/// Resizes this `UInt` to a `u128` primitive type.
+	///
+	/// # Note
+	///
+	/// - All bits but the least significant `128` bits are
+	///   being ignored by this operation to construct the
+	///   result.
+	pub fn resize_to_u128(&self) -> u128 {
+		self.value.resize_to_u128()
+	}
 }
 
 /// # To Primitive (Try-Cast)
 impl UInt {
-    /// Tries to represent the value of this `UInt` as a `bool`.
-    ///
-    /// # Note
-    ///
-    /// This returns `true` if the value represented by this `UInt`
-    /// is `1`, returns `false` if the value represented by this
-    /// `UInt` is `0` and returns an error otherwise.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `bool`.
-    pub fn try_to_bool(&self) -> Result<bool> {
-        self.value.try_to_bool()
-    }
+	/// Tries to represent the value of this `UInt` as a `bool`.
+	///
+	/// # Note
+	///
+	/// This returns `true` if the value represented by this `UInt`
+	/// is `1`, returns `false` if the value represented by this
+	/// `UInt` is `0` and returns an error otherwise.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `bool`.
+	pub fn try_to_bool(&self) -> Result<bool> {
+		self.value.try_to_bool()
+	}
 
-    /// Tries to represent the value of this `UInt` as a `u8`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `UInt` does not exceed the maximum value of `u8`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `u8`.
-    pub fn try_to_u8(&self) -> Result<u8> {
-        self.value.try_to_u8()
-    }
+	/// Tries to represent the value of this `UInt` as a `u8`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `UInt` does not exceed the maximum value of `u8`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `u8`.
+	pub fn try_to_u8(&self) -> Result<u8> {
+		self.value.try_to_u8()
+	}
 
-    /// Tries to represent the value of this `UInt` as a `u16`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `UInt` does not exceed the maximum value of `u16`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `u16`.
-    pub fn try_to_u16(&self) -> Result<u16> {
-        self.value.try_to_u16()
-    }
+	/// Tries to represent the value of this `UInt` as a `u16`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `UInt` does not exceed the maximum value of `u16`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `u16`.
+	pub fn try_to_u16(&self) -> Result<u16> {
+		self.value.try_to_u16()
+	}
 
-    /// Tries to represent the value of this `UInt` as a `u32`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `UInt` does not exceed the maximum value of `u32`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `u32`.
-    pub fn try_to_u32(&self) -> Result<u32> {
-        self.value.try_to_u32()
-    }
+	/// Tries to represent the value of this `UInt` as a `u32`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `UInt` does not exceed the maximum value of `u32`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `u32`.
+	pub fn try_to_u32(&self) -> Result<u32> {
+		self.value.try_to_u32()
+	}
 
-    /// Tries to represent the value of this `UInt` as a `u64`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `UInt` does not exceed the maximum value of `u64`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `u64`.
-    pub fn try_to_u64(&self) -> Result<u64> {
-        self.value.try_to_u64()
-    }
+	/// Tries to represent the value of this `UInt` as a `u64`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `UInt` does not exceed the maximum value of `u64`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `u64`.
+	pub fn try_to_u64(&self) -> Result<u64> {
+		self.value.try_to_u64()
+	}
 
-    /// Tries to represent the value of this `UInt` as a `u128`.
-    ///
-    /// # Note
-    ///
-    /// - This conversion is possible as long as the value represented
-    ///   by this `UInt` does not exceed the maximum value of `u128`.
-    ///
-    /// # Complexity
-    ///
-    /// - 𝒪(n) where n is the number of digits of this `UInt`.
-    ///
-    /// # Errors
-    ///
-    /// - If the value represented by this `UInt` can not be
-    ///   represented by a `u128`.
-    pub fn try_to_u128(&self) -> Result<u128> {
-        self.value.try_to_u128()
-    }
+	/// Tries to represent the value of this `UInt` as a `u128`.
+	///
+	/// # Note
+	///
+	/// - This conversion is possible as long as the value represented
+	///   by this `UInt` does not exceed the maximum value of `u128`.
+	///
+	/// # Complexity
+	///
+	/// - 𝒪(n) where n is the number of digits of this `UInt`.
+	///
+	/// # Errors
+	///
+	/// - If the value represented by this `UInt` can not be
+	///   represented by a `u128`.
+	pub fn try_to_u128(&self) -> Result<u128> {
+		self.value.try_to_u128()
+	}
 }
 
 /// # Shifts
@@ -560,39 +560,39 @@ impl UInt {
 use std::ops::{Shl, ShlAssign, Shr, ShrAssign};
 
 impl<S> Shl<S> for UInt
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn shl(self, shift_amount: S) -> Self::Output {
-        self.into_wrapping_shl(shift_amount).unwrap()
-    }
+	fn shl(self, shift_amount: S) -> Self::Output {
+		self.into_wrapping_shl(shift_amount).unwrap()
+	}
 }
 
 impl<S> Shr<S> for UInt
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn shr(self, shift_amount: S) -> Self::Output {
-        self.into_wrapping_shr(shift_amount).unwrap()
-    }
+	fn shr(self, shift_amount: S) -> Self::Output {
+		self.into_wrapping_shr(shift_amount).unwrap()
+	}
 }
 
 impl<S> ShlAssign<S> for UInt
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    fn shl_assign(&mut self, shift_amount: S) {
-        self.wrapping_shl_assign(shift_amount).unwrap()
-    }
+	fn shl_assign(&mut self, shift_amount: S) {
+		self.wrapping_shl_assign(shift_amount).unwrap()
+	}
 }
 
 impl<S> ShrAssign<S> for UInt
-    where S: Into<ShiftAmount>
+	where S: Into<ShiftAmount>
 {
-    fn shr_assign(&mut self, shift_amount: S) {
-        self.wrapping_shr_assign(shift_amount).unwrap()
-    }
+	fn shr_assign(&mut self, shift_amount: S) {
+		self.wrapping_shr_assign(shift_amount).unwrap()
+	}
 }
 
 /// # Random Utilities using `rand` crate.
@@ -604,31 +604,31 @@ impl UInt {
 	}
 
 	/// Creates a new `UInt` with the given `BitWidth` and random `Digit`s
-    /// using the given random number generator.
-    /// 
-    /// **Note:** This is useful for cryptographic or testing purposes.
-    pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> UInt
-        where R: rand::Rng
-    {
-        UInt::from(ApInt::random_with_width_using(width, rng))
-    }
+	/// using the given random number generator.
+	/// 
+	/// **Note:** This is useful for cryptographic or testing purposes.
+	pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> UInt
+		where R: rand::Rng
+	{
+		UInt::from(ApInt::random_with_width_using(width, rng))
+	}
 
-    /// Randomizes the digits of this `UInt` inplace.
-    /// 
-    /// This won't change its `BitWidth`.
-    pub fn randomize(&mut self) {
-        self.value.randomize()
-    }
+	/// Randomizes the digits of this `UInt` inplace.
+	/// 
+	/// This won't change its `BitWidth`.
+	pub fn randomize(&mut self) {
+		self.value.randomize()
+	}
 
-    /// Randomizes the digits of this `UInt` inplace using the given
-    /// random number generator.
-    /// 
-    /// This won't change its `BitWidth`.
-    pub fn randomize_using<R>(&mut self, rng: &mut R)
-        where R: rand::Rng
-    {
-        self.value.randomize_using(rng)
-    }
+	/// Randomizes the digits of this `UInt` inplace using the given
+	/// random number generator.
+	/// 
+	/// This won't change its `BitWidth`.
+	pub fn randomize_using<R>(&mut self, rng: &mut R)
+		where R: rand::Rng
+	{
+		self.value.randomize_using(rng)
+	}
 }
 
 impl UInt {
@@ -964,27 +964,27 @@ impl Not for UInt {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a UInt> for UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a UInt) -> Self::Output {
+		self.into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a UInt> for &'b UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitAnd<&'a UInt> for &'b mut UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitand(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitand(rhs).unwrap()
-    }
+	fn bitand(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitand(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -992,27 +992,27 @@ impl<'a, 'b> BitAnd<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a UInt> for UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a UInt) -> Self::Output {
+		self.into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a UInt> for &'b UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitOr<&'a UInt> for &'b mut UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitor(rhs).unwrap()
-    }
+	fn bitor(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -1020,27 +1020,27 @@ impl<'a, 'b> BitOr<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a UInt> for UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+		self.into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a UInt> for &'b UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
-    type Output = UInt;
+	type Output = UInt;
 
-    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-        self.clone().into_bitxor(rhs).unwrap()
-    }
+	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+		self.clone().into_bitxor(rhs).unwrap()
+	}
 }
 
 //  ===========================================================================
@@ -1048,21 +1048,21 @@ impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a UInt> for UInt {
-    fn bitand_assign(&mut self, rhs: &'a UInt) {
-        self.bitand_assign(rhs).unwrap();
-    }
+	fn bitand_assign(&mut self, rhs: &'a UInt) {
+		self.bitand_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitOrAssign<&'a UInt> for UInt {
-    fn bitor_assign(&mut self, rhs: &'a UInt) {
-        self.bitor_assign(rhs).unwrap();
-    }
+	fn bitor_assign(&mut self, rhs: &'a UInt) {
+		self.bitor_assign(rhs).unwrap();
+	}
 }
 
 impl<'a> BitXorAssign<&'a UInt> for UInt {
-    fn bitxor_assign(&mut self, rhs: &'a UInt) {
-        self.bitxor_assign(rhs).unwrap();
-    }
+	fn bitxor_assign(&mut self, rhs: &'a UInt) {
+		self.bitxor_assign(rhs).unwrap();
+	}
 }
 
 /// # Arithmetic Operations


### PR DESCRIPTION
I found some places in yours and my code that had space indentation and converted those.
Most `checked` were converted to `wrapping` which is numerically correct.
I checked the code base over about 3 times and you should also check for any mistakes I made and run all the unit tests (there are some unit tests being ignored and I am not sure how to turn those on).
If you have any other name changes you want, now is the time. I remember looking through the codebase a few weeks ago and finding some docs where you said you wanted a better name for the function.