### PR TITLE
Change indentation and convert `...` to `..=`

### DIFF
--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -8,594 +8,594 @@ use ll;
 use utils::{try_forward_bin_mut_impl, forward_mut_impl};
 
 use std::ops::{
-	Neg,
-	Add,
-	Sub,
-	Mul,
-	AddAssign,
-	SubAssign,
-	MulAssign
+    Neg,
+    Add,
+    Sub,
+    Mul,
+    AddAssign,
+    SubAssign,
+    MulAssign
 };
 
 /// # Arithmetic Operations
 impl ApInt {
 
-	/// Increments this `ApInt` by one inplace and returns the result
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	pub fn into_wrapping_inc(self) -> ApInt {
-		forward_mut_impl(self, ApInt::wrapping_inc)
-	}
+    /// Increments this `ApInt` by one inplace and returns the result
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    pub fn into_wrapping_inc(self) -> ApInt {
+        forward_mut_impl(self, ApInt::wrapping_inc)
+    }
 
-	/// Increments this `ApInt` by one inplace and returns the result
-	/// 
-	/// **Note:** This will **not** allocate memory
-	pub fn wrapping_inc(&mut self) {
-		match self.access_data_mut() {
-			DataAccessMut::Inl(x) => {
-				*x = x.wrapping_add(Digit::one());
-			}
-			DataAccessMut::Ext(x) => {
-				for i in 0..x.len() {
-					match x[i].repr().overflowing_add(1) {
-						(v,false) => {
-							x[i] = Digit(v);
-							break;
-						}
-						(v,true) => {
-							//if the ApInt was relatively random this should rarely happen
-							x[i] = Digit(v);
-						}
-					}
-				}
-			}
-		}
-		self.clear_unused_bits();
-	}
+    /// Increments this `ApInt` by one inplace and returns the result
+    /// 
+    /// **Note:** This will **not** allocate memory
+    pub fn wrapping_inc(&mut self) {
+        match self.access_data_mut() {
+            DataAccessMut::Inl(x) => {
+                *x = x.wrapping_add(Digit::one());
+            }
+            DataAccessMut::Ext(x) => {
+                for i in 0..x.len() {
+                    match x[i].repr().overflowing_add(1) {
+                        (v,false) => {
+                            x[i] = Digit(v);
+                            break;
+                        }
+                        (v,true) => {
+                            //if the ApInt was relatively random this should rarely happen
+                            x[i] = Digit(v);
+                        }
+                    }
+                }
+            }
+        }
+        self.clear_unused_bits();
+    }
 
-	/// Negates this `ApInt` inplace and returns the result.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	pub fn into_wrapping_neg(self) -> ApInt {
-		forward_mut_impl(self, ApInt::wrapping_neg)
-	}
+    /// Negates this `ApInt` inplace and returns the result.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    pub fn into_wrapping_neg(self) -> ApInt {
+        forward_mut_impl(self, ApInt::wrapping_neg)
+    }
 
-	/// Negates this `ApInt` inplace.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	pub fn wrapping_neg(&mut self) {
-		self.bitnot();
-		self.wrapping_inc();
-		//`wrapping_inc` handles clearing the unused bits
-	}
+    /// Negates this `ApInt` inplace.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    pub fn wrapping_neg(&mut self) {
+        self.bitnot();
+        self.wrapping_inc();
+        //`wrapping_inc` handles clearing the unused bits
+    }
 
-	/// Adds `rhs` to `self` and returns the result.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_add(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_add_assign)
-	}
+    /// Adds `rhs` to `self` and returns the result.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_add(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_add_assign)
+    }
 
-	/// Add-assigns `rhs` to `self` inplace.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_add_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let lval = lhs.repr();
-				let rval = rhs.repr();
-				let result = lval.wrapping_add(rval);
-				*lhs = Digit(result);
-			}
-			Ext(lhs, rhs) => {
-				let mut carry = Digit::zero();
-				for (l, r) in lhs.into_iter().zip(rhs) {
-					*l = ll::carry_add(*l, *r, &mut carry);
-				}
-			}
-		}
-		self.clear_unused_bits();
-		// Maybe we should return a recoverable error upon carry != 0 at this point.
-		Ok(())
-	}
+    /// Add-assigns `rhs` to `self` inplace.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_add_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let lval = lhs.repr();
+                let rval = rhs.repr();
+                let result = lval.wrapping_add(rval);
+                *lhs = Digit(result);
+            }
+            Ext(lhs, rhs) => {
+                let mut carry = Digit::zero();
+                for (l, r) in lhs.into_iter().zip(rhs) {
+                    *l = ll::carry_add(*l, *r, &mut carry);
+                }
+            }
+        }
+        self.clear_unused_bits();
+        // Maybe we should return a recoverable error upon carry != 0 at this point.
+        Ok(())
+    }
 
-	/// Subtracts `rhs` from `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_sub(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sub_assign)
-	}
+    /// Subtracts `rhs` from `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_sub(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sub_assign)
+    }
 
-	/// Subtract-assigns `rhs` from `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_sub_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let lval = lhs.repr();
-				let rval = rhs.repr();
-				let result = lval.wrapping_sub(rval);
-				*lhs = Digit(result);
-			}
-			Ext(lhs, rhs) => {
-				let mut borrow = Digit::zero();
-				for (l, r) in lhs.into_iter().zip(rhs) {
-					*l = ll::borrow_sub(*l, *r, &mut borrow);
-				}
-			}
-		}
-		self.clear_unused_bits();
-		// Maybe we should return a recoverable error upon borrow != 0 at this point.
-		Ok(())
-	}
+    /// Subtract-assigns `rhs` from `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_sub_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let lval = lhs.repr();
+                let rval = rhs.repr();
+                let result = lval.wrapping_sub(rval);
+                *lhs = Digit(result);
+            }
+            Ext(lhs, rhs) => {
+                let mut borrow = Digit::zero();
+                for (l, r) in lhs.into_iter().zip(rhs) {
+                    *l = ll::borrow_sub(*l, *r, &mut borrow);
+                }
+            }
+        }
+        self.clear_unused_bits();
+        // Maybe we should return a recoverable error upon borrow != 0 at this point.
+        Ok(())
+    }
 
-	/// Multiplies `rhs` with `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_mul(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_mul_assign)
-	}
+    /// Multiplies `rhs` with `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_mul(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_mul_assign)
+    }
 
-	/// Multiply-assigns `rhs` to `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	/// 
-	/// # Performance
-	/// 
-	/// If the function detects a large string of zeros in front of the most significant 1 bit,
-	/// it will apply optimizations so that wasted multiplications and additions of zero are avoided.
-	/// This function is designed to efficiently handle 5 common kinds of multiplication.
-	/// Small here means both small ApInt size and/or small numerical significance 
-	/// 	- multiplication of zero by any size integer (no allocation)
-	/// 	- multiplication of small (<= 64 bits) integers (no allocation)
-	/// 	- wrapping multiplication of medium size (<= 512 bits) integers
-	/// 	- multiplication of medium size integers that will not overflow
-	/// 	- multiplication of small integers by large integers
-	/// 	  (or large integers multiplied by small integers) (no allocation)
-	/// Currently, Karatsuba multiplication is not implemented, so large integer multiplication 
-	/// may be very slow compared to other algorithms.
-	pub fn wrapping_mul_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				*lhs = lhs.wrapping_mul(rhs);
-			}
-			//NOTE: this part assumes that an Ext ApInt will always have at least 2 digits
-			Ext(lhs, rhs) => {
-				//wrapping long multiplication, in the future we could have karatsuba multiplication for larger ints (wikipedia says 320-640 bits is about where karatsuba multiplication algorithms become faster)
+    /// Multiply-assigns `rhs` to `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    /// 
+    /// # Performance
+    /// 
+    /// If the function detects a large string of zeros in front of the most significant 1 bit,
+    /// it will apply optimizations so that wasted multiplications and additions of zero are avoided.
+    /// This function is designed to efficiently handle 5 common kinds of multiplication.
+    /// Small here means both small ApInt size and/or small numerical significance 
+    /// 	- multiplication of zero by any size integer (no allocation)
+    /// 	- multiplication of small (<= 64 bits) integers (no allocation)
+    /// 	- wrapping multiplication of medium size (<= 512 bits) integers
+    /// 	- multiplication of medium size integers that will not overflow
+    /// 	- multiplication of small integers by large integers
+    /// 	  (or large integers multiplied by small integers) (no allocation)
+    /// Currently, Karatsuba multiplication is not implemented, so large integer multiplication 
+    /// may be very slow compared to other algorithms.
+    pub fn wrapping_mul_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                *lhs = lhs.wrapping_mul(rhs);
+            }
+            //NOTE: this part assumes that an Ext ApInt will always have at least 2 digits
+            Ext(lhs, rhs) => {
+                //wrapping long multiplication, in the future we could have karatsuba multiplication for larger ints (wikipedia says 320-640 bits is about where karatsuba multiplication algorithms become faster)
 
-				//finds the most significant nonzero digit (for later optimizations) and handles early return of multiplication by zero.
+                //finds the most significant nonzero digit (for later optimizations) and handles early return of multiplication by zero.
 
-				let rhs_sig_nonzero: usize = match rhs.iter().rposition(|x| x != &Digit::zero()) {
-					Some(x) => x,
-					None => {
-						for x in lhs.iter_mut() {
-							x.unset_all()
-						}
-						return Ok(());
-					}
-				};
-				let lhs_sig_nonzero: usize = match lhs.iter().rposition(|x| x != &Digit::zero()) {
-					Some(x) => x,
-					None => {
-						for x in lhs.iter_mut() {
-							x.unset_all()
-						}
-						return Ok(());
-					}
-				};
-				//for several routines below there was a nested loop that had its first and last iterations unrolled (and the unrolled loops had their first and last iterations unrolled), and then some if statements are added for overflow checks.
-				//This is done because the compiler probably cannot properly unroll the carry system, overflow system, and figure out that only digit multiplications were needed instead of doubledigit mults in some places.
-				match (lhs_sig_nonzero == 0, rhs_sig_nonzero == 0) {
-					(false, false) => {
-						if lhs_sig_nonzero + rhs_sig_nonzero + 2 <= lhs.len() {
-							//no possibility of overflow
-							//first digit of first row
-							let mult = lhs[0];
-							let temp = mult.carrying_mul(rhs[0]);
-							//middle digits of first row
-							//the goal here with `sum` is to allocate and initialize it only once here.
-							let mut sum = Vec::with_capacity(lhs_sig_nonzero + rhs_sig_nonzero + 2);
-							sum.push(temp.0);
-							let mut mul_carry = temp.1;
-							for rhs_i in 1..rhs_sig_nonzero {
-								let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
-								sum.push(temp.0);
-								mul_carry = temp.1;
-							}
-							let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
-							sum.push(temp.0);
-							sum.push(temp.1);
-							//middle rows
-							for lhs_i in 1..lhs_sig_nonzero {
-								let mult = lhs[lhs_i];
-								//first digit of this row
-								let temp0 = mult.carrying_mul(rhs[0]);
-								let mut mul_carry = temp0.1;
-								let temp1 = sum[lhs_i].carrying_add(temp0.0);
-								sum[lhs_i] = temp1.0;
-								let mut add_carry = temp1.1;
-								//middle digits of this row
-								for rhs_i in 1..rhs_sig_nonzero {
-									let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
-									mul_carry = temp0.1;
-									let temp1: DoubleDigit = sum[lhs_i + rhs_i]
-										.dd()
-										.wrapping_add(temp0.0.dd())
-										.wrapping_add(add_carry.dd());
-									sum[lhs_i + rhs_i] = temp1.lo();
-									add_carry = temp1.hi();
-								}
-								//final digits of this row
-								let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero],mul_carry);
-								let temp1: DoubleDigit = sum[lhs_i + rhs_sig_nonzero]
-									.dd()
-									.wrapping_add(temp0.0.dd())
-									.wrapping_add(add_carry.dd());
-								sum[lhs_i + rhs_sig_nonzero] = temp1.lo();
-								sum.push(temp1.hi().wrapping_add(temp0.1));
-							}
-							let mult = lhs[lhs_sig_nonzero];
-							//first digit of final row
-							let temp0 = mult.carrying_mul(rhs[0]);
-							let mut mul_carry = temp0.1;
-							let temp1 = sum[lhs_sig_nonzero].carrying_add(temp0.0);
-							sum[lhs_sig_nonzero] = temp1.0;
-							let mut add_carry = temp1.1;
-							//middle digits of final row
-							println!("{:?}",sum);
-							for rhs_i in 1..rhs_sig_nonzero {
-								let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
-								mul_carry = temp0.1;
-								let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_i]
-									.dd()
-									.wrapping_add(temp0.0.dd())
-									.wrapping_add(add_carry.dd());
-								sum[lhs_sig_nonzero + rhs_i] = temp1.lo();
-								add_carry = temp1.hi();
-							}
-							let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
-							let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_sig_nonzero]
-								.dd()
-								.wrapping_add(temp0.0.dd())
-								.wrapping_add(add_carry.dd());
-							sum[lhs_sig_nonzero + rhs_sig_nonzero] = temp1.lo();
-							sum.push(temp1.hi().wrapping_add(temp0.1));
-							for i in 0..sum.len() {
-								lhs[i] = sum[i];
-							}
-							return Ok(())
-						} else {
-							//wrapping (modular) multiplication
-							let sig_nonzero = lhs.len() - 1;
-							//first digit done and carry
-							let temp = lhs[0].carrying_mul(rhs[0]);
-							//the goal here with `sum` is to allocate and initialize it only once here.
-							//first row
-							let mut sum = Vec::with_capacity(lhs.len());
-							sum.push(temp.0);
-							let mut mul_carry = temp.1;
-							for rhs_i in 1..sig_nonzero {
-								let temp = lhs[0].carrying_mul_add(rhs[rhs_i], mul_carry);
-								sum.push(temp.0);
-								mul_carry = temp.1;
-							}
-							//final digit of first row
-							sum.push(lhs[0].wrapping_mul_add(rhs[sig_nonzero], mul_carry));
-							//middle rows
-							for lhs_i in 1..sig_nonzero {
-								//first digit of this row
-								let temp0 = lhs[lhs_i].carrying_mul(rhs[0]);
-								mul_carry = temp0.1;
-								let temp1 = sum[lhs_i].carrying_add(temp0.0);
-								//sum[lhs_i] does not need to be used again
-								sum[lhs_i] = temp1.0;
-								let mut add_carry = temp1.1;
-								//as we get to the higher lhs digits, the higher rhs digits do not need to be considered
-								let rhs_i_upper = sig_nonzero.wrapping_sub(lhs_i);
-								//middle digits of this row
-								for rhs_i in 1..rhs_i_upper {
-									let temp0 = lhs[lhs_i].carrying_mul_add(rhs[rhs_i], mul_carry);
-									mul_carry = temp0.1;
-									let temp1: DoubleDigit = sum[lhs_i + rhs_i]
-										.dd()
-										.wrapping_add(temp0.0.dd())
-										.wrapping_add(add_carry.dd());
-									sum[lhs_i + rhs_i] = temp1.lo();
-									add_carry = temp1.hi();
-									}
-								//final digit of this row
-								sum[sig_nonzero] = lhs[lhs_i]
-									.wrapping_mul(rhs[rhs_i_upper])
-									.wrapping_add(mul_carry)
-									.wrapping_add(sum[sig_nonzero])
-									.wrapping_add(add_carry);
-							}
-							for i in 0..sig_nonzero {
-								lhs[i] = sum[i];
-							}
-							//final digit (the only one in its row)
-							lhs[sig_nonzero] = lhs[sig_nonzero].wrapping_mul_add(rhs[0], sum[sig_nonzero]);
-							return Ok(())
-						}
-					},
-					(true, false) => {
-						let mult = lhs[0];
-						//first digit done and carry
-						let temp = mult.carrying_mul(rhs[0]);
-						lhs[0] = temp.0;
-						let mut mul_carry = temp.1;
-						//middle of row
-						for rhs_i in 1..rhs_sig_nonzero {
-							let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
-							lhs[rhs_i] = temp.0;
-							mul_carry = temp.1;
-						}
-						//final digit
-						if rhs_sig_nonzero == lhs.len() - 1 {
-							lhs[rhs_sig_nonzero] = mult.wrapping_mul_add(rhs[rhs_sig_nonzero], mul_carry);
-						} else {
-							let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
-							lhs[rhs_sig_nonzero] = temp.0;
-							lhs[rhs_sig_nonzero + 1] = temp.1;
-						}
-					},
-					(false, true) => {
-						//first digit done and carry
-						let temp = rhs[0].carrying_mul(lhs[0]);
-						lhs[0] = temp.0;
-						let mut mul_carry = temp.1;
-						//middle of row
-						for lhs_i in 1..lhs_sig_nonzero {
-							let temp = rhs[0].carrying_mul_add(lhs[lhs_i], mul_carry);
-							lhs[lhs_i] = temp.0;
-							mul_carry = temp.1;
-						}
-						//final digit
-						if lhs_sig_nonzero == lhs.len() - 1 {
-							lhs[lhs_sig_nonzero] = rhs[0].wrapping_mul_add(lhs[lhs_sig_nonzero], mul_carry);
-						} else {
-							let temp = rhs[0].carrying_mul_add(lhs[lhs_sig_nonzero], mul_carry);
-							lhs[lhs_sig_nonzero] = temp.0;
-							lhs[lhs_sig_nonzero + 1] = temp.1;
-						}
-					},
-					(true, true) => {
-						let temp0 = lhs[0].carrying_mul(rhs[0]);
-						lhs[0] = temp0.0;
-						lhs[1] = temp0.1;
-					}
-				}
-			}
-		}
-		self.clear_unused_bits();
-		Ok(())
-	}
+                let rhs_sig_nonzero: usize = match rhs.iter().rposition(|x| x != &Digit::zero()) {
+                    Some(x) => x,
+                    None => {
+                        for x in lhs.iter_mut() {
+                            x.unset_all()
+                        }
+                        return Ok(());
+                    }
+                };
+                let lhs_sig_nonzero: usize = match lhs.iter().rposition(|x| x != &Digit::zero()) {
+                    Some(x) => x,
+                    None => {
+                        for x in lhs.iter_mut() {
+                            x.unset_all()
+                        }
+                        return Ok(());
+                    }
+                };
+                //for several routines below there was a nested loop that had its first and last iterations unrolled (and the unrolled loops had their first and last iterations unrolled), and then some if statements are added for overflow checks.
+                //This is done because the compiler probably cannot properly unroll the carry system, overflow system, and figure out that only digit multiplications were needed instead of doubledigit mults in some places.
+                match (lhs_sig_nonzero == 0, rhs_sig_nonzero == 0) {
+                    (false, false) => {
+                        if lhs_sig_nonzero + rhs_sig_nonzero + 2 <= lhs.len() {
+                            //no possibility of overflow
+                            //first digit of first row
+                            let mult = lhs[0];
+                            let temp = mult.carrying_mul(rhs[0]);
+                            //middle digits of first row
+                            //the goal here with `sum` is to allocate and initialize it only once here.
+                            let mut sum = Vec::with_capacity(lhs_sig_nonzero + rhs_sig_nonzero + 2);
+                            sum.push(temp.0);
+                            let mut mul_carry = temp.1;
+                            for rhs_i in 1..rhs_sig_nonzero {
+                                let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+                                sum.push(temp.0);
+                                mul_carry = temp.1;
+                            }
+                            let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+                            sum.push(temp.0);
+                            sum.push(temp.1);
+                            //middle rows
+                            for lhs_i in 1..lhs_sig_nonzero {
+                                let mult = lhs[lhs_i];
+                                //first digit of this row
+                                let temp0 = mult.carrying_mul(rhs[0]);
+                                let mut mul_carry = temp0.1;
+                                let temp1 = sum[lhs_i].carrying_add(temp0.0);
+                                sum[lhs_i] = temp1.0;
+                                let mut add_carry = temp1.1;
+                                //middle digits of this row
+                                for rhs_i in 1..rhs_sig_nonzero {
+                                    let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+                                    mul_carry = temp0.1;
+                                    let temp1: DoubleDigit = sum[lhs_i + rhs_i]
+                                        .dd()
+                                        .wrapping_add(temp0.0.dd())
+                                        .wrapping_add(add_carry.dd());
+                                    sum[lhs_i + rhs_i] = temp1.lo();
+                                    add_carry = temp1.hi();
+                                }
+                                //final digits of this row
+                                let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero],mul_carry);
+                                let temp1: DoubleDigit = sum[lhs_i + rhs_sig_nonzero]
+                                    .dd()
+                                    .wrapping_add(temp0.0.dd())
+                                    .wrapping_add(add_carry.dd());
+                                sum[lhs_i + rhs_sig_nonzero] = temp1.lo();
+                                sum.push(temp1.hi().wrapping_add(temp0.1));
+                            }
+                            let mult = lhs[lhs_sig_nonzero];
+                            //first digit of final row
+                            let temp0 = mult.carrying_mul(rhs[0]);
+                            let mut mul_carry = temp0.1;
+                            let temp1 = sum[lhs_sig_nonzero].carrying_add(temp0.0);
+                            sum[lhs_sig_nonzero] = temp1.0;
+                            let mut add_carry = temp1.1;
+                            //middle digits of final row
+                            println!("{:?}",sum);
+                            for rhs_i in 1..rhs_sig_nonzero {
+                                let temp0 = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+                                mul_carry = temp0.1;
+                                let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_i]
+                                    .dd()
+                                    .wrapping_add(temp0.0.dd())
+                                    .wrapping_add(add_carry.dd());
+                                sum[lhs_sig_nonzero + rhs_i] = temp1.lo();
+                                add_carry = temp1.hi();
+                            }
+                            let temp0 = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+                            let temp1: DoubleDigit = sum[lhs_sig_nonzero + rhs_sig_nonzero]
+                                .dd()
+                                .wrapping_add(temp0.0.dd())
+                                .wrapping_add(add_carry.dd());
+                            sum[lhs_sig_nonzero + rhs_sig_nonzero] = temp1.lo();
+                            sum.push(temp1.hi().wrapping_add(temp0.1));
+                            for i in 0..sum.len() {
+                                lhs[i] = sum[i];
+                            }
+                            return Ok(())
+                        } else {
+                            //wrapping (modular) multiplication
+                            let sig_nonzero = lhs.len() - 1;
+                            //first digit done and carry
+                            let temp = lhs[0].carrying_mul(rhs[0]);
+                            //the goal here with `sum` is to allocate and initialize it only once here.
+                            //first row
+                            let mut sum = Vec::with_capacity(lhs.len());
+                            sum.push(temp.0);
+                            let mut mul_carry = temp.1;
+                            for rhs_i in 1..sig_nonzero {
+                                let temp = lhs[0].carrying_mul_add(rhs[rhs_i], mul_carry);
+                                sum.push(temp.0);
+                                mul_carry = temp.1;
+                            }
+                            //final digit of first row
+                            sum.push(lhs[0].wrapping_mul_add(rhs[sig_nonzero], mul_carry));
+                            //middle rows
+                            for lhs_i in 1..sig_nonzero {
+                                //first digit of this row
+                                let temp0 = lhs[lhs_i].carrying_mul(rhs[0]);
+                                mul_carry = temp0.1;
+                                let temp1 = sum[lhs_i].carrying_add(temp0.0);
+                                //sum[lhs_i] does not need to be used again
+                                sum[lhs_i] = temp1.0;
+                                let mut add_carry = temp1.1;
+                                //as we get to the higher lhs digits, the higher rhs digits do not need to be considered
+                                let rhs_i_upper = sig_nonzero.wrapping_sub(lhs_i);
+                                //middle digits of this row
+                                for rhs_i in 1..rhs_i_upper {
+                                    let temp0 = lhs[lhs_i].carrying_mul_add(rhs[rhs_i], mul_carry);
+                                    mul_carry = temp0.1;
+                                    let temp1: DoubleDigit = sum[lhs_i + rhs_i]
+                                        .dd()
+                                        .wrapping_add(temp0.0.dd())
+                                        .wrapping_add(add_carry.dd());
+                                    sum[lhs_i + rhs_i] = temp1.lo();
+                                    add_carry = temp1.hi();
+                                    }
+                                //final digit of this row
+                                sum[sig_nonzero] = lhs[lhs_i]
+                                    .wrapping_mul(rhs[rhs_i_upper])
+                                    .wrapping_add(mul_carry)
+                                    .wrapping_add(sum[sig_nonzero])
+                                    .wrapping_add(add_carry);
+                            }
+                            for i in 0..sig_nonzero {
+                                lhs[i] = sum[i];
+                            }
+                            //final digit (the only one in its row)
+                            lhs[sig_nonzero] = lhs[sig_nonzero].wrapping_mul_add(rhs[0], sum[sig_nonzero]);
+                            return Ok(())
+                        }
+                    },
+                    (true, false) => {
+                        let mult = lhs[0];
+                        //first digit done and carry
+                        let temp = mult.carrying_mul(rhs[0]);
+                        lhs[0] = temp.0;
+                        let mut mul_carry = temp.1;
+                        //middle of row
+                        for rhs_i in 1..rhs_sig_nonzero {
+                            let temp = mult.carrying_mul_add(rhs[rhs_i], mul_carry);
+                            lhs[rhs_i] = temp.0;
+                            mul_carry = temp.1;
+                        }
+                        //final digit
+                        if rhs_sig_nonzero == lhs.len() - 1 {
+                            lhs[rhs_sig_nonzero] = mult.wrapping_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+                        } else {
+                            let temp = mult.carrying_mul_add(rhs[rhs_sig_nonzero], mul_carry);
+                            lhs[rhs_sig_nonzero] = temp.0;
+                            lhs[rhs_sig_nonzero + 1] = temp.1;
+                        }
+                    },
+                    (false, true) => {
+                        //first digit done and carry
+                        let temp = rhs[0].carrying_mul(lhs[0]);
+                        lhs[0] = temp.0;
+                        let mut mul_carry = temp.1;
+                        //middle of row
+                        for lhs_i in 1..lhs_sig_nonzero {
+                            let temp = rhs[0].carrying_mul_add(lhs[lhs_i], mul_carry);
+                            lhs[lhs_i] = temp.0;
+                            mul_carry = temp.1;
+                        }
+                        //final digit
+                        if lhs_sig_nonzero == lhs.len() - 1 {
+                            lhs[lhs_sig_nonzero] = rhs[0].wrapping_mul_add(lhs[lhs_sig_nonzero], mul_carry);
+                        } else {
+                            let temp = rhs[0].carrying_mul_add(lhs[lhs_sig_nonzero], mul_carry);
+                            lhs[lhs_sig_nonzero] = temp.0;
+                            lhs[lhs_sig_nonzero + 1] = temp.1;
+                        }
+                    },
+                    (true, true) => {
+                        let temp0 = lhs[0].carrying_mul(rhs[0]);
+                        lhs[0] = temp0.0;
+                        lhs[1] = temp0.1;
+                    }
+                }
+            }
+        }
+        self.clear_unused_bits();
+        Ok(())
+    }
 
-	/// Divides `self` by `rhs` using **unsigned** interpretation and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_udiv(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_udiv_assign)
-	}
+    /// Divides `self` by `rhs` using **unsigned** interpretation and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_udiv(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_udiv_assign)
+    }
 
-	/// Assignes `self` to the division of `self` by `rhs` using **unsigned**
-	/// interpretation of the values.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_udiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		if rhs.is_zero() {
-			return Err(Error::division_by_zero(DivOp::UnsignedDiv, self.clone()))
-		}
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let lval = lhs.repr();
-				let rval = rhs.repr();
-				let result = lval.wrapping_div(rval);
-				*lhs = Digit(result);
-			}
-			Ext(_lhs, _rhs) => {
-				unimplemented!()
-			}
-		}
-		Ok(())
-	}
+    /// Assignes `self` to the division of `self` by `rhs` using **unsigned**
+    /// interpretation of the values.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_udiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        if rhs.is_zero() {
+            return Err(Error::division_by_zero(DivOp::UnsignedDiv, self.clone()))
+        }
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let lval = lhs.repr();
+                let rval = rhs.repr();
+                let result = lval.wrapping_div(rval);
+                *lhs = Digit(result);
+            }
+            Ext(_lhs, _rhs) => {
+                unimplemented!()
+            }
+        }
+        Ok(())
+    }
 
-	/// Divides `self` by `rhs` using **signed** interpretation and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_sdiv(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sdiv_assign)
-	}
+    /// Divides `self` by `rhs` using **signed** interpretation and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_sdiv(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_sdiv_assign)
+    }
 
-	/// Assignes `self` to the division of `self` by `rhs` using **signed**
-	/// interpretation of the values.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_sdiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		if rhs.is_zero() {
-			return Err(Error::division_by_zero(DivOp::SignedDiv, self.clone()))
-		}
-		let width = self.width();
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let mut l = lhs.clone();
-				let mut r = rhs.clone();
-				l.sign_extend_from(width).unwrap();
-				r.sign_extend_from(width).unwrap();
-				let lval = l.repr() as i64;
-				let rval = r.repr() as i64;
-				let result = lval.wrapping_div(rval) as DigitRepr;
-				*lhs = Digit(result);
-			}
-			Ext(_lhs, _rhs) => {
-				unimplemented!()
-			}
-		}
-		self.clear_unused_bits();
-		Ok(())
-	}
+    /// Assignes `self` to the division of `self` by `rhs` using **signed**
+    /// interpretation of the values.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_sdiv_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        if rhs.is_zero() {
+            return Err(Error::division_by_zero(DivOp::SignedDiv, self.clone()))
+        }
+        let width = self.width();
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let mut l = lhs.clone();
+                let mut r = rhs.clone();
+                l.sign_extend_from(width).unwrap();
+                r.sign_extend_from(width).unwrap();
+                let lval = l.repr() as i64;
+                let rval = r.repr() as i64;
+                let result = lval.wrapping_div(rval) as DigitRepr;
+                *lhs = Digit(result);
+            }
+            Ext(_lhs, _rhs) => {
+                unimplemented!()
+            }
+        }
+        self.clear_unused_bits();
+        Ok(())
+    }
 
-	/// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_urem(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_urem_assign)
-	}
+    /// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_urem(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_urem_assign)
+    }
 
-	/// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_urem_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		if rhs.is_zero() {
-			return Err(Error::division_by_zero(DivOp::UnsignedRem, self.clone()))
-		}
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let lval = lhs.repr();
-				let rval = rhs.repr();
-				let result = lval.wrapping_rem(rval);
-				*lhs = Digit(result);
-			}
-			Ext(_lhs, _rhs) => {
-				unimplemented!()
-			}
-		}
-		Ok(())
-	}
+    /// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_urem_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        if rhs.is_zero() {
+            return Err(Error::division_by_zero(DivOp::UnsignedRem, self.clone()))
+        }
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let lval = lhs.repr();
+                let rval = rhs.repr();
+                let result = lval.wrapping_rem(rval);
+                *lhs = Digit(result);
+            }
+            Ext(_lhs, _rhs) => {
+                unimplemented!()
+            }
+        }
+        Ok(())
+    }
 
-	/// Calculates the **signed** remainder of `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_srem(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_srem_assign)
-	}
+    /// Calculates the **signed** remainder of `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_srem(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::wrapping_srem_assign)
+    }
 
-	/// Assignes `self` to the **signed** remainder of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_srem_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		if rhs.is_zero() {
-			return Err(Error::division_by_zero(DivOp::SignedRem, self.clone()))
-		}
-		let width = self.width();
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => {
-				let mut l = lhs.clone();
-				let mut r = rhs.clone();
-				l.sign_extend_from(width).unwrap();
-				r.sign_extend_from(width).unwrap();
-				let lval = l.repr() as i64;
-				let rval = r.repr() as i64;
-				let result = lval.wrapping_rem(rval) as DigitRepr;
-				*lhs = Digit(result);
-			}
-			Ext(_lhs, _rhs) => {
-				unimplemented!()
-			}
-		}
-		self.clear_unused_bits();
-		Ok(())
-	}
+    /// Assignes `self` to the **signed** remainder of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_srem_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        if rhs.is_zero() {
+            return Err(Error::division_by_zero(DivOp::SignedRem, self.clone()))
+        }
+        let width = self.width();
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => {
+                let mut l = lhs.clone();
+                let mut r = rhs.clone();
+                l.sign_extend_from(width).unwrap();
+                r.sign_extend_from(width).unwrap();
+                let lval = l.repr() as i64;
+                let rval = r.repr() as i64;
+                let result = lval.wrapping_rem(rval) as DigitRepr;
+                *lhs = Digit(result);
+            }
+            Ext(_lhs, _rhs) => {
+                unimplemented!()
+            }
+        }
+        self.clear_unused_bits();
+        Ok(())
+    }
 
 }
 
@@ -615,28 +615,28 @@ impl ApInt {
 // ============================================================================
 
 impl Neg for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn neg(self) -> Self::Output {
-		self.into_wrapping_neg()
-	}
+    fn neg(self) -> Self::Output {
+        self.into_wrapping_neg()
+    }
 }
 
 impl<'a> Neg for &'a ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn neg(self) -> Self::Output {
-		self.clone().into_wrapping_neg()
-	}
+    fn neg(self) -> Self::Output {
+        self.clone().into_wrapping_neg()
+    }
 }
 
 impl<'a> Neg for &'a mut ApInt {
-	type Output = &'a mut ApInt;
+    type Output = &'a mut ApInt;
 
-	fn neg(self) -> Self::Output {
-		self.wrapping_neg();
-		self
-	}
+    fn neg(self) -> Self::Output {
+        self.wrapping_neg();
+        self
+    }
 }
 
 // ============================================================================
@@ -644,25 +644,25 @@ impl<'a> Neg for &'a mut ApInt {
 // ============================================================================
 
 impl<'a> Add<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn add(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Add<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn add(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a> AddAssign<&'a ApInt> for ApInt {
-	fn add_assign(&mut self, rhs: &'a ApInt) {
-		self.wrapping_add_assign(rhs).unwrap()
-	}
+    fn add_assign(&mut self, rhs: &'a ApInt) {
+        self.wrapping_add_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -670,25 +670,25 @@ impl<'a> AddAssign<&'a ApInt> for ApInt {
 // ============================================================================
 
 impl<'a> Sub<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn sub(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Sub<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn sub(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a> SubAssign<&'a ApInt> for ApInt {
-	fn sub_assign(&mut self, rhs: &'a ApInt) {
-		self.wrapping_sub_assign(rhs).unwrap()
-	}
+    fn sub_assign(&mut self, rhs: &'a ApInt) {
+        self.wrapping_sub_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -696,291 +696,291 @@ impl<'a> SubAssign<&'a ApInt> for ApInt {
 // ============================================================================
 
 impl<'a> Mul<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn mul(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Mul<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn mul(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a> MulAssign<&'a ApInt> for ApInt {
-	fn mul_assign(&mut self, rhs: &'a ApInt) {
-		self.wrapping_mul_assign(rhs).unwrap();
-	}
+    fn mul_assign(&mut self, rhs: &'a ApInt) {
+        self.wrapping_mul_assign(rhs).unwrap();
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	mod inc {
-		use super::*;
-		use std::u64;
+    mod inc {
+        use super::*;
+        use std::u64;
 
-		#[test]
-		fn test() {
-			assert_eq!(ApInt::from(14u8).into_wrapping_inc(),ApInt::from(15u8));
-			assert_eq!(ApInt::from(15u8).into_wrapping_inc(),ApInt::from(16u8));
-			assert_eq!(ApInt::from(16u8).into_wrapping_inc(),ApInt::from(17u8));
-			assert_eq!(ApInt::from(17u8).into_wrapping_inc(),ApInt::from(18u8));
-			assert_eq!(ApInt::from([0u64,0,0]).into_wrapping_inc(),ApInt::from([0u64,0,1]));			
-			assert_eq!(ApInt::from([0,7,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,8,0]));
-			assert_eq!(ApInt::from([u64::MAX,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,0]));
-			assert_eq!(ApInt::from([0,u64::MAX,u64::MAX - 1]).into_wrapping_inc(),ApInt::from([0,u64::MAX,u64::MAX]));
-			assert_eq!(ApInt::from([0,u64::MAX,0]).into_wrapping_inc(),ApInt::from([0,u64::MAX,1]));	
-		}
-	}
+        #[test]
+        fn test() {
+            assert_eq!(ApInt::from(14u8).into_wrapping_inc(),ApInt::from(15u8));
+            assert_eq!(ApInt::from(15u8).into_wrapping_inc(),ApInt::from(16u8));
+            assert_eq!(ApInt::from(16u8).into_wrapping_inc(),ApInt::from(17u8));
+            assert_eq!(ApInt::from(17u8).into_wrapping_inc(),ApInt::from(18u8));
+            assert_eq!(ApInt::from([0u64,0,0]).into_wrapping_inc(),ApInt::from([0u64,0,1]));			
+            assert_eq!(ApInt::from([0,7,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,8,0]));
+            assert_eq!(ApInt::from([u64::MAX,u64::MAX]).into_wrapping_inc(),ApInt::from([0u64,0]));
+            assert_eq!(ApInt::from([0,u64::MAX,u64::MAX - 1]).into_wrapping_inc(),ApInt::from([0,u64::MAX,u64::MAX]));
+            assert_eq!(ApInt::from([0,u64::MAX,0]).into_wrapping_inc(),ApInt::from([0,u64::MAX,1]));	
+        }
+    }
 
-	mod wrapping_neg {
-		use super::*;
-		use bitwidth::{BitWidth};
+    mod wrapping_neg {
+        use super::*;
+        use bitwidth::{BitWidth};
 
-		fn assert_symmetry(input: ApInt, expected: ApInt) {
-			assert_eq!(input.clone().into_wrapping_neg(), expected.clone());
-			assert_eq!(expected.into_wrapping_neg(), input);
-		}
+        fn assert_symmetry(input: ApInt, expected: ApInt) {
+            assert_eq!(input.clone().into_wrapping_neg(), expected.clone());
+            assert_eq!(expected.into_wrapping_neg(), input);
+        }
 
-		fn test_vals() -> impl Iterator<Item = i128> {
-			[0_i128, 1, 2, 4, 5, 7, 10, 42, 50, 100, 128, 150,
-			 1337, 123123, 999999, 987432, 77216417].into_iter().map(|v| *v)
-		}
+        fn test_vals() -> impl Iterator<Item = i128> {
+            [0_i128, 1, 2, 4, 5, 7, 10, 42, 50, 100, 128, 150,
+             1337, 123123, 999999, 987432, 77216417].into_iter().map(|v| *v)
+        }
 
-		#[test]
-		fn simple() {
-			assert_symmetry(ApInt::zero(BitWidth::w1()), ApInt::zero(BitWidth::w1()));
-			assert_symmetry(ApInt::one(BitWidth::w1()), ApInt::all_set(BitWidth::w1()));
-		}
+        #[test]
+        fn simple() {
+            assert_symmetry(ApInt::zero(BitWidth::w1()), ApInt::zero(BitWidth::w1()));
+            assert_symmetry(ApInt::one(BitWidth::w1()), ApInt::all_set(BitWidth::w1()));
+        }
 
-		#[test]
-		fn range() {
-			for v in test_vals() {
-				assert_symmetry(ApInt::from_i8(v as i8), ApInt::from_i8(-v as i8));
-				assert_symmetry(ApInt::from_i16(v as i16), ApInt::from_i16(-v as i16));
-				assert_symmetry(ApInt::from_i32(v as i32), ApInt::from_i32(-v as i32));
-				assert_symmetry(ApInt::from_i64(v as i64), ApInt::from_i64(-v as i64));
-				assert_symmetry(ApInt::from_i128(v), ApInt::from_i128(-v));
-			}
-		}
-	}
+        #[test]
+        fn range() {
+            for v in test_vals() {
+                assert_symmetry(ApInt::from_i8(v as i8), ApInt::from_i8(-v as i8));
+                assert_symmetry(ApInt::from_i16(v as i16), ApInt::from_i16(-v as i16));
+                assert_symmetry(ApInt::from_i32(v as i32), ApInt::from_i32(-v as i32));
+                assert_symmetry(ApInt::from_i64(v as i64), ApInt::from_i64(-v as i64));
+                assert_symmetry(ApInt::from_i128(v), ApInt::from_i128(-v));
+            }
+        }
+    }
 
-	mod mul {
-		use super::*;
-		use bitwidth::BitWidth;
-		use std::{u8,u64};
+    mod mul {
+        use super::*;
+        use bitwidth::BitWidth;
+        use std::{u8,u64};
 
-		#[test]
-		fn rigorous() {
-			//there are many special case and size optimization paths, so this test must be very rigorous.
+        #[test]
+        fn rigorous() {
+            //there are many special case and size optimization paths, so this test must be very rigorous.
 
-			//multiplication of apints composed of only u8::MAX in their least significant digits
-			//only works for num_u8 > 1
-			fn nine_test(num_u8: usize) {
-				let mut lhs;
-				let mut rhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
-				let nine =
-					ApInt::from(u8::MAX).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
-				for rhs_nine in 1..=num_u8 {
-					rhs.wrapping_shl_assign(8).unwrap();
-					rhs |= &nine;
-					lhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
-					'outer: for lhs_nine in 1..=num_u8 {
-						lhs.wrapping_shl_assign(8).unwrap();
-						lhs |= &nine;
-						//imagine multiplying a string of base 10 nines together.
-						//It will produce things like 998001, 8991, 98901, 9989001.
-						//this uses a formula for the number of nines, eights, and zeros except here nine is u8::MAX, eight is u8::MAX - 1, and zero is 0u8
-						let mut zeros_after_one = if lhs_nine < rhs_nine {
-							lhs_nine - 1
-						} else {
-							rhs_nine - 1
-						};
-						let mut nines_before_eight = if lhs_nine > rhs_nine {
-							lhs_nine - rhs_nine
-						} else {
-							rhs_nine - lhs_nine
-						};
-						let mut nines_after_eight = if lhs_nine < rhs_nine {
-							lhs_nine - 1
-						} else {
-							rhs_nine - 1
-						};
-						let mut result = lhs.clone().into_wrapping_mul(&rhs).unwrap();
-						assert_eq!(result.clone().resize_to_u8(), 1u8);
-						for i in 0..zeros_after_one {
-							if i >= num_u8 - 1 {
-								continue 'outer;
-							}
-							result.wrapping_lshr_assign(8).unwrap();
-							let temp = result.clone().resize_to_u8();
-							if temp != 0 {
-								panic!(
-									"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
-									lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
-								);
-							}
-						}
-						for i in 0..nines_before_eight {
-							if zeros_after_one + i >= num_u8 - 1 {
-								continue 'outer;
-							}
-							result.wrapping_lshr_assign(8).unwrap();
-							assert_eq!(result.clone().resize_to_u8(), u8::MAX);
-						}
-						if zeros_after_one + nines_before_eight >= num_u8 - 1 {
-							continue 'outer;
-						}
-						result.wrapping_lshr_assign(8).unwrap();
-						let temp = result.clone().resize_to_u8();
-						if temp != u8::MAX - 1 {
-							panic!(
-								"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
-								lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
-							);
-						}
-						for i in 0..nines_after_eight {
-							if 1 + zeros_after_one + nines_before_eight + i >= num_u8 - 1 {
-								continue 'outer;
-							}
-							result.wrapping_lshr_assign(8).unwrap();
-							if result.clone().resize_to_u8() != u8::MAX {
-								panic!(
-									"\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
-									lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
-								);
-							}
-						}
-					}
-				}
-			}
-			//test inl apints
-			assert_eq!(
-				ApInt::from(u8::MAX)
-					.into_wrapping_mul(&ApInt::from(u8::MAX))
-					.unwrap(),
-				ApInt::from(1u8)
-			);
-			nine_test(2);
-			nine_test(3);
-			nine_test(4);
-			nine_test(7);
-			nine_test(8);
-			//test ext apints
-			nine_test(9);
-			nine_test(16);
-			//5 digits wide
-			nine_test(40);
-			nine_test(63);
-			//non overflowing test
-			let resize = [
-				7usize, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 137, 200, 255,
-				256, 700, 907, 1024, 2018, 2019,
-			];
-			let lhs_shl = [
-				0usize, 1, 0, 1, 4, 7, 4, 10, 13, 0, 31, 25, 7, 17, 32, 50, 0, 64, 249, 8, 777, 0,
-				1000, 0,
-			];
-			let rhs_shl = [
-				0usize, 0, 1, 1, 3, 6, 4, 14, 10, 0, 0, 25, 0, 18, 32, 49, 100, 64, 0, 256, 64,
-				900, 1000, 0,
-			];
-			for (i, _) in resize.iter().enumerate() {
-				let mut lhs = ApInt::from(5u8)
-					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_wrapping_shl(lhs_shl[i])
-					.unwrap();
-				let mut rhs = ApInt::from(11u8)
-					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_wrapping_shl(rhs_shl[i])
-					.unwrap();
-				let mut zero = ApInt::from(0u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
-				let mut one = ApInt::from(1u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
-				let mut expected = ApInt::from(55u8)
-					.into_zero_resize(BitWidth::new(resize[i]).unwrap())
-					.into_wrapping_shl(rhs_shl[i] + lhs_shl[i])
-					.unwrap();
-				assert_eq!(lhs.clone().into_wrapping_mul(&zero).unwrap(), zero);
-				assert_eq!(zero.clone().into_wrapping_mul(&rhs).unwrap(), zero);
-				assert_eq!(lhs.clone().into_wrapping_mul(&one).unwrap(), lhs);
-				assert_eq!(one.clone().into_wrapping_mul(&rhs).unwrap(), rhs);
-				assert_eq!(lhs.clone().into_wrapping_mul(&rhs).unwrap(), expected);
-			}
-			assert_eq!(
-				ApInt::from([0,0,0,0,u64::MAX,0,u64::MAX,u64::MAX])
-				.into_wrapping_mul(&ApInt::from([0,0,0,0,u64::MAX,u64::MAX,0,u64::MAX])).unwrap()
-				,ApInt::from([u64::MAX,0,1,u64::MAX - 3,1,u64::MAX,u64::MAX,1]));
-		}
-	}
+            //multiplication of apints composed of only u8::MAX in their least significant digits
+            //only works for num_u8 > 1
+            fn nine_test(num_u8: usize) {
+                let mut lhs;
+                let mut rhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+                let nine =
+                    ApInt::from(u8::MAX).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+                for rhs_nine in 1..=num_u8 {
+                    rhs.wrapping_shl_assign(8).unwrap();
+                    rhs |= &nine;
+                    lhs = ApInt::from(0u8).into_zero_resize(BitWidth::new(num_u8 * 8).unwrap());
+                    'outer: for lhs_nine in 1..=num_u8 {
+                        lhs.wrapping_shl_assign(8).unwrap();
+                        lhs |= &nine;
+                        //imagine multiplying a string of base 10 nines together.
+                        //It will produce things like 998001, 8991, 98901, 9989001.
+                        //this uses a formula for the number of nines, eights, and zeros except here nine is u8::MAX, eight is u8::MAX - 1, and zero is 0u8
+                        let mut zeros_after_one = if lhs_nine < rhs_nine {
+                            lhs_nine - 1
+                        } else {
+                            rhs_nine - 1
+                        };
+                        let mut nines_before_eight = if lhs_nine > rhs_nine {
+                            lhs_nine - rhs_nine
+                        } else {
+                            rhs_nine - lhs_nine
+                        };
+                        let mut nines_after_eight = if lhs_nine < rhs_nine {
+                            lhs_nine - 1
+                        } else {
+                            rhs_nine - 1
+                        };
+                        let mut result = lhs.clone().into_wrapping_mul(&rhs).unwrap();
+                        assert_eq!(result.clone().resize_to_u8(), 1u8);
+                        for i in 0..zeros_after_one {
+                            if i >= num_u8 - 1 {
+                                continue 'outer;
+                            }
+                            result.wrapping_lshr_assign(8).unwrap();
+                            let temp = result.clone().resize_to_u8();
+                            if temp != 0 {
+                                panic!(
+                                    "\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+                                    lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+                                );
+                            }
+                        }
+                        for i in 0..nines_before_eight {
+                            if zeros_after_one + i >= num_u8 - 1 {
+                                continue 'outer;
+                            }
+                            result.wrapping_lshr_assign(8).unwrap();
+                            assert_eq!(result.clone().resize_to_u8(), u8::MAX);
+                        }
+                        if zeros_after_one + nines_before_eight >= num_u8 - 1 {
+                            continue 'outer;
+                        }
+                        result.wrapping_lshr_assign(8).unwrap();
+                        let temp = result.clone().resize_to_u8();
+                        if temp != u8::MAX - 1 {
+                            panic!(
+                                "\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+                                lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+                            );
+                        }
+                        for i in 0..nines_after_eight {
+                            if 1 + zeros_after_one + nines_before_eight + i >= num_u8 - 1 {
+                                continue 'outer;
+                            }
+                            result.wrapping_lshr_assign(8).unwrap();
+                            if result.clone().resize_to_u8() != u8::MAX {
+                                panic!(
+                                    "\nlhs_nine:{}\nrhs_nine:{}\nresult:{:?}\nzeros_after_one:{}\nnines_before_eight:{}\nnines_after_eight:{}\n",
+                                    lhs_nine, rhs_nine, result,zeros_after_one,nines_before_eight,nines_after_eight
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            //test inl apints
+            assert_eq!(
+                ApInt::from(u8::MAX)
+                    .into_wrapping_mul(&ApInt::from(u8::MAX))
+                    .unwrap(),
+                ApInt::from(1u8)
+            );
+            nine_test(2);
+            nine_test(3);
+            nine_test(4);
+            nine_test(7);
+            nine_test(8);
+            //test ext apints
+            nine_test(9);
+            nine_test(16);
+            //5 digits wide
+            nine_test(40);
+            nine_test(63);
+            //non overflowing test
+            let resize = [
+                7usize, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 137, 200, 255,
+                256, 700, 907, 1024, 2018, 2019,
+            ];
+            let lhs_shl = [
+                0usize, 1, 0, 1, 4, 7, 4, 10, 13, 0, 31, 25, 7, 17, 32, 50, 0, 64, 249, 8, 777, 0,
+                1000, 0,
+            ];
+            let rhs_shl = [
+                0usize, 0, 1, 1, 3, 6, 4, 14, 10, 0, 0, 25, 0, 18, 32, 49, 100, 64, 0, 256, 64,
+                900, 1000, 0,
+            ];
+            for (i, _) in resize.iter().enumerate() {
+                let mut lhs = ApInt::from(5u8)
+                    .into_zero_resize(BitWidth::new(resize[i]).unwrap())
+                    .into_wrapping_shl(lhs_shl[i])
+                    .unwrap();
+                let mut rhs = ApInt::from(11u8)
+                    .into_zero_resize(BitWidth::new(resize[i]).unwrap())
+                    .into_wrapping_shl(rhs_shl[i])
+                    .unwrap();
+                let mut zero = ApInt::from(0u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
+                let mut one = ApInt::from(1u8).into_zero_resize(BitWidth::new(resize[i]).unwrap());
+                let mut expected = ApInt::from(55u8)
+                    .into_zero_resize(BitWidth::new(resize[i]).unwrap())
+                    .into_wrapping_shl(rhs_shl[i] + lhs_shl[i])
+                    .unwrap();
+                assert_eq!(lhs.clone().into_wrapping_mul(&zero).unwrap(), zero);
+                assert_eq!(zero.clone().into_wrapping_mul(&rhs).unwrap(), zero);
+                assert_eq!(lhs.clone().into_wrapping_mul(&one).unwrap(), lhs);
+                assert_eq!(one.clone().into_wrapping_mul(&rhs).unwrap(), rhs);
+                assert_eq!(lhs.clone().into_wrapping_mul(&rhs).unwrap(), expected);
+            }
+            assert_eq!(
+                ApInt::from([0,0,0,0,u64::MAX,0,u64::MAX,u64::MAX])
+                .into_wrapping_mul(&ApInt::from([0,0,0,0,u64::MAX,u64::MAX,0,u64::MAX])).unwrap()
+                ,ApInt::from([u64::MAX,0,1,u64::MAX - 3,1,u64::MAX,u64::MAX,1]));
+        }
+    }
 
-	mod udiv {
-		use super::*;
+    mod udiv {
+        use super::*;
 
-		#[test]
-		fn simple() {
-			let lhs = ApInt::from(56_u32);
-			let rhs = ApInt::from(7_u32);
-			let result = lhs.into_wrapping_udiv(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(8_u32));
-		}
-	}
+        #[test]
+        fn simple() {
+            let lhs = ApInt::from(56_u32);
+            let rhs = ApInt::from(7_u32);
+            let result = lhs.into_wrapping_udiv(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(8_u32));
+        }
+    }
 
-	mod sdiv {
-		use super::*;
+    mod sdiv {
+        use super::*;
 
-		#[test]
-		fn simple() {
-			let lhs = ApInt::from(72_i32);
-			let rhs = ApInt::from(12_i32);
-			let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(6_u32));
-		}
+        #[test]
+        fn simple() {
+            let lhs = ApInt::from(72_i32);
+            let rhs = ApInt::from(12_i32);
+            let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(6_u32));
+        }
 
-		#[test]
-		fn with_neg() {
-			let lhs = ApInt::from(72_i32);
-			let rhs = ApInt::from(-12_i32);
-			let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(-6_i32));
-		}
-	}
+        #[test]
+        fn with_neg() {
+            let lhs = ApInt::from(72_i32);
+            let rhs = ApInt::from(-12_i32);
+            let result = lhs.into_wrapping_sdiv(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(-6_i32));
+        }
+    }
 
-	mod urem {
-		use super::*;
+    mod urem {
+        use super::*;
 
-		#[test]
-		fn simple() {
-			let lhs = ApInt::from(15_u32);
-			let rhs = ApInt::from(4_u32);
-			let result = lhs.into_wrapping_urem(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(3_u32));
-		}
-	}
+        #[test]
+        fn simple() {
+            let lhs = ApInt::from(15_u32);
+            let rhs = ApInt::from(4_u32);
+            let result = lhs.into_wrapping_urem(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(3_u32));
+        }
+    }
 
-	mod srem {
-		use super::*;
+    mod srem {
+        use super::*;
 
-		#[test]
-		fn simple() {
-			let lhs = ApInt::from(23_i32);
-			let rhs = ApInt::from(7_i32);
-			let result = lhs.into_wrapping_srem(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(2_u32));
-		}
+        #[test]
+        fn simple() {
+            let lhs = ApInt::from(23_i32);
+            let rhs = ApInt::from(7_i32);
+            let result = lhs.into_wrapping_srem(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(2_u32));
+        }
 
-		#[test]
-		fn with_neg() {
-			let lhs = ApInt::from(-23_i32);
-			let rhs = ApInt::from(7_i32);
-			let result = lhs.into_wrapping_srem(&rhs).unwrap();
-			assert_eq!(result, ApInt::from(-2_i32));
-		}
-	}
+        #[test]
+        fn with_neg() {
+            let lhs = ApInt::from(-23_i32);
+            let rhs = ApInt::from(7_i32);
+            let result = lhs.into_wrapping_srem(&rhs).unwrap();
+            assert_eq!(result, ApInt::from(-2_i32));
+        }
+    }
 
 }

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -3,8 +3,8 @@ use digit::{Bit};
 use digit;
 use errors::{Result};
 use apint::utils::{
-	DataAccess,
-	DataAccessMut
+    DataAccess,
+    DataAccessMut
 };
 use bitpos::{BitPos};
 use traits::{Width};
@@ -12,302 +12,302 @@ use checks;
 use utils::{try_forward_bin_mut_impl, forward_mut_impl};
 
 use std::ops::{
-	Not,
-	BitAnd,
-	BitOr,
-	BitXor,
-	BitAndAssign,
-	BitOrAssign,
-	BitXorAssign
+    Not,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitAndAssign,
+    BitOrAssign,
+    BitXorAssign
 };
 
 /// # Bitwise Operations
 impl ApInt {
-	/// Flips all bits of `self` and returns the result.
-	pub fn into_bitnot(self) -> Self {
-		forward_mut_impl(self, ApInt::bitnot)
-	}
+    /// Flips all bits of `self` and returns the result.
+    pub fn into_bitnot(self) -> Self {
+        forward_mut_impl(self, ApInt::bitnot)
+    }
 
-	/// Flip all bits of this `ApInt` inplace.
-	pub fn bitnot(&mut self) {
-		self.modify_digits(|digit| digit.not_inplace());
-		self.clear_unused_bits();
-	}
+    /// Flip all bits of this `ApInt` inplace.
+    pub fn bitnot(&mut self) {
+        self.modify_digits(|digit| digit.not_inplace());
+        self.clear_unused_bits();
+    }
 
-	/// Tries to bit-and assign this `ApInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitand(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::bitand_assign)
-	}
+    /// Tries to bit-and assign this `ApInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitand(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::bitand_assign)
+    }
 
-	/// Bit-and assigns all bits of this `ApInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitand_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		self.modify_zipped_digits(rhs, |l, r| *l &= r)
-	}
+    /// Bit-and assigns all bits of this `ApInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitand_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        self.modify_zipped_digits(rhs, |l, r| *l &= r)
+    }
 
-	/// Tries to bit-and assign this `ApInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitor(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::bitor_assign)
-	}
+    /// Tries to bit-and assign this `ApInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitor(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::bitor_assign)
+    }
 
-	/// Bit-or assigns all bits of this `ApInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitor_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		self.modify_zipped_digits(rhs, |l, r| *l |= r)
-	}
+    /// Bit-or assigns all bits of this `ApInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitor_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        self.modify_zipped_digits(rhs, |l, r| *l |= r)
+    }
 
-	/// Tries to bit-xor assign this `ApInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitxor(self, rhs: &ApInt) -> Result<ApInt> {
-		try_forward_bin_mut_impl(self, rhs, ApInt::bitxor_assign)
-	}
+    /// Tries to bit-xor assign this `ApInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitxor(self, rhs: &ApInt) -> Result<ApInt> {
+        try_forward_bin_mut_impl(self, rhs, ApInt::bitxor_assign)
+    }
 
-	/// Bit-xor assigns all bits of this `ApInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitxor_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		self.modify_zipped_digits(rhs, |l, r| *l ^= r)
-	}
+    /// Bit-xor assigns all bits of this `ApInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitxor_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        self.modify_zipped_digits(rhs, |l, r| *l ^= r)
+    }
 }
 
 /// # Bitwise Access
 impl ApInt {
-	/// Returns the bit at the given bit position `pos`.
-	/// 
-	/// This returns
-	/// 
-	/// - `Bit::Set` if the bit at `pos` is `1`
-	/// - `Bit::Unset` otherwise
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `ApInt`.
-	pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		match self.access_data() {
-			DataAccess::Inl(digit) => digit.get(pos),
-			DataAccess::Ext(digits) => {
-				let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
-				digits[digit_pos].get(bit_pos)
-			}
-		}
-	}
+    /// Returns the bit at the given bit position `pos`.
+    /// 
+    /// This returns
+    /// 
+    /// - `Bit::Set` if the bit at `pos` is `1`
+    /// - `Bit::Unset` otherwise
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `ApInt`.
+    pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        match self.access_data() {
+            DataAccess::Inl(digit) => digit.get(pos),
+            DataAccess::Ext(digits) => {
+                let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
+                digits[digit_pos].get(bit_pos)
+            }
+        }
+    }
 
-	/// Sets the bit at the given bit position `pos` to one (`1`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `ApInt`.
-	pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => digit.set(pos),
-			DataAccessMut::Ext(digits) => {
-				let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
-				digits[digit_pos].set(bit_pos)
-			}
-		}
-	}
+    /// Sets the bit at the given bit position `pos` to one (`1`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `ApInt`.
+    pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => digit.set(pos),
+            DataAccessMut::Ext(digits) => {
+                let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
+                digits[digit_pos].set(bit_pos)
+            }
+        }
+    }
 
-	/// Sets the bit at the given bit position `pos` to zero (`0`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `ApInt`.
-	pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => digit.unset(pos),
-			DataAccessMut::Ext(digits) => {
-				let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
-				digits[digit_pos].unset(bit_pos)
-			}
-		}
-	}
+    /// Sets the bit at the given bit position `pos` to zero (`0`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `ApInt`.
+    pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => digit.unset(pos),
+            DataAccessMut::Ext(digits) => {
+                let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
+                digits[digit_pos].unset(bit_pos)
+            }
+        }
+    }
 
-	/// Flips the bit at the given bit position `pos`.
-	/// 
-	/// # Note
-	/// 
-	/// - If the bit at the given position was `0` it will be `1`
-	///   after this operation and vice versa.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `ApInt`.
-	pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => digit.flip(pos),
-			DataAccessMut::Ext(digits) => {
-				let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
-				digits[digit_pos].flip(bit_pos)
-			}
-		}
-	}
+    /// Flips the bit at the given bit position `pos`.
+    /// 
+    /// # Note
+    /// 
+    /// - If the bit at the given position was `0` it will be `1`
+    ///   after this operation and vice versa.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `ApInt`.
+    pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => digit.flip(pos),
+            DataAccessMut::Ext(digits) => {
+                let (digit_pos, bit_pos) = pos.to_digit_and_bit_pos();
+                digits[digit_pos].flip(bit_pos)
+            }
+        }
+    }
 
-	/// Sets all bits of this `ApInt` to one (`1`).
-	pub fn set_all(&mut self) {
-		self.modify_digits(|digit| digit.set_all());
-		self.clear_unused_bits();
-	}
+    /// Sets all bits of this `ApInt` to one (`1`).
+    pub fn set_all(&mut self) {
+        self.modify_digits(|digit| digit.set_all());
+        self.clear_unused_bits();
+    }
 
-	/// Returns``true` if all bits in the `ApInt` are set.
-	pub fn is_all_set(&self) -> bool {
-		let (msb, rest) = self.split_most_significant_digit();
-		if let Some(excess_bits) = self.width().excess_bits() {
-			if msb.repr().count_ones() as usize != excess_bits {
-				return false
-			}
-		}
-		rest.iter().all(|d| d.is_all_set())
-	}
+    /// Returns``true` if all bits in the `ApInt` are set.
+    pub fn is_all_set(&self) -> bool {
+        let (msb, rest) = self.split_most_significant_digit();
+        if let Some(excess_bits) = self.width().excess_bits() {
+            if msb.repr().count_ones() as usize != excess_bits {
+                return false
+            }
+        }
+        rest.iter().all(|d| d.is_all_set())
+    }
 
-	/// Sets all bits of this `ApInt` to zero (`0`).
-	pub fn unset_all(&mut self) {
-		self.modify_digits(|digit| digit.unset_all());
-	}
+    /// Sets all bits of this `ApInt` to zero (`0`).
+    pub fn unset_all(&mut self) {
+        self.modify_digits(|digit| digit.unset_all());
+    }
 
-	/// Returns `true` if all bits in the `ApInt` are unset.
-	pub fn is_all_unset(&self) -> bool {
-		self.is_zero()
-	}
+    /// Returns `true` if all bits in the `ApInt` are unset.
+    pub fn is_all_unset(&self) -> bool {
+        self.is_zero()
+    }
 
-	/// Flips all bits of this `ApInt`.
-	pub fn flip_all(&mut self) {
-		// TODO: remove since equal to ApInt::bitnot_assign
-		self.modify_digits(|digit| digit.flip_all());
-		self.clear_unused_bits();
-	}
+    /// Flips all bits of this `ApInt`.
+    pub fn flip_all(&mut self) {
+        // TODO: remove since equal to ApInt::bitnot_assign
+        self.modify_digits(|digit| digit.flip_all());
+        self.clear_unused_bits();
+    }
 
-	/// Returns the sign bit of this `ApInt`.
-	/// 
-	/// **Note:** This is equal to the most significant bit of this `ApInt`.
-	pub fn sign_bit(&self) -> Bit {
-		self.most_significant_bit()
-	}
+    /// Returns the sign bit of this `ApInt`.
+    /// 
+    /// **Note:** This is equal to the most significant bit of this `ApInt`.
+    pub fn sign_bit(&self) -> Bit {
+        self.most_significant_bit()
+    }
 
-	/// Sets the sign bit of this `ApInt` to one (`1`).
-	pub fn set_sign_bit(&mut self) {
-		let sign_bit_pos = self.width().sign_bit_pos();
-		self.set_bit_at(sign_bit_pos)
-			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-					 for usage in the associated `ApInt` for operating on bits.")
-	}
+    /// Sets the sign bit of this `ApInt` to one (`1`).
+    pub fn set_sign_bit(&mut self) {
+        let sign_bit_pos = self.width().sign_bit_pos();
+        self.set_bit_at(sign_bit_pos)
+            .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+                     for usage in the associated `ApInt` for operating on bits.")
+    }
 
-	/// Sets the sign bit of this `ApInt` to zero (`0`).
-	pub fn unset_sign_bit(&mut self) {
-		let sign_bit_pos = self.width().sign_bit_pos();
-		self.unset_bit_at(sign_bit_pos)
-			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-					 for usage in the associated `ApInt` for operating on bits.")
-	}
+    /// Sets the sign bit of this `ApInt` to zero (`0`).
+    pub fn unset_sign_bit(&mut self) {
+        let sign_bit_pos = self.width().sign_bit_pos();
+        self.unset_bit_at(sign_bit_pos)
+            .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+                     for usage in the associated `ApInt` for operating on bits.")
+    }
 
-	/// Flips the sign bit of this `ApInt`.
-	/// 
-	/// # Note
-	/// 
-	/// - If the sign bit was `0` it will be `1` after this operation and vice versa.
-	/// - Depending on the interpretation of the `ApInt` this
-	///   operation changes its signedness.
-	pub fn flip_sign_bit(&mut self) {
-		let sign_bit_pos = self.width().sign_bit_pos();
-		self.flip_bit_at(sign_bit_pos)
-			.expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
-					 for usage in the associated `ApInt` for operating on bits.")
-	}
+    /// Flips the sign bit of this `ApInt`.
+    /// 
+    /// # Note
+    /// 
+    /// - If the sign bit was `0` it will be `1` after this operation and vice versa.
+    /// - Depending on the interpretation of the `ApInt` this
+    ///   operation changes its signedness.
+    pub fn flip_sign_bit(&mut self) {
+        let sign_bit_pos = self.width().sign_bit_pos();
+        self.flip_bit_at(sign_bit_pos)
+            .expect("`BitWidth::sign_bit_pos` always returns a valid `BitPos`
+                     for usage in the associated `ApInt` for operating on bits.")
+    }
 }
 
 /// # Bitwise utility methods.
 impl ApInt {
-	/// Returns the number of ones in the binary representation of this `ApInt`.
-	pub fn count_ones(&self) -> usize {
-		self.as_digit_slice()
-			.into_iter()
-			.map(|d| d.repr().count_ones() as usize)
-			.sum::<usize>()
-	}
+    /// Returns the number of ones in the binary representation of this `ApInt`.
+    pub fn count_ones(&self) -> usize {
+        self.as_digit_slice()
+            .into_iter()
+            .map(|d| d.repr().count_ones() as usize)
+            .sum::<usize>()
+    }
 
-	/// Returns the number of zeros in the binary representation of this `ApInt`.
-	pub fn count_zeros(&self) -> usize {
-		let zeros = self.as_digit_slice()
-			.into_iter()
-			.map(|d| d.repr().count_zeros() as usize)
-			.sum::<usize>();
-		// Since `ApInt` instances with width's that are no powers of two
-		// have unused excess bits that are always zero we need to cut them off
-		// for a correct implementation of this operation.
-		zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
-	}
+    /// Returns the number of zeros in the binary representation of this `ApInt`.
+    pub fn count_zeros(&self) -> usize {
+        let zeros = self.as_digit_slice()
+            .into_iter()
+            .map(|d| d.repr().count_zeros() as usize)
+            .sum::<usize>();
+        // Since `ApInt` instances with width's that are no powers of two
+        // have unused excess bits that are always zero we need to cut them off
+        // for a correct implementation of this operation.
+        zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
+    }
 
-	/// Returns the number of leading zeros in the binary representation of this `ApInt`.
-	pub fn leading_zeros(&self) -> usize {
-		let mut zeros = 0;
-		for d in self.as_digit_slice().into_iter().rev() {
-			let leading_zeros = d.repr().leading_zeros() as usize;
-			zeros += leading_zeros;
-			if leading_zeros != digit::BITS {
-				break;
-			}
-		}
-		zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
-	}
+    /// Returns the number of leading zeros in the binary representation of this `ApInt`.
+    pub fn leading_zeros(&self) -> usize {
+        let mut zeros = 0;
+        for d in self.as_digit_slice().into_iter().rev() {
+            let leading_zeros = d.repr().leading_zeros() as usize;
+            zeros += leading_zeros;
+            if leading_zeros != digit::BITS {
+                break;
+            }
+        }
+        zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
+    }
 
-	/// Returns the number of trailing zeros in the binary representation of this `ApInt`.
-	pub fn trailing_zeros(&self) -> usize {
-		let mut zeros = 0;
-		for d in self.as_digit_slice() {
-			let trailing_zeros = d.repr().trailing_zeros() as usize;
-			zeros += trailing_zeros;
-			if trailing_zeros != digit::BITS {
-				break;
-			}
-		}
-		if zeros >= self.width().to_usize() {
-			zeros -= digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS);
-		}
-		zeros
-	}
+    /// Returns the number of trailing zeros in the binary representation of this `ApInt`.
+    pub fn trailing_zeros(&self) -> usize {
+        let mut zeros = 0;
+        for d in self.as_digit_slice() {
+            let trailing_zeros = d.repr().trailing_zeros() as usize;
+            zeros += trailing_zeros;
+            if trailing_zeros != digit::BITS {
+                break;
+            }
+        }
+        if zeros >= self.width().to_usize() {
+            zeros -= digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS);
+        }
+        zeros
+    }
 }
 
 //  ===========================================================================
@@ -315,11 +315,11 @@ impl ApInt {
 //  ===========================================================================
 
 impl Not for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn not(self) -> Self::Output {
-		forward_mut_impl(self, ApInt::bitnot)
-	}
+    fn not(self) -> Self::Output {
+        forward_mut_impl(self, ApInt::bitnot)
+    }
 }
 
 //  ===========================================================================
@@ -327,27 +327,27 @@ impl Not for ApInt {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a ApInt> for &'b mut ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitand(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -355,27 +355,27 @@ impl<'a, 'b> BitAnd<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a ApInt> for &'b mut ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitor(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -383,27 +383,27 @@ impl<'a, 'b> BitOr<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a ApInt> for ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-		self.into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+        self.into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a ApInt> for &'b ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
-	type Output = ApInt;
+    type Output = ApInt;
 
-	fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a ApInt) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -411,190 +411,190 @@ impl<'a, 'b> BitXor<&'a ApInt> for &'b mut ApInt {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a ApInt> for ApInt {
-	fn bitand_assign(&mut self, rhs: &'a ApInt) {
-		self.bitand_assign(rhs).unwrap();
-	}
+    fn bitand_assign(&mut self, rhs: &'a ApInt) {
+        self.bitand_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitOrAssign<&'a ApInt> for ApInt {
-	fn bitor_assign(&mut self, rhs: &'a ApInt) {
-		self.bitor_assign(rhs).unwrap();
-	}
+    fn bitor_assign(&mut self, rhs: &'a ApInt) {
+        self.bitor_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitXorAssign<&'a ApInt> for ApInt {
-	fn bitxor_assign(&mut self, rhs: &'a ApInt) {
-		self.bitxor_assign(rhs).unwrap();
-	}
+    fn bitxor_assign(&mut self, rhs: &'a ApInt) {
+        self.bitxor_assign(rhs).unwrap();
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	use bitwidth::{BitWidth};
+    use bitwidth::{BitWidth};
 
-	#[test]
-	fn count_ones() {
-		assert_eq!(ApInt::zero(BitWidth::w1()).count_ones(), 0);
-		assert_eq!(ApInt::zero(BitWidth::w8()).count_ones(), 0);
-		assert_eq!(ApInt::zero(BitWidth::w16()).count_ones(), 0);
-		assert_eq!(ApInt::zero(BitWidth::w32()).count_ones(), 0);
-		assert_eq!(ApInt::zero(BitWidth::w64()).count_ones(), 0);
-		assert_eq!(ApInt::zero(BitWidth::w128()).count_ones(), 0);
+    #[test]
+    fn count_ones() {
+        assert_eq!(ApInt::zero(BitWidth::w1()).count_ones(), 0);
+        assert_eq!(ApInt::zero(BitWidth::w8()).count_ones(), 0);
+        assert_eq!(ApInt::zero(BitWidth::w16()).count_ones(), 0);
+        assert_eq!(ApInt::zero(BitWidth::w32()).count_ones(), 0);
+        assert_eq!(ApInt::zero(BitWidth::w64()).count_ones(), 0);
+        assert_eq!(ApInt::zero(BitWidth::w128()).count_ones(), 0);
 
-		assert_eq!(ApInt::one(BitWidth::w1()).count_ones(), 1);
-		assert_eq!(ApInt::one(BitWidth::w8()).count_ones(), 1);
-		assert_eq!(ApInt::one(BitWidth::w16()).count_ones(), 1);
-		assert_eq!(ApInt::one(BitWidth::w32()).count_ones(), 1);
-		assert_eq!(ApInt::one(BitWidth::w64()).count_ones(), 1);
-		assert_eq!(ApInt::one(BitWidth::w128()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w1()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w8()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w16()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w32()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w64()).count_ones(), 1);
+        assert_eq!(ApInt::one(BitWidth::w128()).count_ones(), 1);
 
-		assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_ones(), 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_ones(), 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_ones(), 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_ones(), 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_ones(), 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_ones(), 1);
 
-		assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_ones(), 0);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_ones(), 8 - 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_ones(), 16 - 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_ones(), 32 - 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_ones(), 64 - 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_ones(), 128 - 1);
-	}
+        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_ones(), 0);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_ones(), 8 - 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_ones(), 16 - 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_ones(), 32 - 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_ones(), 64 - 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_ones(), 128 - 1);
+    }
 
-	#[test]
-	fn count_zeros() {
-		assert_eq!(ApInt::zero(BitWidth::w1()).count_zeros(), 1);
-		assert_eq!(ApInt::zero(BitWidth::w8()).count_zeros(), 8);
-		assert_eq!(ApInt::zero(BitWidth::w16()).count_zeros(), 16);
-		assert_eq!(ApInt::zero(BitWidth::w32()).count_zeros(), 32);
-		assert_eq!(ApInt::zero(BitWidth::w64()).count_zeros(), 64);
-		assert_eq!(ApInt::zero(BitWidth::w128()).count_zeros(), 128);
+    #[test]
+    fn count_zeros() {
+        assert_eq!(ApInt::zero(BitWidth::w1()).count_zeros(), 1);
+        assert_eq!(ApInt::zero(BitWidth::w8()).count_zeros(), 8);
+        assert_eq!(ApInt::zero(BitWidth::w16()).count_zeros(), 16);
+        assert_eq!(ApInt::zero(BitWidth::w32()).count_zeros(), 32);
+        assert_eq!(ApInt::zero(BitWidth::w64()).count_zeros(), 64);
+        assert_eq!(ApInt::zero(BitWidth::w128()).count_zeros(), 128);
 
-		assert_eq!(ApInt::one(BitWidth::w1()).count_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w8()).count_zeros(), 8 - 1);
-		assert_eq!(ApInt::one(BitWidth::w16()).count_zeros(), 16 - 1);
-		assert_eq!(ApInt::one(BitWidth::w32()).count_zeros(), 32 - 1);
-		assert_eq!(ApInt::one(BitWidth::w64()).count_zeros(), 64 - 1);
-		assert_eq!(ApInt::one(BitWidth::w128()).count_zeros(), 128 - 1);
+        assert_eq!(ApInt::one(BitWidth::w1()).count_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w8()).count_zeros(), 8 - 1);
+        assert_eq!(ApInt::one(BitWidth::w16()).count_zeros(), 16 - 1);
+        assert_eq!(ApInt::one(BitWidth::w32()).count_zeros(), 32 - 1);
+        assert_eq!(ApInt::one(BitWidth::w64()).count_zeros(), 64 - 1);
+        assert_eq!(ApInt::one(BitWidth::w128()).count_zeros(), 128 - 1);
 
-		assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_zeros(), 8 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_zeros(), 16 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_zeros(), 32 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_zeros(), 64 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_zeros(), 128 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_zeros(), 8 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_zeros(), 16 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_zeros(), 32 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_zeros(), 64 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_zeros(), 128 - 1);
 
-		assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_zeros(), 1);
-	}
+        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_zeros(), 1);
+    }
 
-	#[test]
-	fn leading_zeros() {
-		assert_eq!(ApInt::zero(BitWidth::w1()).leading_zeros(), 1);
-		assert_eq!(ApInt::zero(BitWidth::w8()).leading_zeros(), 8);
-		assert_eq!(ApInt::zero(BitWidth::w16()).leading_zeros(), 16);
-		assert_eq!(ApInt::zero(BitWidth::w32()).leading_zeros(), 32);
-		assert_eq!(ApInt::zero(BitWidth::w64()).leading_zeros(), 64);
-		assert_eq!(ApInt::zero(BitWidth::w128()).leading_zeros(), 128);
+    #[test]
+    fn leading_zeros() {
+        assert_eq!(ApInt::zero(BitWidth::w1()).leading_zeros(), 1);
+        assert_eq!(ApInt::zero(BitWidth::w8()).leading_zeros(), 8);
+        assert_eq!(ApInt::zero(BitWidth::w16()).leading_zeros(), 16);
+        assert_eq!(ApInt::zero(BitWidth::w32()).leading_zeros(), 32);
+        assert_eq!(ApInt::zero(BitWidth::w64()).leading_zeros(), 64);
+        assert_eq!(ApInt::zero(BitWidth::w128()).leading_zeros(), 128);
 
-		assert_eq!(ApInt::one(BitWidth::w1()).leading_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w8()).leading_zeros(), 8 - 1);
-		assert_eq!(ApInt::one(BitWidth::w16()).leading_zeros(), 16 - 1);
-		assert_eq!(ApInt::one(BitWidth::w32()).leading_zeros(), 32 - 1);
-		assert_eq!(ApInt::one(BitWidth::w64()).leading_zeros(), 64 - 1);
-		assert_eq!(ApInt::one(BitWidth::w128()).leading_zeros(), 128 - 1);
+        assert_eq!(ApInt::one(BitWidth::w1()).leading_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w8()).leading_zeros(), 8 - 1);
+        assert_eq!(ApInt::one(BitWidth::w16()).leading_zeros(), 16 - 1);
+        assert_eq!(ApInt::one(BitWidth::w32()).leading_zeros(), 32 - 1);
+        assert_eq!(ApInt::one(BitWidth::w64()).leading_zeros(), 64 - 1);
+        assert_eq!(ApInt::one(BitWidth::w128()).leading_zeros(), 128 - 1);
 
-		assert_eq!(ApInt::signed_min_value(BitWidth::w1()).leading_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w8()).leading_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w16()).leading_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w32()).leading_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w64()).leading_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w128()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).leading_zeros(), 0);
 
-		assert_eq!(ApInt::signed_max_value(BitWidth::w1()).leading_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w8()).leading_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w16()).leading_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w32()).leading_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w64()).leading_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w128()).leading_zeros(), 1);
-	}
+        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).leading_zeros(), 1);
+    }
 
-	#[test]
-	fn trailing_zeros() {
-		assert_eq!(ApInt::zero(BitWidth::w1()).trailing_zeros(), 1);
-		assert_eq!(ApInt::zero(BitWidth::w8()).trailing_zeros(), 8);
-		assert_eq!(ApInt::zero(BitWidth::w16()).trailing_zeros(), 16);
-		assert_eq!(ApInt::zero(BitWidth::w32()).trailing_zeros(), 32);
-		assert_eq!(ApInt::zero(BitWidth::w64()).trailing_zeros(), 64);
-		assert_eq!(ApInt::zero(BitWidth::w128()).trailing_zeros(), 128);
+    #[test]
+    fn trailing_zeros() {
+        assert_eq!(ApInt::zero(BitWidth::w1()).trailing_zeros(), 1);
+        assert_eq!(ApInt::zero(BitWidth::w8()).trailing_zeros(), 8);
+        assert_eq!(ApInt::zero(BitWidth::w16()).trailing_zeros(), 16);
+        assert_eq!(ApInt::zero(BitWidth::w32()).trailing_zeros(), 32);
+        assert_eq!(ApInt::zero(BitWidth::w64()).trailing_zeros(), 64);
+        assert_eq!(ApInt::zero(BitWidth::w128()).trailing_zeros(), 128);
 
-		assert_eq!(ApInt::one(BitWidth::w1()).trailing_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w8()).trailing_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w16()).trailing_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w32()).trailing_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w64()).trailing_zeros(), 0);
-		assert_eq!(ApInt::one(BitWidth::w128()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w1()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w8()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w16()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w32()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w64()).trailing_zeros(), 0);
+        assert_eq!(ApInt::one(BitWidth::w128()).trailing_zeros(), 0);
 
-		assert_eq!(ApInt::signed_min_value(BitWidth::w1()).trailing_zeros(), 0);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w8()).trailing_zeros(), 8 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w16()).trailing_zeros(), 16 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w32()).trailing_zeros(), 32 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w64()).trailing_zeros(), 64 - 1);
-		assert_eq!(ApInt::signed_min_value(BitWidth::w128()).trailing_zeros(), 128 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).trailing_zeros(), 8 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).trailing_zeros(), 16 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).trailing_zeros(), 32 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).trailing_zeros(), 64 - 1);
+        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).trailing_zeros(), 128 - 1);
 
-		assert_eq!(ApInt::signed_max_value(BitWidth::w1()).trailing_zeros(), 1);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w8()).trailing_zeros(), 0);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w16()).trailing_zeros(), 0);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w32()).trailing_zeros(), 0);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w64()).trailing_zeros(), 0);
-		assert_eq!(ApInt::signed_max_value(BitWidth::w128()).trailing_zeros(), 0);
-	}
+        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).trailing_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).trailing_zeros(), 0);
+    }
 
-	mod is_all_set {
-		use super::*;
+    mod is_all_set {
+        use super::*;
 
-		#[test]
-		fn simple_false() {
-			let input = ApInt::from(0b0001_1011_0110_0111_u16);
-			assert_eq!(input.width(), BitWidth::w16());
-			assert_eq!(input.count_ones(), 9);
-			assert!(!input.is_all_set());
-		}
+        #[test]
+        fn simple_false() {
+            let input = ApInt::from(0b0001_1011_0110_0111_u16);
+            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.count_ones(), 9);
+            assert!(!input.is_all_set());
+        }
 
-		#[test]
-		fn simple_true() {
-			let input = ApInt::all_set(BitWidth::w32());
-			assert_eq!(input.width(), BitWidth::w32());
-			assert_eq!(input.count_ones(), 32);
-			assert!(input.is_all_set());
-		}
-	}
+        #[test]
+        fn simple_true() {
+            let input = ApInt::all_set(BitWidth::w32());
+            assert_eq!(input.width(), BitWidth::w32());
+            assert_eq!(input.count_ones(), 32);
+            assert!(input.is_all_set());
+        }
+    }
 
-	mod is_all_unset {
-		use super::*;
+    mod is_all_unset {
+        use super::*;
 
-		#[test]
-		fn simple_false() {
-			let input = ApInt::from(0b0001_1011_0110_0111_u16);
-			assert_eq!(input.width(), BitWidth::w16());
-			assert_eq!(input.count_ones(), 9);
-			assert_eq!(input.is_zero(), input.is_all_unset());
-		}
+        #[test]
+        fn simple_false() {
+            let input = ApInt::from(0b0001_1011_0110_0111_u16);
+            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.count_ones(), 9);
+            assert_eq!(input.is_zero(), input.is_all_unset());
+        }
 
-		#[test]
-		fn simple_true() {
-			let input = ApInt::all_unset(BitWidth::w32());
-			assert_eq!(input.width(), BitWidth::w32());
-			assert_eq!(input.count_ones(), 0);
-			assert_eq!(input.is_zero(), input.is_all_unset());
-		}
-	}
+        #[test]
+        fn simple_true() {
+            let input = ApInt::all_unset(BitWidth::w32());
+            assert_eq!(input.width(), BitWidth::w32());
+            assert_eq!(input.count_ones(), 0);
+            assert_eq!(input.is_zero(), input.is_all_unset());
+        }
+    }
 }

--- a/src/apint/casting.rs
+++ b/src/apint/casting.rs
@@ -9,791 +9,791 @@ use traits::Width;
 use utils::{try_forward_bin_mut_impl, forward_bin_mut_impl};
 
 impl Clone for ApInt {
-	fn clone(&self) -> Self {
-		match self.storage() {
-			Storage::Inl => {
-				ApInt::new_inl(self.len, unsafe{ self.data.inl })
-			}
-			Storage::Ext => {
-				use std::mem;
-				let req_digits = self.len_digits();
-				let mut buffer = self.as_digit_slice()
-					.to_vec()
-					.into_boxed_slice();
-				assert_eq!(buffer.len(), req_digits);
-				let ptr_buffer = buffer.as_mut_ptr();
-				mem::forget(buffer);
-				unsafe{ ApInt::new_ext(self.len, ptr_buffer) }
-			}
-		}
-	}
+    fn clone(&self) -> Self {
+        match self.storage() {
+            Storage::Inl => {
+                ApInt::new_inl(self.len, unsafe{ self.data.inl })
+            }
+            Storage::Ext => {
+                use std::mem;
+                let req_digits = self.len_digits();
+                let mut buffer = self.as_digit_slice()
+                    .to_vec()
+                    .into_boxed_slice();
+                assert_eq!(buffer.len(), req_digits);
+                let ptr_buffer = buffer.as_mut_ptr();
+                mem::forget(buffer);
+                unsafe{ ApInt::new_ext(self.len, ptr_buffer) }
+            }
+        }
+    }
 }
 
 /// # Assignment Operations
 impl ApInt {
-	/// Assigns `rhs` to this `ApInt`.
-	///
-	/// This mutates digits and may affect the bitwidth of `self`
-	/// which **might result in an expensive operations**.
-	///
-	/// After this operation `rhs` and `self` are equal to each other.
-	pub fn assign(&mut self, rhs: &ApInt) {
-		if self.len_digits() == rhs.len_digits() {
-			// If `self` and `rhs` require the same amount of digits
-			// for their representation we can simply utilize `ApInt`
-			// invariants and basically `memcpy` from `rhs` to `self`.
-			// Afterwards a simple adjustment of the length is sufficient.
-			// (At the end of this method.)
-			self.as_digit_slice_mut()
-			    .copy_from_slice(rhs.as_digit_slice());
-		}
-		else {
-			// In this case `rhs` and `self` require an unequal amount
-			// of digits for their representation which means that the
-			// digits that may be allocated by `self` must be dropped.
-			//
-			// Note that `ApInt::drop_digits` only deallocates if possible.
-			unsafe{ self.drop_digits(); }
+    /// Assigns `rhs` to this `ApInt`.
+    ///
+    /// This mutates digits and may affect the bitwidth of `self`
+    /// which **might result in an expensive operations**.
+    ///
+    /// After this operation `rhs` and `self` are equal to each other.
+    pub fn assign(&mut self, rhs: &ApInt) {
+        if self.len_digits() == rhs.len_digits() {
+            // If `self` and `rhs` require the same amount of digits
+            // for their representation we can simply utilize `ApInt`
+            // invariants and basically `memcpy` from `rhs` to `self`.
+            // Afterwards a simple adjustment of the length is sufficient.
+            // (At the end of this method.)
+            self.as_digit_slice_mut()
+                .copy_from_slice(rhs.as_digit_slice());
+        }
+        else {
+            // In this case `rhs` and `self` require an unequal amount
+            // of digits for their representation which means that the
+            // digits that may be allocated by `self` must be dropped.
+            //
+            // Note that `ApInt::drop_digits` only deallocates if possible.
+            unsafe{ self.drop_digits(); }
 
-			match rhs.storage() {
-				Storage::Inl => {
-					// If `rhs` is a small `ApInt` we can simply update
-					// the `digit` field of `self` and we are done.
-					self.data.inl = unsafe{ rhs.data.inl };
-				}
-				Storage::Ext => {
-					// If `rhs` is a large heap-allocated `ApInt` we first
-					// need to expensively clone its buffer and feed it to `self`.
-					let cloned = rhs.clone();
-					self.data.ext = unsafe{ cloned.data.ext };
-					use std::mem;
-					mem::forget(cloned);
-				}
-			}
-		}
-		// Since all cases may need bit width adjustment we outsourced it
-		// to the end of this method.
-		self.len = rhs.len;
-	}
+            match rhs.storage() {
+                Storage::Inl => {
+                    // If `rhs` is a small `ApInt` we can simply update
+                    // the `digit` field of `self` and we are done.
+                    self.data.inl = unsafe{ rhs.data.inl };
+                }
+                Storage::Ext => {
+                    // If `rhs` is a large heap-allocated `ApInt` we first
+                    // need to expensively clone its buffer and feed it to `self`.
+                    let cloned = rhs.clone();
+                    self.data.ext = unsafe{ cloned.data.ext };
+                    use std::mem;
+                    mem::forget(cloned);
+                }
+            }
+        }
+        // Since all cases may need bit width adjustment we outsourced it
+        // to the end of this method.
+        self.len = rhs.len;
+    }
 
-	/// Strictly assigns `rhs` to this `ApInt`.
-	/// 
-	/// After this operation `rhs` and `self` are equal to each other.
-	/// 
-	/// **Note:** Strict assigns protect against mutating the bit width
-	/// of `self` and thus return an error instead of executing a probably
-	/// expensive `assign` operation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `rhs` and `self` have unmatching bit widths.
-	pub fn strict_assign(&mut self, rhs: &ApInt) -> Result<()> {
-		if self.width() != rhs.width() {
-			return Error::unmatching_bitwidths(self.width(), rhs.width())
-				.with_annotation(format!(
-					"Occured while trying to `strict_assign` {:?} to {:?}.", self, rhs))
-				.into()
-		}
-		self.as_digit_slice_mut()
-			.copy_from_slice(rhs.as_digit_slice());
-		Ok(())
-	}
+    /// Strictly assigns `rhs` to this `ApInt`.
+    /// 
+    /// After this operation `rhs` and `self` are equal to each other.
+    /// 
+    /// **Note:** Strict assigns protect against mutating the bit width
+    /// of `self` and thus return an error instead of executing a probably
+    /// expensive `assign` operation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `rhs` and `self` have unmatching bit widths.
+    pub fn strict_assign(&mut self, rhs: &ApInt) -> Result<()> {
+        if self.width() != rhs.width() {
+            return Error::unmatching_bitwidths(self.width(), rhs.width())
+                .with_annotation(format!(
+                    "Occured while trying to `strict_assign` {:?} to {:?}.", self, rhs))
+                .into()
+        }
+        self.as_digit_slice_mut()
+            .copy_from_slice(rhs.as_digit_slice());
+        Ok(())
+    }
 }
 
 /// # Casting: Truncation & Extension
 impl ApInt {
-	/// Tries to truncate this `ApInt` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`truncate`](struct.ApInt.html#method.truncate).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn into_truncate<W>(self, target_width: W) -> Result<ApInt>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, ApInt::truncate)
-	}
+    /// Tries to truncate this `ApInt` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`truncate`](struct.ApInt.html#method.truncate).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn into_truncate<W>(self, target_width: W) -> Result<ApInt>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, ApInt::truncate)
+    }
 
-	/// Tries to truncate this `ApInt` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		let actual_width = self.width();
-		let target_width = target_width.into();
+    /// Tries to truncate this `ApInt` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        let actual_width = self.width();
+        let target_width = target_width.into();
 
-		if target_width == actual_width {
-			return Ok(())
-		}
+        if target_width == actual_width {
+            return Ok(())
+        }
 
-		if target_width > self.width() {
-			return
-				Error::truncation_bitwidth_too_large(target_width, actual_width)
-					.with_annotation(format!(
-						"Cannot truncate `ApInt` with a width of {:?}
-						 to an `ApInt` with a width of {:?} bits. \
-						 Do you mean to extend the instance instead?",
-						actual_width.to_usize(),
-						target_width.to_usize()))
-					.into()
-		}
+        if target_width > self.width() {
+            return
+                Error::truncation_bitwidth_too_large(target_width, actual_width)
+                    .with_annotation(format!(
+                        "Cannot truncate `ApInt` with a width of {:?}
+                         to an `ApInt` with a width of {:?} bits. \
+                         Do you mean to extend the instance instead?",
+                        actual_width.to_usize(),
+                        target_width.to_usize()))
+                    .into()
+        }
 
-		let actual_req_digits = actual_width.required_digits();
-		let target_req_digits = target_width.required_digits();
+        let actual_req_digits = actual_width.required_digits();
+        let target_req_digits = target_width.required_digits();
 
-		if actual_req_digits == target_req_digits {
-			// We can do a cheap truncation, here!
-			// 
-			// For example this could be a truncation from `128` bits
-			// to `100` bits which just has to truncate the bits of the
-			// most significant digits since both bit width require
-			// exactly `2` digits for the representation.
-			// The same applies to all bit widths that require the same
-			// amount of digits for their representation.
-			let excess_width = target_width.excess_bits()
-				.expect("We already filtered cases where `excess_bits` may return `None` \
-					     by requiring that `self.width() > target_width`.");
-			self.most_significant_digit_mut()
-				.truncate_to(excess_width)
-				.expect("Excess bits are guaranteed to be within the bounds for valid \
-					     truncation of a single `Digit`.");
-			self.len = target_width;
-		}
-		else {
-			// We need to copy the digits for a correct truncation, here!
-			// 
-			// For example this could be a truncation from `196` bits
-			// to `100` bits. The former requires `3` digits whereas the 
-			// latter requires only `2`. So allocation of a new sequence
-			// is required since no memory can be reused.
-			// The same applies to all bit widths that require a different
-			// amount of digits for their representation.
-			let mut truncated_copy = {
-				let req_digits = self.digits().take(target_req_digits);
-				ApInt::from_iter(req_digits).unwrap()
-			};
-			// We just truncated with digit precision, not with bit precision.
-			// The next step is to recursively truncate `truncated_digits`
-			// with bit precision.
-			// This will simply call the `then` branch of this method.
-			if truncated_copy.width() != target_width {
-				truncated_copy.truncate(target_width)?;
-			}
-			*self = truncated_copy;
-		}
-		Ok(())
-	}
+        if actual_req_digits == target_req_digits {
+            // We can do a cheap truncation, here!
+            // 
+            // For example this could be a truncation from `128` bits
+            // to `100` bits which just has to truncate the bits of the
+            // most significant digits since both bit width require
+            // exactly `2` digits for the representation.
+            // The same applies to all bit widths that require the same
+            // amount of digits for their representation.
+            let excess_width = target_width.excess_bits()
+                .expect("We already filtered cases where `excess_bits` may return `None` \
+                         by requiring that `self.width() > target_width`.");
+            self.most_significant_digit_mut()
+                .truncate_to(excess_width)
+                .expect("Excess bits are guaranteed to be within the bounds for valid \
+                         truncation of a single `Digit`.");
+            self.len = target_width;
+        }
+        else {
+            // We need to copy the digits for a correct truncation, here!
+            // 
+            // For example this could be a truncation from `196` bits
+            // to `100` bits. The former requires `3` digits whereas the 
+            // latter requires only `2`. So allocation of a new sequence
+            // is required since no memory can be reused.
+            // The same applies to all bit widths that require a different
+            // amount of digits for their representation.
+            let mut truncated_copy = {
+                let req_digits = self.digits().take(target_req_digits);
+                ApInt::from_iter(req_digits).unwrap()
+            };
+            // We just truncated with digit precision, not with bit precision.
+            // The next step is to recursively truncate `truncated_digits`
+            // with bit precision.
+            // This will simply call the `then` branch of this method.
+            if truncated_copy.width() != target_width {
+                truncated_copy.truncate(target_width)?;
+            }
+            *self = truncated_copy;
+        }
+        Ok(())
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Tries to zero-extend this `ApInt` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`zero_extend`](struct.ApInt.html#method.zero_extend).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn into_zero_extend<W>(self, target_width: W) -> Result<ApInt>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, ApInt::zero_extend)
-	}
+    /// Tries to zero-extend this `ApInt` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`zero_extend`](struct.ApInt.html#method.zero_extend).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn into_zero_extend<W>(self, target_width: W) -> Result<ApInt>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, ApInt::zero_extend)
+    }
 
-	/// Tries to zero-extend this `ApInt` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn zero_extend<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		let actual_width = self.width();
-		let target_width = target_width.into();
+    /// Tries to zero-extend this `ApInt` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn zero_extend<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        let actual_width = self.width();
+        let target_width = target_width.into();
 
-		if target_width == actual_width {
-			return Ok(())
-		}
+        if target_width == actual_width {
+            return Ok(())
+        }
 
-		if target_width < actual_width {
-			return Error::extension_bitwidth_too_small(target_width, actual_width)
-				.with_annotation(format!(
-					"Cannot zero-extend bit-width of {:?} to {:?} bits. \
-					 Do you mean to truncate the instance instead?",
-					actual_width, target_width))
-				.into()
-		}
+        if target_width < actual_width {
+            return Error::extension_bitwidth_too_small(target_width, actual_width)
+                .with_annotation(format!(
+                    "Cannot zero-extend bit-width of {:?} to {:?} bits. \
+                     Do you mean to truncate the instance instead?",
+                    actual_width, target_width))
+                .into()
+        }
 
-		let actual_req_digits = actual_width.required_digits();
-		let target_req_digits = target_width.required_digits();
+        let actual_req_digits = actual_width.required_digits();
+        let target_req_digits = target_width.required_digits();
 
-		if actual_req_digits == target_req_digits {
-			// We can do a cheap zero-extension here.
-			// 
-			// In this case we can reuse the heap memory of the consumed `ApInt`.
-			// 
-			// For example when given an `ApInt` with a `BitWidth` of `100` bits
-			// and we want to zero-extend it to `120` bits then both `BitWidth`
-			// require exactly `2` digits for their representation and we can simply
-			// set the `BitWidth` of the consumed `ApInt` to the target width
-			// and we are done.
-			self.len = target_width;
-		}
-		else {
-			// In this case we cannot reuse the consumed `ApInt`'s heap memory but
-			// must allocate a new buffer that fits for the required amount of digits
-			// for the target width. Also we need to `memcpy` the digits of the
-			// extended `ApInt` to the newly allocated buffer.
-			use digit;
-			use std::iter;
-			assert!(target_req_digits > actual_req_digits);
-			let additional_digits = target_req_digits - actual_req_digits;
-			let extended_clone = ApInt::from_iter(
-				self.digits()
-				    .chain(iter::repeat(digit::ZERO).take(additional_digits)))
-				.and_then(|apint| apint.into_truncate(target_width))?;
-			*self = extended_clone;
-		}
-		Ok(())
-	}
+        if actual_req_digits == target_req_digits {
+            // We can do a cheap zero-extension here.
+            // 
+            // In this case we can reuse the heap memory of the consumed `ApInt`.
+            // 
+            // For example when given an `ApInt` with a `BitWidth` of `100` bits
+            // and we want to zero-extend it to `120` bits then both `BitWidth`
+            // require exactly `2` digits for their representation and we can simply
+            // set the `BitWidth` of the consumed `ApInt` to the target width
+            // and we are done.
+            self.len = target_width;
+        }
+        else {
+            // In this case we cannot reuse the consumed `ApInt`'s heap memory but
+            // must allocate a new buffer that fits for the required amount of digits
+            // for the target width. Also we need to `memcpy` the digits of the
+            // extended `ApInt` to the newly allocated buffer.
+            use digit;
+            use std::iter;
+            assert!(target_req_digits > actual_req_digits);
+            let additional_digits = target_req_digits - actual_req_digits;
+            let extended_clone = ApInt::from_iter(
+                self.digits()
+                    .chain(iter::repeat(digit::ZERO).take(additional_digits)))
+                .and_then(|apint| apint.into_truncate(target_width))?;
+            *self = extended_clone;
+        }
+        Ok(())
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Tries to sign-extend this `ApInt` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`sign_extend`](struct.ApInt.html#method.sign_extend).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn into_sign_extend<W>(self, target_width: W) -> Result<ApInt>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, ApInt::sign_extend)
-	}
+    /// Tries to sign-extend this `ApInt` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`sign_extend`](struct.ApInt.html#method.sign_extend).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn into_sign_extend<W>(self, target_width: W) -> Result<ApInt>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, ApInt::sign_extend)
+    }
 
-	/// Tries to sign-extend this `ApInt` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn sign_extend<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		let actual_width = self.width();
-		let target_width = target_width.into();
+    /// Tries to sign-extend this `ApInt` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn sign_extend<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        let actual_width = self.width();
+        let target_width = target_width.into();
 
-		if target_width == actual_width {
-			return Ok(())
-		}
+        if target_width == actual_width {
+            return Ok(())
+        }
 
-		if target_width < actual_width {
-			return Error::extension_bitwidth_too_small(target_width, actual_width)
-				.with_annotation(
-					format!(
-						"Cannot sign-extend bit-width of {:?} to {:?} bits. \
-						 Do you mean to truncate the instance instead?",
-						actual_width, target_width
-					)
-				)
-				.into()
-		}
+        if target_width < actual_width {
+            return Error::extension_bitwidth_too_small(target_width, actual_width)
+                .with_annotation(
+                    format!(
+                        "Cannot sign-extend bit-width of {:?} to {:?} bits. \
+                         Do you mean to truncate the instance instead?",
+                        actual_width, target_width
+                    )
+                )
+                .into()
+        }
 
-		if self.most_significant_bit() == Bit::Unset {
-			return self.zero_extend(target_width)
-		}
+        if self.most_significant_bit() == Bit::Unset {
+            return self.zero_extend(target_width)
+        }
 
-		let actual_req_digits = actual_width.required_digits();
-		let target_req_digits = target_width.required_digits();
+        let actual_req_digits = actual_width.required_digits();
+        let target_req_digits = target_width.required_digits();
 
-		if actual_req_digits == target_req_digits {
-			// We can do a cheap sign-extension here.
-			// 
-			// In this case we can reuse the heap memory of the consumed `ApInt`.
-			// 
-			// For example when given an `ApInt` with a `BitWidth` of `100` bits
-			// and we want to sign-extend it to `120` bits then both `BitWidth`
-			// require exactly `2` digits for their representation and we can simply
-			// set the `BitWidth` of the consumed `ApInt` to the target width
-			// and we are done.
+        if actual_req_digits == target_req_digits {
+            // We can do a cheap sign-extension here.
+            // 
+            // In this case we can reuse the heap memory of the consumed `ApInt`.
+            // 
+            // For example when given an `ApInt` with a `BitWidth` of `100` bits
+            // and we want to sign-extend it to `120` bits then both `BitWidth`
+            // require exactly `2` digits for their representation and we can simply
+            // set the `BitWidth` of the consumed `ApInt` to the target width
+            // and we are done.
 
-			self.len = target_width;
+            self.len = target_width;
 
-			// Fill most-significant-digit of `self` with `1` starting from its
-			// most-significant bit up to the `target_width`.
-			if let Some(excess_width) = actual_width.excess_width() {
-				self.most_significant_digit_mut().sign_extend_from(excess_width)?;
-			}
-			self.clear_unused_bits();
-		}
-		else {
-			// In this case we cannot reuse the consumed `ApInt`'s heap memory but
-			// must allocate a new buffer that fits for the required amount of digits
-			// for the target width. Also we need to `memcpy` the digits of the
-			// extended `ApInt` to the newly allocated buffer.
-			use digit;
-			use std::iter;
-			assert!(target_req_digits > actual_req_digits);
-			let additional_digits = target_req_digits - actual_req_digits;
+            // Fill most-significant-digit of `self` with `1` starting from its
+            // most-significant bit up to the `target_width`.
+            if let Some(excess_width) = actual_width.excess_width() {
+                self.most_significant_digit_mut().sign_extend_from(excess_width)?;
+            }
+            self.clear_unused_bits();
+        }
+        else {
+            // In this case we cannot reuse the consumed `ApInt`'s heap memory but
+            // must allocate a new buffer that fits for the required amount of digits
+            // for the target width. Also we need to `memcpy` the digits of the
+            // extended `ApInt` to the newly allocated buffer.
+            use digit;
+            use std::iter;
+            assert!(target_req_digits > actual_req_digits);
+            let additional_digits = target_req_digits - actual_req_digits;
 
-			// Fill most-significant-digit of `self` with `1` starting from its most-significant bit.
-			if let Some(excess_width) = actual_width.excess_width() {
-				self.most_significant_digit_mut().sign_extend_from(excess_width)?;
-			}
+            // Fill most-significant-digit of `self` with `1` starting from its most-significant bit.
+            if let Some(excess_width) = actual_width.excess_width() {
+                self.most_significant_digit_mut().sign_extend_from(excess_width)?;
+            }
 
-			let extended_copy = ApInt::from_iter(
-				self.digits()
-				    .chain(iter::repeat(digit::ONES).take(additional_digits)))
-				.and_then(|apint| apint.into_truncate(target_width))?;
+            let extended_copy = ApInt::from_iter(
+                self.digits()
+                    .chain(iter::repeat(digit::ONES).take(additional_digits)))
+                .and_then(|apint| apint.into_truncate(target_width))?;
 
-			self.clear_unused_bits();
-			*self = extended_copy;
-		}
+            self.clear_unused_bits();
+            *self = extended_copy;
+        }
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Zero-resizes this `ApInt` to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`zero_resize`](struct.ApInt.html#method.zero_resize).
-	pub fn into_zero_resize<W>(self, target_width: W) -> ApInt
-		where W: Into<BitWidth>
-	{
-		forward_bin_mut_impl(self, target_width, ApInt::zero_resize)
-	}
+    /// Zero-resizes this `ApInt` to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`zero_resize`](struct.ApInt.html#method.zero_resize).
+    pub fn into_zero_resize<W>(self, target_width: W) -> ApInt
+        where W: Into<BitWidth>
+    {
+        forward_bin_mut_impl(self, target_width, ApInt::zero_resize)
+    }
 
-	/// Sign-resizes this `ApInt` to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`sign_resize`](struct.ApInt.html#method.sign_resize).
-	pub fn into_sign_resize<W>(self, target_width: W) -> ApInt
-		where W: Into<BitWidth>
-	{
-		forward_bin_mut_impl(self, target_width, ApInt::sign_resize)
-	}
+    /// Sign-resizes this `ApInt` to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`sign_resize`](struct.ApInt.html#method.sign_resize).
+    pub fn into_sign_resize<W>(self, target_width: W) -> ApInt
+        where W: Into<BitWidth>
+    {
+        forward_bin_mut_impl(self, target_width, ApInt::sign_resize)
+    }
 
-	/// Zero-resizes the given `ApInt` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// This operation will forward to
-	/// 
-	/// - [`truncate`](struct.ApInt.html#method.truncate)
-	///   if `target_width` is less than or equal to the width of
-	///   the given `ApInt`
-	/// - [`zero_extend`](struct.ApInt.html#method.zero_extend)
-	///   otherwise
-	pub fn zero_resize<W>(&mut self, target_width: W)
-		where W: Into<BitWidth>
-	{
-		let actual_width = self.width();
-		let target_width = target_width.into();
+    /// Zero-resizes the given `ApInt` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// This operation will forward to
+    /// 
+    /// - [`truncate`](struct.ApInt.html#method.truncate)
+    ///   if `target_width` is less than or equal to the width of
+    ///   the given `ApInt`
+    /// - [`zero_extend`](struct.ApInt.html#method.zero_extend)
+    ///   otherwise
+    pub fn zero_resize<W>(&mut self, target_width: W)
+        where W: Into<BitWidth>
+    {
+        let actual_width = self.width();
+        let target_width = target_width.into();
 
-		if target_width <= actual_width {
-			self.truncate(target_width)
-			    .expect("It was asserted that `target_width` is \
-			             a valid truncation `BitWidth` in this context.")
-		}
-		else {
-			self.zero_extend(target_width)
-			    .expect("It was asserted that `target_width` is \
-			             a valid zero-extension `BitWidth` in this context.")
-		}
-	}
+        if target_width <= actual_width {
+            self.truncate(target_width)
+                .expect("It was asserted that `target_width` is \
+                         a valid truncation `BitWidth` in this context.")
+        }
+        else {
+            self.zero_extend(target_width)
+                .expect("It was asserted that `target_width` is \
+                         a valid zero-extension `BitWidth` in this context.")
+        }
+    }
 
-	/// Sign-resizes the given `ApInt` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// This operation will forward to
-	/// 
-	/// - [`truncate`](struct.ApInt.html#method.truncate)
-	///   if `target_width` is less than or equal to the width of
-	///   the given `ApInt`
-	/// - [`sign_extend`](struct.ApInt.html#method.sign_extend)
-	///   otherwise
-	pub fn sign_resize<W>(&mut self, target_width: W)
-		where W: Into<BitWidth>
-	{
-		let actual_width = self.width();
-		let target_width = target_width.into();
+    /// Sign-resizes the given `ApInt` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// This operation will forward to
+    /// 
+    /// - [`truncate`](struct.ApInt.html#method.truncate)
+    ///   if `target_width` is less than or equal to the width of
+    ///   the given `ApInt`
+    /// - [`sign_extend`](struct.ApInt.html#method.sign_extend)
+    ///   otherwise
+    pub fn sign_resize<W>(&mut self, target_width: W)
+        where W: Into<BitWidth>
+    {
+        let actual_width = self.width();
+        let target_width = target_width.into();
 
-		if target_width <= actual_width {
-			self.truncate(target_width)
-			    .expect("It was asserted that `target_width` is \
-			             a valid truncation `BitWidth` in this context.")
-		}
-		else {
-			self.sign_extend(target_width)
-			    .expect("It was asserted that `target_width` is \
-			             a valid sign-extension `BitWidth` in this context.")
-		}
-	}
+        if target_width <= actual_width {
+            self.truncate(target_width)
+                .expect("It was asserted that `target_width` is \
+                         a valid truncation `BitWidth` in this context.")
+        }
+        else {
+            self.sign_extend(target_width)
+                .expect("It was asserted that `target_width` is \
+                         a valid sign-extension `BitWidth` in this context.")
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	fn test_apints() -> impl Iterator<Item=ApInt> {
-		vec![
-			ApInt::from_u8(0),
-			ApInt::from_u8(1),
-			ApInt::from_u8(42),
-			ApInt::from_u8(0xF0),
-			ApInt::from_u8(0x0F),
-			ApInt::all_set(BitWidth::w8()),
+    fn test_apints() -> impl Iterator<Item=ApInt> {
+        vec![
+            ApInt::from_u8(0),
+            ApInt::from_u8(1),
+            ApInt::from_u8(42),
+            ApInt::from_u8(0xF0),
+            ApInt::from_u8(0x0F),
+            ApInt::all_set(BitWidth::w8()),
 
-			ApInt::from_u16(0),
-			ApInt::from_u16(1),
-			ApInt::from_u16(42),
-			ApInt::from_u16(1337),
-			ApInt::from_u16(0xFF00),
-			ApInt::from_u16(0x0FF0),
-			ApInt::from_u16(0x00FF),
-			ApInt::all_set(BitWidth::w16()),
+            ApInt::from_u16(0),
+            ApInt::from_u16(1),
+            ApInt::from_u16(42),
+            ApInt::from_u16(1337),
+            ApInt::from_u16(0xFF00),
+            ApInt::from_u16(0x0FF0),
+            ApInt::from_u16(0x00FF),
+            ApInt::all_set(BitWidth::w16()),
 
-			ApInt::from_u32(0),
-			ApInt::from_u32(1),
-			ApInt::from_u32(42),
-			ApInt::from_u32(1337),
-			ApInt::from_u32(0xFFFF_0000),
-			ApInt::from_u32(0x00FF_FF00),
-			ApInt::from_u32(0x0000_FFFF),
-			ApInt::all_set(BitWidth::w32()),
+            ApInt::from_u32(0),
+            ApInt::from_u32(1),
+            ApInt::from_u32(42),
+            ApInt::from_u32(1337),
+            ApInt::from_u32(0xFFFF_0000),
+            ApInt::from_u32(0x00FF_FF00),
+            ApInt::from_u32(0x0000_FFFF),
+            ApInt::all_set(BitWidth::w32()),
 
-			ApInt::from_u64(0),
-			ApInt::from_u64(1),
-			ApInt::from_u64(42),
-			ApInt::from_u64(1337),
-			ApInt::from_u64(0xFFFF_FFFF_0000_0000),
-			ApInt::from_u64(0x0000_FFFF_FFFF_0000),
-			ApInt::from_u64(0x0000_0000_FFFF_FFFF),
-			ApInt::all_set(BitWidth::w64()),
+            ApInt::from_u64(0),
+            ApInt::from_u64(1),
+            ApInt::from_u64(42),
+            ApInt::from_u64(1337),
+            ApInt::from_u64(0xFFFF_FFFF_0000_0000),
+            ApInt::from_u64(0x0000_FFFF_FFFF_0000),
+            ApInt::from_u64(0x0000_0000_FFFF_FFFF),
+            ApInt::all_set(BitWidth::w64()),
 
-			ApInt::from_u128(0),
-			ApInt::from_u128(1),
-			ApInt::from_u128(42),
-			ApInt::from_u128(1337),
-			ApInt::from_u128(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000),
-			ApInt::from_u128(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000),
-			ApInt::from_u128(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF),
-			ApInt::all_set(BitWidth::w128()),
+            ApInt::from_u128(0),
+            ApInt::from_u128(1),
+            ApInt::from_u128(42),
+            ApInt::from_u128(1337),
+            ApInt::from_u128(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000),
+            ApInt::from_u128(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000),
+            ApInt::from_u128(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF),
+            ApInt::all_set(BitWidth::w128()),
 
-			// ApInt::zero(width_256),
-			// ApInt::one(width_256),
-			// ApInt::repeat_digit(width_256, Digit(1)),
-			// ApInt::repeat_digit(width_256, Digit(42)),
-			// ApInt::repeat_digit(width_256, Digit(1337)),
-			// ApInt::repeat_digit(width_256, 0xFFFF_FFFF_0000_0000),
-			// ApInt::repeat_digit(width_256, 0x0000_FFFF_FFFF_0000),
-			// ApInt::repeat_digit(width_256, 0x0000_0000_FFFF_FFFF),
-			// ApInt::all_set(width_256),
+            // ApInt::zero(width_256),
+            // ApInt::one(width_256),
+            // ApInt::repeat_digit(width_256, Digit(1)),
+            // ApInt::repeat_digit(width_256, Digit(42)),
+            // ApInt::repeat_digit(width_256, Digit(1337)),
+            // ApInt::repeat_digit(width_256, 0xFFFF_FFFF_0000_0000),
+            // ApInt::repeat_digit(width_256, 0x0000_FFFF_FFFF_0000),
+            // ApInt::repeat_digit(width_256, 0x0000_0000_FFFF_FFFF),
+            // ApInt::all_set(width_256),
 
-			// ApInt::zero(width_500),
-			// ApInt::one(width_500),
-			// ApInt::repeat_digit(width_500, Digit(1)),
-			// ApInt::repeat_digit(width_500, Digit(42)),
-			// ApInt::repeat_digit(width_500, Digit(1337)),
-			// ApInt::repeat_digit(width_500, 0xFFFF_FFFF_0000_0000),
-			// ApInt::repeat_digit(width_500, 0x0000_FFFF_FFFF_0000),
-			// ApInt::repeat_digit(width_500, 0x0000_0000_FFFF_FFFF),
-			// ApInt::all_set(width_500),
+            // ApInt::zero(width_500),
+            // ApInt::one(width_500),
+            // ApInt::repeat_digit(width_500, Digit(1)),
+            // ApInt::repeat_digit(width_500, Digit(42)),
+            // ApInt::repeat_digit(width_500, Digit(1337)),
+            // ApInt::repeat_digit(width_500, 0xFFFF_FFFF_0000_0000),
+            // ApInt::repeat_digit(width_500, 0x0000_FFFF_FFFF_0000),
+            // ApInt::repeat_digit(width_500, 0x0000_0000_FFFF_FFFF),
+            // ApInt::all_set(width_500),
 
-			// ApInt::zero(width_512),
-			// ApInt::one(width_512),
-			// ApInt::repeat_digit(width_512, Digit(1)),
-			// ApInt::repeat_digit(width_512, Digit(42)),
-			// ApInt::repeat_digit(width_512, Digit(1337)),
-			// ApInt::repeat_digit(width_512, 0xFFFF_FFFF_0000_0000),
-			// ApInt::repeat_digit(width_512, 0x0000_FFFF_FFFF_0000),
-			// ApInt::repeat_digit(width_512, 0x0000_0000_FFFF_FFFF),
-			// ApInt::all_set(width_512),
-		].into_iter()
-	}
+            // ApInt::zero(width_512),
+            // ApInt::one(width_512),
+            // ApInt::repeat_digit(width_512, Digit(1)),
+            // ApInt::repeat_digit(width_512, Digit(42)),
+            // ApInt::repeat_digit(width_512, Digit(1337)),
+            // ApInt::repeat_digit(width_512, 0xFFFF_FFFF_0000_0000),
+            // ApInt::repeat_digit(width_512, 0x0000_FFFF_FFFF_0000),
+            // ApInt::repeat_digit(width_512, 0x0000_0000_FFFF_FFFF),
+            // ApInt::all_set(width_512),
+        ].into_iter()
+    }
 
-	mod clone {
-		use super::*;
+    mod clone {
+        use super::*;
 
-		/// Test Clone impl of `ApInt`.
-		/// 
-		/// Invariants between the origin `ApInt` `o` and for the cloned `c` are:
-		/// 
-		/// - `o` and `c` have same bit widths
-		/// - If `o` is heap-allocated then `c` is, too and vice versa for stack.
-		/// - `o` and `c` have an equal amount of digits and the values of their
-		///   digits is equal and in the same order.
-		/// - Memory addresses of `c` and `o` won't overlap. (No aliasing!)
-		///   This is enforced by safe Rust.
-		#[test]
-		fn clone() {
-			for apint in test_apints() {
-				assert_eq!(apint, apint.clone())
-			}
-		}
-	}
+        /// Test Clone impl of `ApInt`.
+        /// 
+        /// Invariants between the origin `ApInt` `o` and for the cloned `c` are:
+        /// 
+        /// - `o` and `c` have same bit widths
+        /// - If `o` is heap-allocated then `c` is, too and vice versa for stack.
+        /// - `o` and `c` have an equal amount of digits and the values of their
+        ///   digits is equal and in the same order.
+        /// - Memory addresses of `c` and `o` won't overlap. (No aliasing!)
+        ///   This is enforced by safe Rust.
+        #[test]
+        fn clone() {
+            for apint in test_apints() {
+                assert_eq!(apint, apint.clone())
+            }
+        }
+    }
 
-	mod assign {
-		use super::*;
+    mod assign {
+        use super::*;
 
-		/// Test for assigning to the same bit width.
-		#[test]
-		fn equal_width() {
-			for apint in test_apints() {
-				let width         = apint.width();
-				let mut all_set   = ApInt::all_set(width);
-				let mut all_unset = ApInt::all_unset(width);
-				assert_ne!(all_set, all_unset);
-				all_set.assign(&apint);
-				all_unset.assign(&apint);
-				assert_eq!(all_set, all_unset);
-				assert_eq!(apint, all_set);
-				assert_eq!(apint, all_unset);
-			}
-		}
+        /// Test for assigning to the same bit width.
+        #[test]
+        fn equal_width() {
+            for apint in test_apints() {
+                let width         = apint.width();
+                let mut all_set   = ApInt::all_set(width);
+                let mut all_unset = ApInt::all_unset(width);
+                assert_ne!(all_set, all_unset);
+                all_set.assign(&apint);
+                all_unset.assign(&apint);
+                assert_eq!(all_set, all_unset);
+                assert_eq!(apint, all_set);
+                assert_eq!(apint, all_unset);
+            }
+        }
 
-		/// Test for assigning between bit widths that
-		/// can be stored entirely on the stack.
-		#[test]
-		#[ignore]
-		fn inl() {
-		}
+        /// Test for assigning between bit widths that
+        /// can be stored entirely on the stack.
+        #[test]
+        #[ignore]
+        fn inl() {
+        }
 
-		/// Test for assigning where a heap-allocated
-		/// `ApInt` is truncated to a purely stack-allocated one.
-		#[test]
-		#[ignore]
-		fn ext_to_inl() {
-		}
+        /// Test for assigning where a heap-allocated
+        /// `ApInt` is truncated to a purely stack-allocated one.
+        #[test]
+        #[ignore]
+        fn ext_to_inl() {
+        }
 
-		/// Test for assigning where origin and target `ApInt`
-		/// are both entirely heap-allocated.
-		#[test]
-		#[ignore]
-		fn ext() {
-		}
-	}
+        /// Test for assigning where origin and target `ApInt`
+        /// are both entirely heap-allocated.
+        #[test]
+        #[ignore]
+        fn ext() {
+        }
+    }
 
-	mod strict_assign {
-		// use super::*;
+    mod strict_assign {
+        // use super::*;
 
-		/// Test for assigning to a non-strict assigning width
-		/// which results in an error.
-		#[test]
-		#[ignore]
-		fn fail_strict() {
-		}
+        /// Test for assigning to a non-strict assigning width
+        /// which results in an error.
+        #[test]
+        #[ignore]
+        fn fail_strict() {
+        }
 
-		/// Test to assert equality to non-strict assign.
-		#[test]
-		#[ignore]
-		fn equal_to_assign() {
-		}
-	}
+        /// Test to assert equality to non-strict assign.
+        #[test]
+        #[ignore]
+        fn equal_to_assign() {
+        }
+    }
 
-	mod into_truncate {
-		// use super::*;
+    mod into_truncate {
+        // use super::*;
 
-		/// Test for truncation to the same bit width.
-		#[test]
-		#[ignore]
-		fn equal_width() {
-		}
+        /// Test for truncation to the same bit width.
+        #[test]
+        #[ignore]
+        fn equal_width() {
+        }
 
-		/// Test for truncation to a bit width that is
-		/// greater than the current bit width and thus an error.
-		#[test]
-		#[ignore]
-		fn fail_width() {
-		}
+        /// Test for truncation to a bit width that is
+        /// greater than the current bit width and thus an error.
+        #[test]
+        #[ignore]
+        fn fail_width() {
+        }
 
-		/// Test for truncation between bit widths that
-		/// can be stored entirely on the stack.
-		#[test]
-		#[ignore]
-		fn inl() {
-		}
+        /// Test for truncation between bit widths that
+        /// can be stored entirely on the stack.
+        #[test]
+        #[ignore]
+        fn inl() {
+        }
 
-		/// Test for truncation where a heap-allocated
-		/// `ApInt` is truncated to a purely stack-allocated one.
-		#[test]
-		#[ignore]
-		fn ext_to_inl() {
-		}
+        /// Test for truncation where a heap-allocated
+        /// `ApInt` is truncated to a purely stack-allocated one.
+        #[test]
+        #[ignore]
+        fn ext_to_inl() {
+        }
 
-		/// Test for truncation where origin and target `ApInt`
-		/// are both entirely heap-allocated.
-		#[test]
-		#[ignore]
-		fn ext() {
-		}
-	}
+        /// Test for truncation where origin and target `ApInt`
+        /// are both entirely heap-allocated.
+        #[test]
+        #[ignore]
+        fn ext() {
+        }
+    }
 
-	mod truncate {
-		// use super::*;
+    mod truncate {
+        // use super::*;
 
-		/// Test to assert behavioural equality to `into_truncate`.
-		#[test]
-		#[ignore]
-		fn equal_to_into_truncate() {
-		}
-	}
+        /// Test to assert behavioural equality to `into_truncate`.
+        #[test]
+        #[ignore]
+        fn equal_to_into_truncate() {
+        }
+    }
 
-	mod into_zero_extend {
-		// use super::*;
+    mod into_zero_extend {
+        // use super::*;
 
-		/// Test for zero-extension to the same bit width.
-		#[test]
-		#[ignore]
-		fn equal_width() {
-		}
+        /// Test for zero-extension to the same bit width.
+        #[test]
+        #[ignore]
+        fn equal_width() {
+        }
 
-		/// Test for zero-extension to a bit width that is
-		/// greater than the current bit width and thus an error.
-		#[test]
-		#[ignore]
-		fn fail_width() {
-		}
+        /// Test for zero-extension to a bit width that is
+        /// greater than the current bit width and thus an error.
+        #[test]
+        #[ignore]
+        fn fail_width() {
+        }
 
-		/// Test for zero-extension between bit widths that
-		/// can be stored entirely on the stack.
-		#[test]
-		#[ignore]
-		fn inl() {
-		}
+        /// Test for zero-extension between bit widths that
+        /// can be stored entirely on the stack.
+        #[test]
+        #[ignore]
+        fn inl() {
+        }
 
-		/// Test for zero-extension where a heap-allocated
-		/// `ApInt` is zero-extended to a purely stack-allocated one.
-		#[test]
-		#[ignore]
-		fn ext_to_inl() {
-		}
+        /// Test for zero-extension where a heap-allocated
+        /// `ApInt` is zero-extended to a purely stack-allocated one.
+        #[test]
+        #[ignore]
+        fn ext_to_inl() {
+        }
 
-		/// Test for zero-extension where origin and target `ApInt`
-		/// are both entirely heap-allocated.
-		#[test]
-		#[ignore]
-		fn ext() {
-		}
-	}
+        /// Test for zero-extension where origin and target `ApInt`
+        /// are both entirely heap-allocated.
+        #[test]
+        #[ignore]
+        fn ext() {
+        }
+    }
 
-	mod zero_extend {
-		// use super::*;
+    mod zero_extend {
+        // use super::*;
 
-		/// Test to assert behavioural equality to `into_zero_extend`.
-		#[test]
-		#[ignore]
-		fn equal_to_into_zero_extend() {
-		}
-	}
+        /// Test to assert behavioural equality to `into_zero_extend`.
+        #[test]
+        #[ignore]
+        fn equal_to_into_zero_extend() {
+        }
+    }
 
-	mod into_sign_extend {
-		use super::*;
+    mod into_sign_extend {
+        use super::*;
 
-		#[test]
-		fn regression_issue15() {
-			use std::{i64, i128};
-			{
-				let input = ApInt::from_i64(i64::MIN).into_sign_extend(BitWidth::new(128).unwrap()).unwrap();
-				let expected = ApInt::from([-1_i64, i64::MIN]);
-				assert_eq!(input, expected);
-			}
-			{
-				let input = ApInt::from_i128(i128::MIN).into_sign_extend(BitWidth::new(256).unwrap()).unwrap();
-				let expected = ApInt::from([-1_i64, -1_i64, i64::MIN, 0_i64]);
-				assert_eq!(input, expected);
-			}
-		}
+        #[test]
+        fn regression_issue15() {
+            use std::{i64, i128};
+            {
+                let input = ApInt::from_i64(i64::MIN).into_sign_extend(BitWidth::new(128).unwrap()).unwrap();
+                let expected = ApInt::from([-1_i64, i64::MIN]);
+                assert_eq!(input, expected);
+            }
+            {
+                let input = ApInt::from_i128(i128::MIN).into_sign_extend(BitWidth::new(256).unwrap()).unwrap();
+                let expected = ApInt::from([-1_i64, -1_i64, i64::MIN, 0_i64]);
+                assert_eq!(input, expected);
+            }
+        }
 
-		/// Test for sign-extension to the same bit width.
-		#[test]
-		#[ignore]
-		fn equal_width() {
-		}
+        /// Test for sign-extension to the same bit width.
+        #[test]
+        #[ignore]
+        fn equal_width() {
+        }
 
-		/// Test for sign-extension to a bit width that is
-		/// greater than the current bit width and thus an error.
-		#[test]
-		#[ignore]
-		fn fail_width() {
-		}
+        /// Test for sign-extension to a bit width that is
+        /// greater than the current bit width and thus an error.
+        #[test]
+        #[ignore]
+        fn fail_width() {
+        }
 
-		/// Test for sign-extension between bit widths that
-		/// can be stored entirely on the stack.
-		#[test]
-		#[ignore]
-		fn inl() {
-		}
+        /// Test for sign-extension between bit widths that
+        /// can be stored entirely on the stack.
+        #[test]
+        #[ignore]
+        fn inl() {
+        }
 
-		/// Test for sign-extension where a heap-allocated
-		/// `ApInt` is sign-extended to a purely stack-allocated one.
-		#[test]
-		#[ignore]
-		fn ext_to_inl() {
-		}
+        /// Test for sign-extension where a heap-allocated
+        /// `ApInt` is sign-extended to a purely stack-allocated one.
+        #[test]
+        #[ignore]
+        fn ext_to_inl() {
+        }
 
-		/// Test for sign-extension where origin and target `ApInt`
-		/// are both entirely heap-allocated.
-		#[test]
-		#[ignore]
-		fn ext() {
-		}
-	}
+        /// Test for sign-extension where origin and target `ApInt`
+        /// are both entirely heap-allocated.
+        #[test]
+        #[ignore]
+        fn ext() {
+        }
+    }
 
-	mod sign_extend {
-		// use super::*;
+    mod sign_extend {
+        // use super::*;
 
-		/// Test to assert behavioural equality to `into_sign_extend`.
-		#[test]
-		#[ignore]
-		fn equal_to_into_zero_extend() {
-		}
-	}
+        /// Test to assert behavioural equality to `into_sign_extend`.
+        #[test]
+        #[ignore]
+        fn equal_to_into_zero_extend() {
+        }
+    }
 }

--- a/src/apint/constructors.rs
+++ b/src/apint/constructors.rs
@@ -11,357 +11,357 @@ use smallvec::SmallVec;
 use std::ptr::NonNull;
 
 impl ApInt {
-	/// Deallocates memory that may be allocated by this `ApInt`.
-	/// 
-	/// `ApInt` instances with a bit width larger than `64` bits
-	/// allocate their digits on the heap. With `drop_digits` this
-	/// memory can be freed.
-	/// 
-	/// **Note:** This is extremely unsafe, only use this if the
-	///           `ApInt` no longer needs its digits.
-	/// 
-	/// **Note:** This is `unsafe` since it violates invariants
-	///           of the `ApInt`.
-	pub(in apint) unsafe fn drop_digits(&mut self) {
-		if self.len.storage() == Storage::Ext {
-			let len = self.len_digits();
-			drop(Vec::from_raw_parts(
-				self.data.ext.as_ptr(), len, len))
-		}
-	}
+    /// Deallocates memory that may be allocated by this `ApInt`.
+    /// 
+    /// `ApInt` instances with a bit width larger than `64` bits
+    /// allocate their digits on the heap. With `drop_digits` this
+    /// memory can be freed.
+    /// 
+    /// **Note:** This is extremely unsafe, only use this if the
+    ///           `ApInt` no longer needs its digits.
+    /// 
+    /// **Note:** This is `unsafe` since it violates invariants
+    ///           of the `ApInt`.
+    pub(in apint) unsafe fn drop_digits(&mut self) {
+        if self.len.storage() == Storage::Ext {
+            let len = self.len_digits();
+            drop(Vec::from_raw_parts(
+                self.data.ext.as_ptr(), len, len))
+        }
+    }
 }
 
 impl Drop for ApInt {
-	fn drop(&mut self) {
-		unsafe{self.drop_digits()}
-	}
+    fn drop(&mut self) {
+        unsafe{self.drop_digits()}
+    }
 }
 
 /// # Constructors
 impl ApInt {
 
-	/// Creates a new small `ApInt` from the given `BitWidth` and `Digit`.
-	/// 
-	/// Small `ApInt` instances are stored entirely on the stack.
-	/// 
-	/// # Panics
-	/// 
-	/// - If the given `width` represents a `BitWidth` larger than `64` bits.
-	#[inline]
-	pub(in apint) fn new_inl(width: BitWidth, digit: Digit) -> ApInt {
-		assert_eq!(width.storage(), Storage::Inl);
-		ApInt{
-			len: width,
-			data: ApIntData{ inl: digit }}
-	}
+    /// Creates a new small `ApInt` from the given `BitWidth` and `Digit`.
+    /// 
+    /// Small `ApInt` instances are stored entirely on the stack.
+    /// 
+    /// # Panics
+    /// 
+    /// - If the given `width` represents a `BitWidth` larger than `64` bits.
+    #[inline]
+    pub(in apint) fn new_inl(width: BitWidth, digit: Digit) -> ApInt {
+        assert_eq!(width.storage(), Storage::Inl);
+        ApInt{
+            len: width,
+            data: ApIntData{ inl: digit }}
+    }
 
-	/// Creates a new large `ApInt` from the given `BitWidth` and `Digit`.
-	/// 
-	/// Large `ApInt` instances allocate their digits on the heap.
-	/// 
-	/// **Note:** This operation is unsafe since the buffer length behind the
-	///           given `ext_ptr` must be trusted.
-	/// 
-	/// # Panics
-	/// 
-	/// - If the given `width` represents a `BitWidth` smaller than
-	///   or equal to `64` bits.
-	pub(in apint) unsafe fn new_ext(width: BitWidth, ext_ptr: *mut Digit) -> ApInt {
-		assert_eq!(width.storage(), Storage::Ext);
-		ApInt{
-			len: width,
-			data: ApIntData{ ext: NonNull::new_unchecked(ext_ptr) }
-		}
-	}
+    /// Creates a new large `ApInt` from the given `BitWidth` and `Digit`.
+    /// 
+    /// Large `ApInt` instances allocate their digits on the heap.
+    /// 
+    /// **Note:** This operation is unsafe since the buffer length behind the
+    ///           given `ext_ptr` must be trusted.
+    /// 
+    /// # Panics
+    /// 
+    /// - If the given `width` represents a `BitWidth` smaller than
+    ///   or equal to `64` bits.
+    pub(in apint) unsafe fn new_ext(width: BitWidth, ext_ptr: *mut Digit) -> ApInt {
+        assert_eq!(width.storage(), Storage::Ext);
+        ApInt{
+            len: width,
+            data: ApIntData{ ext: NonNull::new_unchecked(ext_ptr) }
+        }
+    }
 
-	/// Creates a new `ApInt` from the given `Bit` value with a bit width of `1`.
-	/// 
-	/// This function is generic over types that are convertible to `Bit` such as `bool`.
-	pub fn from_bit<B>(bit: B) -> ApInt
-		where B: Into<Bit>
-	{
-		ApInt::new_inl(BitWidth::w1(), Digit(bit.into().to_bool() as u64))
-	}
+    /// Creates a new `ApInt` from the given `Bit` value with a bit width of `1`.
+    /// 
+    /// This function is generic over types that are convertible to `Bit` such as `bool`.
+    pub fn from_bit<B>(bit: B) -> ApInt
+        where B: Into<Bit>
+    {
+        ApInt::new_inl(BitWidth::w1(), Digit(bit.into().to_bool() as u64))
+    }
 
-	/// Creates a new `ApInt` from a given `i8` value with a bit-width of 8.
-	#[inline]
-	pub fn from_i8(val: i8) -> ApInt {
-		ApInt::from_u8(val as u8)
-	}
+    /// Creates a new `ApInt` from a given `i8` value with a bit-width of 8.
+    #[inline]
+    pub fn from_i8(val: i8) -> ApInt {
+        ApInt::from_u8(val as u8)
+    }
 
-	/// Creates a new `ApInt` from a given `u8` value with a bit-width of 8.
-	#[inline]
-	pub fn from_u8(val: u8) -> ApInt {
-		ApInt::new_inl(BitWidth::w8(), Digit(u64::from(val)))
-	}
+    /// Creates a new `ApInt` from a given `u8` value with a bit-width of 8.
+    #[inline]
+    pub fn from_u8(val: u8) -> ApInt {
+        ApInt::new_inl(BitWidth::w8(), Digit(u64::from(val)))
+    }
 
-	/// Creates a new `ApInt` from a given `i16` value with a bit-width of 16.
-	#[inline]
-	pub fn from_i16(val: i16) -> ApInt {
-		ApInt::from_u16(val as u16)
-	}
+    /// Creates a new `ApInt` from a given `i16` value with a bit-width of 16.
+    #[inline]
+    pub fn from_i16(val: i16) -> ApInt {
+        ApInt::from_u16(val as u16)
+    }
 
-	/// Creates a new `ApInt` from a given `u16` value with a bit-width of 16.
-	#[inline]
-	pub fn from_u16(val: u16) -> ApInt {
-		ApInt::new_inl(BitWidth::w16(), Digit(u64::from(val)))
-	}
+    /// Creates a new `ApInt` from a given `u16` value with a bit-width of 16.
+    #[inline]
+    pub fn from_u16(val: u16) -> ApInt {
+        ApInt::new_inl(BitWidth::w16(), Digit(u64::from(val)))
+    }
 
-	/// Creates a new `ApInt` from a given `i32` value with a bit-width of 32.
-	#[inline]
-	pub fn from_i32(val: i32) -> ApInt {
-		ApInt::from_u32(val as u32)
-	}
+    /// Creates a new `ApInt` from a given `i32` value with a bit-width of 32.
+    #[inline]
+    pub fn from_i32(val: i32) -> ApInt {
+        ApInt::from_u32(val as u32)
+    }
 
-	/// Creates a new `ApInt` from a given `u32` value with a bit-width of 32.
-	#[inline]
-	pub fn from_u32(val: u32) -> ApInt {
-		ApInt::new_inl(BitWidth::w32(), Digit(u64::from(val)))
-	}
+    /// Creates a new `ApInt` from a given `u32` value with a bit-width of 32.
+    #[inline]
+    pub fn from_u32(val: u32) -> ApInt {
+        ApInt::new_inl(BitWidth::w32(), Digit(u64::from(val)))
+    }
 
-	/// Creates a new `ApInt` from a given `i64` value with a bit-width of 64.
-	#[inline]
-	pub fn from_i64(val: i64) -> ApInt {
-		ApInt::from_u64(val as u64)
-	}
+    /// Creates a new `ApInt` from a given `i64` value with a bit-width of 64.
+    #[inline]
+    pub fn from_i64(val: i64) -> ApInt {
+        ApInt::from_u64(val as u64)
+    }
 
-	/// Creates a new `ApInt` from a given `u64` value with a bit-width of 64.
-	#[inline]
-	pub fn from_u64(val: u64) -> ApInt {
-		ApInt::new_inl(BitWidth::w64(), Digit(val))
-	}
+    /// Creates a new `ApInt` from a given `u64` value with a bit-width of 64.
+    #[inline]
+    pub fn from_u64(val: u64) -> ApInt {
+        ApInt::new_inl(BitWidth::w64(), Digit(val))
+    }
 
-	/// Creates a new `ApInt` from a given `i128` value with a bit-width of 128.
-	#[inline]
-	pub fn from_i128(val: i128) -> ApInt {
-		ApInt::from_u128(val as u128)
-	}
+    /// Creates a new `ApInt` from a given `i128` value with a bit-width of 128.
+    #[inline]
+    pub fn from_i128(val: i128) -> ApInt {
+        ApInt::from_u128(val as u128)
+    }
 
-	/// Creates a new `ApInt` from a given `u128` value with a bit-width of 128.
-	pub fn from_u128(val: u128) -> ApInt {
-		let hi = (val >> digit::BITS) as u64;
-		let lo = (val & ((1u128 << 64) - 1)) as u64;
-		ApInt::from([hi, lo])
-	}
+    /// Creates a new `ApInt` from a given `u128` value with a bit-width of 128.
+    pub fn from_u128(val: u128) -> ApInt {
+        let hi = (val >> digit::BITS) as u64;
+        let lo = (val & ((1u128 << 64) - 1)) as u64;
+        ApInt::from([hi, lo])
+    }
 
-	/// Creates a new `ApInt` from the given iterator over `Digit`s.
-	/// 
-	/// This results in `ApInt` instances with bitwidths that are a multiple
-	/// of a `Digit`s bitwidth (e.g. 64 bit).
-	/// 
-	/// Users of this API may truncate, extend or simply resize the resulting
-	/// `ApInt` afterwards to obtain the desired bitwidth. This may be very cheap
-	/// depending on the difference between the actual and target bitwidths.
-	/// For example, `move_truncate`ing a `128` bitwidth `ApInt` to `100` is
-	/// relatively cheap and won't allocate memory since both `ApInt` instances can use
-	/// the same amount of `Digit`s.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the iterator yields no elements.
-	pub(in apint) fn from_iter<I>(digits: I) -> Result<ApInt>
-		where I: IntoIterator<Item=Digit>,
-	{
-		let mut buffer = digits.into_iter().collect::<SmallVec<[Digit; 1]>>();
-		match buffer.len() {
-			0 => {
-				Err(Error::expected_non_empty_digits())
-			}
-			1 => {
-				let first_and_only = *buffer
-					.first()
-					.expect("We have already asserted that `digits.len()` must be at exactly `1`.");
-				Ok(ApInt::new_inl(BitWidth::w64(), first_and_only))
-			}
-			n => {
-				use std::mem;
-				let bitwidth = BitWidth::new(n * digit::BITS)
-					.expect("We have already asserted that the number of items the given Iterator \
-						     iterates over is greater than `1` and thus non-zero and thus a valid `BitWidth`.");
-				let req_digits = bitwidth.required_digits();
-				buffer.shrink_to_fit();
-				assert_eq!(buffer.capacity(), req_digits);
-				assert_eq!(buffer.len()     , req_digits);
-				let ptr_buffer = buffer.as_ptr() as *mut Digit;
-				mem::forget(buffer);
-				Ok(unsafe{ ApInt::new_ext(bitwidth, ptr_buffer) })
-			}
-		}
-	}
+    /// Creates a new `ApInt` from the given iterator over `Digit`s.
+    /// 
+    /// This results in `ApInt` instances with bitwidths that are a multiple
+    /// of a `Digit`s bitwidth (e.g. 64 bit).
+    /// 
+    /// Users of this API may truncate, extend or simply resize the resulting
+    /// `ApInt` afterwards to obtain the desired bitwidth. This may be very cheap
+    /// depending on the difference between the actual and target bitwidths.
+    /// For example, `move_truncate`ing a `128` bitwidth `ApInt` to `100` is
+    /// relatively cheap and won't allocate memory since both `ApInt` instances can use
+    /// the same amount of `Digit`s.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the iterator yields no elements.
+    pub(in apint) fn from_iter<I>(digits: I) -> Result<ApInt>
+        where I: IntoIterator<Item=Digit>,
+    {
+        let mut buffer = digits.into_iter().collect::<SmallVec<[Digit; 1]>>();
+        match buffer.len() {
+            0 => {
+                Err(Error::expected_non_empty_digits())
+            }
+            1 => {
+                let first_and_only = *buffer
+                    .first()
+                    .expect("We have already asserted that `digits.len()` must be at exactly `1`.");
+                Ok(ApInt::new_inl(BitWidth::w64(), first_and_only))
+            }
+            n => {
+                use std::mem;
+                let bitwidth = BitWidth::new(n * digit::BITS)
+                    .expect("We have already asserted that the number of items the given Iterator \
+                             iterates over is greater than `1` and thus non-zero and thus a valid `BitWidth`.");
+                let req_digits = bitwidth.required_digits();
+                buffer.shrink_to_fit();
+                assert_eq!(buffer.capacity(), req_digits);
+                assert_eq!(buffer.len()     , req_digits);
+                let ptr_buffer = buffer.as_ptr() as *mut Digit;
+                mem::forget(buffer);
+                Ok(unsafe{ ApInt::new_ext(bitwidth, ptr_buffer) })
+            }
+        }
+    }
 
-	/// Creates a new `ApInt` that represents the repetition of the given digit
-	/// up to the given target bitwidth.
-	/// 
-	/// Note: The last digit in the generated sequence is truncated to make the `ApInt`'s
-	///       value representation fit the given bit-width.
-	pub(in apint) fn repeat_digit<D>(target_width: BitWidth, digit: D) -> ApInt
-		where D: Into<Digit>
-	{
-		use std::iter;
-		let digit = digit.into();
-		let req_digits = target_width.required_digits();
-		ApInt::from_iter(iter::repeat(digit).take(req_digits))
-			.expect("Since `required_digits` always returns `1` or more \
-			         required digits we can safely assume that this operation \
-			         never fails.")
-			.into_truncate(target_width)
-			.expect("Since `BitWidth::required_digits` always returns the upper bound \
-			         for the number of digits required to represent the given `BitWidth` \
-			         and `ApInt::from_iter` will use exactly this upper bound \
-			         we can safely assume that `target_width` is always equal or \
-			         less than what `ApInt::from_iter` returns and thus truncation will \
-			         never fail.")
-	}
+    /// Creates a new `ApInt` that represents the repetition of the given digit
+    /// up to the given target bitwidth.
+    /// 
+    /// Note: The last digit in the generated sequence is truncated to make the `ApInt`'s
+    ///       value representation fit the given bit-width.
+    pub(in apint) fn repeat_digit<D>(target_width: BitWidth, digit: D) -> ApInt
+        where D: Into<Digit>
+    {
+        use std::iter;
+        let digit = digit.into();
+        let req_digits = target_width.required_digits();
+        ApInt::from_iter(iter::repeat(digit).take(req_digits))
+            .expect("Since `required_digits` always returns `1` or more \
+                     required digits we can safely assume that this operation \
+                     never fails.")
+            .into_truncate(target_width)
+            .expect("Since `BitWidth::required_digits` always returns the upper bound \
+                     for the number of digits required to represent the given `BitWidth` \
+                     and `ApInt::from_iter` will use exactly this upper bound \
+                     we can safely assume that `target_width` is always equal or \
+                     less than what `ApInt::from_iter` returns and thus truncation will \
+                     never fail.")
+    }
 
-	/// Creates a new `ApInt` with the given bit width that represents zero.
-	pub fn zero(width: BitWidth) -> ApInt {
-		ApInt::repeat_digit(width, digit::ZERO)
-	}
+    /// Creates a new `ApInt` with the given bit width that represents zero.
+    pub fn zero(width: BitWidth) -> ApInt {
+        ApInt::repeat_digit(width, digit::ZERO)
+    }
 
-	/// Creates a new `ApInt` with the given bit width that represents one.
-	pub fn one(width: BitWidth) -> ApInt {
-		ApInt::from_u64(1).into_zero_resize(width)
-	}
+    /// Creates a new `ApInt` with the given bit width that represents one.
+    pub fn one(width: BitWidth) -> ApInt {
+        ApInt::from_u64(1).into_zero_resize(width)
+    }
 
-	/// Creates a new `ApInt` with the given bit width that has all bits unset.
-	/// 
-	/// **Note:** This is equal to calling `ApInt::zero` with the given `width`.
-	pub fn all_unset(width: BitWidth) -> ApInt {
-		ApInt::zero(width)
-	}
+    /// Creates a new `ApInt` with the given bit width that has all bits unset.
+    /// 
+    /// **Note:** This is equal to calling `ApInt::zero` with the given `width`.
+    pub fn all_unset(width: BitWidth) -> ApInt {
+        ApInt::zero(width)
+    }
 
-	/// Creates a new `ApInt` with the given bit width that has all bits set.
-	pub fn all_set(width: BitWidth) -> ApInt {
-		ApInt::repeat_digit(width, digit::ONES)
-	}
+    /// Creates a new `ApInt` with the given bit width that has all bits set.
+    pub fn all_set(width: BitWidth) -> ApInt {
+        ApInt::repeat_digit(width, digit::ONES)
+    }
 
-	/// Returns the smallest unsigned `ApInt` that can be represented by the given `BitWidth`.
-	pub fn unsigned_min_value(width: BitWidth) -> ApInt {
-		ApInt::zero(width)
-	}
+    /// Returns the smallest unsigned `ApInt` that can be represented by the given `BitWidth`.
+    pub fn unsigned_min_value(width: BitWidth) -> ApInt {
+        ApInt::zero(width)
+    }
 
-	/// Returns the largest unsigned `ApInt` that can be represented by the given `BitWidth`.
-	pub fn unsigned_max_value(width: BitWidth) -> ApInt {
-		ApInt::all_set(width)
-	}
+    /// Returns the largest unsigned `ApInt` that can be represented by the given `BitWidth`.
+    pub fn unsigned_max_value(width: BitWidth) -> ApInt {
+        ApInt::all_set(width)
+    }
 
-	/// Returns the smallest signed `ApInt` that can be represented by the given `BitWidth`.
-	pub fn signed_min_value(width: BitWidth) -> ApInt {
-		let mut result = ApInt::zero(width);
-		result.set_sign_bit();
-		result
-	}
+    /// Returns the smallest signed `ApInt` that can be represented by the given `BitWidth`.
+    pub fn signed_min_value(width: BitWidth) -> ApInt {
+        let mut result = ApInt::zero(width);
+        result.set_sign_bit();
+        result
+    }
 
-	/// Returns the largest signed `ApInt` that can be represented by the given `BitWidth`.
-	pub fn signed_max_value(width: BitWidth) -> ApInt {
-		let mut result = ApInt::all_set(width);
-		result.unset_sign_bit();
-		result
-	}
+    /// Returns the largest signed `ApInt` that can be represented by the given `BitWidth`.
+    pub fn signed_max_value(width: BitWidth) -> ApInt {
+        let mut result = ApInt::all_set(width);
+        result.unset_sign_bit();
+        result
+    }
 }
 
 impl<B> From<B> for ApInt
-	where B: Into<Bit>
+    where B: Into<Bit>
 {
-	#[inline]
-	fn from(bit: B) -> ApInt {
-		ApInt::from_bit(bit)
-	}
+    #[inline]
+    fn from(bit: B) -> ApInt {
+        ApInt::from_bit(bit)
+    }
 }
 
 impl From<u8> for ApInt {
-	#[inline]
-	fn from(val: u8) -> ApInt {
-		ApInt::from_u8(val)
-	}
+    #[inline]
+    fn from(val: u8) -> ApInt {
+        ApInt::from_u8(val)
+    }
 }
 
 impl From<i8> for ApInt {
-	#[inline]
-	fn from(val: i8) -> ApInt {
-		ApInt::from_i8(val)
-	}
+    #[inline]
+    fn from(val: i8) -> ApInt {
+        ApInt::from_i8(val)
+    }
 }
 
 impl From<u16> for ApInt {
-	#[inline]
-	fn from(val: u16) -> ApInt {
-		ApInt::from_u16(val)
-	}
+    #[inline]
+    fn from(val: u16) -> ApInt {
+        ApInt::from_u16(val)
+    }
 }
 
 impl From<i16> for ApInt {
-	#[inline]
-	fn from(val: i16) -> ApInt {
-		ApInt::from_i16(val)
-	}
+    #[inline]
+    fn from(val: i16) -> ApInt {
+        ApInt::from_i16(val)
+    }
 }
 
 impl From<u32> for ApInt {
-	#[inline]
-	fn from(val: u32) -> ApInt {
-		ApInt::from_u32(val)
-	}
+    #[inline]
+    fn from(val: u32) -> ApInt {
+        ApInt::from_u32(val)
+    }
 }
 
 impl From<i32> for ApInt {
-	#[inline]
-	fn from(val: i32) -> ApInt {
-		ApInt::from_i32(val)
-	}
+    #[inline]
+    fn from(val: i32) -> ApInt {
+        ApInt::from_i32(val)
+    }
 }
 
 impl From<u64> for ApInt {
-	#[inline]
-	fn from(val: u64) -> ApInt {
-		ApInt::from_u64(val)
-	}
+    #[inline]
+    fn from(val: u64) -> ApInt {
+        ApInt::from_u64(val)
+    }
 }
 
 impl From<i64> for ApInt {
-	#[inline]
-	fn from(val: i64) -> ApInt {
-		ApInt::from_i64(val)
-	}
+    #[inline]
+    fn from(val: i64) -> ApInt {
+        ApInt::from_i64(val)
+    }
 }
 
 impl From<u128> for ApInt {
-	#[inline]
-	fn from(val: u128) -> ApInt {
-		ApInt::from_u128(val)
-	}
+    #[inline]
+    fn from(val: u128) -> ApInt {
+        ApInt::from_u128(val)
+    }
 }
 
 impl From<i128> for ApInt {
-	#[inline]
-	fn from(val: i128) -> ApInt {
-		ApInt::from_i128(val)
-	}
+    #[inline]
+    fn from(val: i128) -> ApInt {
+        ApInt::from_i128(val)
+    }
 }
 
 macro_rules! impl_from_array_for_apint {
-	($n:expr) => {
-		impl From<[i64; $n]> for ApInt {
-			fn from(val: [i64; $n]) -> ApInt {
-				<Self as From<[u64; $n]>>::from(
-					unsafe{ ::std::mem::transmute::<[i64; $n], [u64; $n]>(val) })
-			}
-		}
+    ($n:expr) => {
+        impl From<[i64; $n]> for ApInt {
+            fn from(val: [i64; $n]) -> ApInt {
+                <Self as From<[u64; $n]>>::from(
+                    unsafe{ ::std::mem::transmute::<[i64; $n], [u64; $n]>(val) })
+            }
+        }
 
-		impl From<[u64; $n]> for ApInt {
-			fn from(val: [u64; $n]) -> ApInt {
-				let buffer = val.into_iter()
-				                .rev()
-				                .cloned()
-				                .map(Digit)
-				                .collect::<Vec<Digit>>();
-				assert_eq!(buffer.len(), $n);
-				ApInt::from_iter(buffer)
-					.expect("We asserted that `buffer.len()` is exactly `$n` \
-								so we can expect `ApInt::from_iter` to be successful.")
-			}
-		}
-	}
+        impl From<[u64; $n]> for ApInt {
+            fn from(val: [u64; $n]) -> ApInt {
+                let buffer = val.into_iter()
+                                .rev()
+                                .cloned()
+                                .map(Digit)
+                                .collect::<Vec<Digit>>();
+                assert_eq!(buffer.len(), $n);
+                ApInt::from_iter(buffer)
+                    .expect("We asserted that `buffer.len()` is exactly `$n` \
+                                so we can expect `ApInt::from_iter` to be successful.")
+            }
+        }
+    }
 }
 
 impl_from_array_for_apint!(2);  // 128 bits
@@ -376,367 +376,367 @@ impl_from_array_for_apint!(32); // 2048 bits
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	use std::ops::Range;
+    use std::ops::Range;
 
-	fn powers() -> impl Iterator<Item=u128> {
-		(0..128).map(|p| 1 << p)
-	}
+    fn powers() -> impl Iterator<Item=u128> {
+        (0..128).map(|p| 1 << p)
+    }
 
-	fn powers_from_to(range: Range<usize>) -> impl Iterator<Item=u128> {
-		powers().skip(range.start).take(range.end - range.start)
-	}
+    fn powers_from_to(range: Range<usize>) -> impl Iterator<Item=u128> {
+        powers().skip(range.start).take(range.end - range.start)
+    }
 
-	mod tests {
-		use super::{powers, powers_from_to};
+    mod tests {
+        use super::{powers, powers_from_to};
 
-		#[test]
-		fn test_powers() {
-			let mut pows = powers();
-			assert_eq!(pows.next(), Some(1 << 0));
-			assert_eq!(pows.next(), Some(1 << 1));
-			assert_eq!(pows.next(), Some(1 << 2));
-			assert_eq!(pows.next(), Some(1 << 3));
-			assert_eq!(pows.next(), Some(1 << 4));
-			assert_eq!(pows.next(), Some(1 << 5));
-			assert_eq!(pows.last(), Some(1 << 127));
-		}
+        #[test]
+        fn test_powers() {
+            let mut pows = powers();
+            assert_eq!(pows.next(), Some(1 << 0));
+            assert_eq!(pows.next(), Some(1 << 1));
+            assert_eq!(pows.next(), Some(1 << 2));
+            assert_eq!(pows.next(), Some(1 << 3));
+            assert_eq!(pows.next(), Some(1 << 4));
+            assert_eq!(pows.next(), Some(1 << 5));
+            assert_eq!(pows.last(), Some(1 << 127));
+        }
 
-		#[test]
-		fn test_powers_from_to() {
-			{
-				let mut powsft = powers_from_to(0..4);
-				assert_eq!(powsft.next(), Some(1 << 0));
-				assert_eq!(powsft.next(), Some(1 << 1));
-				assert_eq!(powsft.next(), Some(1 << 2));
-				assert_eq!(powsft.next(), Some(1 << 3));
-				assert_eq!(powsft.next(), None);
-			}
-			{
-				let mut powsft = powers_from_to(4..7);
-				assert_eq!(powsft.next(), Some(1 << 4));
-				assert_eq!(powsft.next(), Some(1 << 5));
-				assert_eq!(powsft.next(), Some(1 << 6));
-				assert_eq!(powsft.next(), None);
-			}
-		}
-	}
+        #[test]
+        fn test_powers_from_to() {
+            {
+                let mut powsft = powers_from_to(0..4);
+                assert_eq!(powsft.next(), Some(1 << 0));
+                assert_eq!(powsft.next(), Some(1 << 1));
+                assert_eq!(powsft.next(), Some(1 << 2));
+                assert_eq!(powsft.next(), Some(1 << 3));
+                assert_eq!(powsft.next(), None);
+            }
+            {
+                let mut powsft = powers_from_to(4..7);
+                assert_eq!(powsft.next(), Some(1 << 4));
+                assert_eq!(powsft.next(), Some(1 << 5));
+                assert_eq!(powsft.next(), Some(1 << 6));
+                assert_eq!(powsft.next(), None);
+            }
+        }
+    }
 
-	fn test_values_u8() -> impl Iterator<Item=u8> {
-		powers_from_to(0..8)
-			.map(|v| v as u8)
-			.chain([
-				u8::max_value(),
-				10,
-				42,
-				99,
-				123
-			].into_iter()
-			 .map(|v| *v))
-	}
+    fn test_values_u8() -> impl Iterator<Item=u8> {
+        powers_from_to(0..8)
+            .map(|v| v as u8)
+            .chain([
+                u8::max_value(),
+                10,
+                42,
+                99,
+                123
+            ].into_iter()
+             .map(|v| *v))
+    }
 
-	#[test]
-	fn from_bit() {
-		{
-			let explicit = ApInt::from_bit(Bit::Set);
-			let implicit = ApInt::from(Bit::Set);
-			let expected = ApInt::new_inl(BitWidth::w1(), Digit::one());
-			assert_eq!(explicit, implicit);
-			assert_eq!(explicit, expected);
-		}
-		{
-			let explicit = ApInt::from_bit(Bit::Unset);
-			let implicit = ApInt::from(Bit::Unset);
-			let expected = ApInt::new_inl(BitWidth::w1(), Digit::zero());
-			assert_eq!(explicit, implicit);
-			assert_eq!(explicit, expected);
-		}
-	}
+    #[test]
+    fn from_bit() {
+        {
+            let explicit = ApInt::from_bit(Bit::Set);
+            let implicit = ApInt::from(Bit::Set);
+            let expected = ApInt::new_inl(BitWidth::w1(), Digit::one());
+            assert_eq!(explicit, implicit);
+            assert_eq!(explicit, expected);
+        }
+        {
+            let explicit = ApInt::from_bit(Bit::Unset);
+            let implicit = ApInt::from(Bit::Unset);
+            let expected = ApInt::new_inl(BitWidth::w1(), Digit::zero());
+            assert_eq!(explicit, implicit);
+            assert_eq!(explicit, expected);
+        }
+    }
 
-	#[test]
-	fn from_w8() {
-		for val in test_values_u8() {
-			let explicit_u8 = ApInt::from_u8(val);
-			let explicit_i8 = ApInt::from_i8(val as i8);
-			let implicit_u8 = ApInt::from(val);
-			let implicit_i8 = ApInt::from(val as i8);
-			let expected = ApInt{
-				len : BitWidth::w8(),
-				data: ApIntData{inl: Digit(u64::from(val))}
-			};
-			assert_eq!(explicit_u8, explicit_i8);
-			assert_eq!(explicit_u8, implicit_i8);
-			assert_eq!(explicit_u8, implicit_u8);
-			assert_eq!(explicit_u8, expected);
-		}
-	}
+    #[test]
+    fn from_w8() {
+        for val in test_values_u8() {
+            let explicit_u8 = ApInt::from_u8(val);
+            let explicit_i8 = ApInt::from_i8(val as i8);
+            let implicit_u8 = ApInt::from(val);
+            let implicit_i8 = ApInt::from(val as i8);
+            let expected = ApInt{
+                len : BitWidth::w8(),
+                data: ApIntData{inl: Digit(u64::from(val))}
+            };
+            assert_eq!(explicit_u8, explicit_i8);
+            assert_eq!(explicit_u8, implicit_i8);
+            assert_eq!(explicit_u8, implicit_u8);
+            assert_eq!(explicit_u8, expected);
+        }
+    }
 
-	fn test_values_u16() -> impl Iterator<Item=u16> {
-		test_values_u8()
-			.map(u16::from)
-			.chain(powers_from_to(8..16)
-				.map(|v| v as u16))
-			.chain([
-				u16::max_value(),
-				500,
-				1000,
-				1337,
-				7777,
-				42_000
-			].into_iter().map(|v| *v))
-	}
+    fn test_values_u16() -> impl Iterator<Item=u16> {
+        test_values_u8()
+            .map(u16::from)
+            .chain(powers_from_to(8..16)
+                .map(|v| v as u16))
+            .chain([
+                u16::max_value(),
+                500,
+                1000,
+                1337,
+                7777,
+                42_000
+            ].into_iter().map(|v| *v))
+    }
 
-	#[test]
-	fn from_w16() {
-		for val in test_values_u16() {
-			let explicit_u16 = ApInt::from_u16(val);
-			let explicit_i16 = ApInt::from_i16(val as i16);
-			let implicit_u16 = ApInt::from(val);
-			let implicit_i16 = ApInt::from(val as i16);
-			let expected = ApInt{
-				len : BitWidth::w16(),
-				data: ApIntData{inl: Digit(u64::from(val))}
-			};
-			assert_eq!(explicit_u16, explicit_i16);
-			assert_eq!(explicit_u16, implicit_i16);
-			assert_eq!(explicit_u16, implicit_u16);
-			assert_eq!(explicit_u16, expected);
-		}
-	}
+    #[test]
+    fn from_w16() {
+        for val in test_values_u16() {
+            let explicit_u16 = ApInt::from_u16(val);
+            let explicit_i16 = ApInt::from_i16(val as i16);
+            let implicit_u16 = ApInt::from(val);
+            let implicit_i16 = ApInt::from(val as i16);
+            let expected = ApInt{
+                len : BitWidth::w16(),
+                data: ApIntData{inl: Digit(u64::from(val))}
+            };
+            assert_eq!(explicit_u16, explicit_i16);
+            assert_eq!(explicit_u16, implicit_i16);
+            assert_eq!(explicit_u16, implicit_u16);
+            assert_eq!(explicit_u16, expected);
+        }
+    }
 
-	fn test_values_u32() -> impl Iterator<Item=u32> {
-		test_values_u16()
-			.map(u32::from)
-			.chain(powers_from_to(16..32)
-				.map(|v| v as u32))
-			.chain([
-				u32::max_value(),
-				1_000_000,
-				999_999_999,
-				1_234_567_890
-			].into_iter().map(|v| *v))
-	}
+    fn test_values_u32() -> impl Iterator<Item=u32> {
+        test_values_u16()
+            .map(u32::from)
+            .chain(powers_from_to(16..32)
+                .map(|v| v as u32))
+            .chain([
+                u32::max_value(),
+                1_000_000,
+                999_999_999,
+                1_234_567_890
+            ].into_iter().map(|v| *v))
+    }
 
-	#[test]
-	fn from_w32() {
-		for val in test_values_u32() {
-			let explicit_u32 = ApInt::from_u32(val);
-			let explicit_i32 = ApInt::from_i32(val as i32);
-			let implicit_u32 = ApInt::from(val);
-			let implicit_i32 = ApInt::from(val as i32);
-			let expected = ApInt{
-				len : BitWidth::w32(),
-				data: ApIntData{inl: Digit(u64::from(val))}
-			};
-			assert_eq!(explicit_u32, explicit_i32);
-			assert_eq!(explicit_u32, implicit_i32);
-			assert_eq!(explicit_u32, implicit_u32);
-			assert_eq!(explicit_u32, expected);
-		}
-	}
+    #[test]
+    fn from_w32() {
+        for val in test_values_u32() {
+            let explicit_u32 = ApInt::from_u32(val);
+            let explicit_i32 = ApInt::from_i32(val as i32);
+            let implicit_u32 = ApInt::from(val);
+            let implicit_i32 = ApInt::from(val as i32);
+            let expected = ApInt{
+                len : BitWidth::w32(),
+                data: ApIntData{inl: Digit(u64::from(val))}
+            };
+            assert_eq!(explicit_u32, explicit_i32);
+            assert_eq!(explicit_u32, implicit_i32);
+            assert_eq!(explicit_u32, implicit_u32);
+            assert_eq!(explicit_u32, expected);
+        }
+    }
 
-	fn test_values_u64() -> impl Iterator<Item=u64> {
-		test_values_u32()
-			.map(u64::from)
-			.chain(powers_from_to(32..64)
-				.map(|v| v as u64))
-			.chain([
-				u64::max_value(),
-				1_000_000_000_000,
-				999_999_999_999_999_999,
-				0x0123_4567_89AB_CDEF
-			].into_iter().map(|v| *v))
-	}
+    fn test_values_u64() -> impl Iterator<Item=u64> {
+        test_values_u32()
+            .map(u64::from)
+            .chain(powers_from_to(32..64)
+                .map(|v| v as u64))
+            .chain([
+                u64::max_value(),
+                1_000_000_000_000,
+                999_999_999_999_999_999,
+                0x0123_4567_89AB_CDEF
+            ].into_iter().map(|v| *v))
+    }
 
-	#[test]
-	fn from_w64() {
-		for val in test_values_u64() {
-			let explicit_u64 = ApInt::from_u64(val);
-			let explicit_i64 = ApInt::from_i64(val as i64);
-			let implicit_u64 = ApInt::from(val);
-			let implicit_i64 = ApInt::from(val as i64);
-			let expected = ApInt{
-				len : BitWidth::w64(),
-				data: ApIntData{inl: Digit(u64::from(val))}
-			};
-			assert_eq!(explicit_u64, explicit_i64);
-			assert_eq!(explicit_u64, implicit_i64);
-			assert_eq!(explicit_u64, implicit_u64);
-			assert_eq!(explicit_u64, expected);
-		}
-	}
+    #[test]
+    fn from_w64() {
+        for val in test_values_u64() {
+            let explicit_u64 = ApInt::from_u64(val);
+            let explicit_i64 = ApInt::from_i64(val as i64);
+            let implicit_u64 = ApInt::from(val);
+            let implicit_i64 = ApInt::from(val as i64);
+            let expected = ApInt{
+                len : BitWidth::w64(),
+                data: ApIntData{inl: Digit(u64::from(val))}
+            };
+            assert_eq!(explicit_u64, explicit_i64);
+            assert_eq!(explicit_u64, implicit_i64);
+            assert_eq!(explicit_u64, implicit_u64);
+            assert_eq!(explicit_u64, expected);
+        }
+    }
 
-	fn test_values_u128() -> impl Iterator<Item=u128> {
-		test_values_u64()
-			.map(u128::from)
-			.chain(powers_from_to(64..128)
-				.map(|v| v as u128))
-			.chain([
-				u128::max_value(),
-				1_000_000_000_000_000_000_000_000,
-				999_999_999_999_999_999_999_999_999,
-				0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210
-			].into_iter().map(|v| *v))
-	}
+    fn test_values_u128() -> impl Iterator<Item=u128> {
+        test_values_u64()
+            .map(u128::from)
+            .chain(powers_from_to(64..128)
+                .map(|v| v as u128))
+            .chain([
+                u128::max_value(),
+                1_000_000_000_000_000_000_000_000,
+                999_999_999_999_999_999_999_999_999,
+                0x0123_4567_89AB_CDEF_FEDC_BA98_7654_3210
+            ].into_iter().map(|v| *v))
+    }
 
-	#[test]
-	fn from_w128() {
-		use digit::{Digit, DigitRepr};
-		for val in test_values_u128() {
-			let explicit_u128 = ApInt::from_u128(val);
-			let explicit_i128 = ApInt::from_i128(val as i128);
-			let implicit_u128 = ApInt::from(val);
-			let implicit_i128 = ApInt::from(val as i128);
-			let expected = ApInt::from_iter(
-				vec![
-					Digit((val & u128::from(u64::max_value())) as DigitRepr),
-					Digit((val >> 64) as DigitRepr)
-				]).unwrap();
-			assert_eq!(explicit_u128, explicit_i128);
-			assert_eq!(explicit_u128, implicit_i128);
-			assert_eq!(explicit_u128, implicit_u128);
-			assert_eq!(explicit_u128, expected);
-		}
-	}
+    #[test]
+    fn from_w128() {
+        use digit::{Digit, DigitRepr};
+        for val in test_values_u128() {
+            let explicit_u128 = ApInt::from_u128(val);
+            let explicit_i128 = ApInt::from_i128(val as i128);
+            let implicit_u128 = ApInt::from(val);
+            let implicit_i128 = ApInt::from(val as i128);
+            let expected = ApInt::from_iter(
+                vec![
+                    Digit((val & u128::from(u64::max_value())) as DigitRepr),
+                    Digit((val >> 64) as DigitRepr)
+                ]).unwrap();
+            assert_eq!(explicit_u128, explicit_i128);
+            assert_eq!(explicit_u128, implicit_i128);
+            assert_eq!(explicit_u128, implicit_u128);
+            assert_eq!(explicit_u128, expected);
+        }
+    }
 
-	#[test]
-	fn zero() {
-		assert_eq!(ApInt::zero(BitWidth::w1()), ApInt::from_bit(false));
-		assert_eq!(ApInt::zero(BitWidth::w8()), ApInt::from_u8(0));
-		assert_eq!(ApInt::zero(BitWidth::w16()), ApInt::from_u16(0));
-		assert_eq!(ApInt::zero(BitWidth::w32()), ApInt::from_u32(0));
-		assert_eq!(ApInt::zero(BitWidth::w64()), ApInt::from_u64(0));
-		assert_eq!(ApInt::zero(BitWidth::w128()), ApInt::from_u128(0));
-		assert_eq!(ApInt::zero(BitWidth::new(192).unwrap()), ApInt::from([0_u64; 3]));
-		assert_eq!(ApInt::zero(BitWidth::new(256).unwrap()), ApInt::from([0_u64; 4]));
-	}
+    #[test]
+    fn zero() {
+        assert_eq!(ApInt::zero(BitWidth::w1()), ApInt::from_bit(false));
+        assert_eq!(ApInt::zero(BitWidth::w8()), ApInt::from_u8(0));
+        assert_eq!(ApInt::zero(BitWidth::w16()), ApInt::from_u16(0));
+        assert_eq!(ApInt::zero(BitWidth::w32()), ApInt::from_u32(0));
+        assert_eq!(ApInt::zero(BitWidth::w64()), ApInt::from_u64(0));
+        assert_eq!(ApInt::zero(BitWidth::w128()), ApInt::from_u128(0));
+        assert_eq!(ApInt::zero(BitWidth::new(192).unwrap()), ApInt::from([0_u64; 3]));
+        assert_eq!(ApInt::zero(BitWidth::new(256).unwrap()), ApInt::from([0_u64; 4]));
+    }
 
-	#[test]
-	fn one() {
-		assert_eq!(ApInt::one(BitWidth::w1()), ApInt::from_bit(true));
-		assert_eq!(ApInt::one(BitWidth::w8()), ApInt::from_u8(1));
-		assert_eq!(ApInt::one(BitWidth::w16()), ApInt::from_u16(1));
-		assert_eq!(ApInt::one(BitWidth::w32()), ApInt::from_u32(1));
-		assert_eq!(ApInt::one(BitWidth::w64()), ApInt::from_u64(1));
-		assert_eq!(ApInt::one(BitWidth::w128()), ApInt::from_u128(1));
-		assert_eq!(ApInt::one(BitWidth::new(192).unwrap()), ApInt::from([0_u64, 0, 1]));
-		assert_eq!(ApInt::one(BitWidth::new(256).unwrap()), ApInt::from([0_u64, 0, 0, 1]));
-	}
+    #[test]
+    fn one() {
+        assert_eq!(ApInt::one(BitWidth::w1()), ApInt::from_bit(true));
+        assert_eq!(ApInt::one(BitWidth::w8()), ApInt::from_u8(1));
+        assert_eq!(ApInt::one(BitWidth::w16()), ApInt::from_u16(1));
+        assert_eq!(ApInt::one(BitWidth::w32()), ApInt::from_u32(1));
+        assert_eq!(ApInt::one(BitWidth::w64()), ApInt::from_u64(1));
+        assert_eq!(ApInt::one(BitWidth::w128()), ApInt::from_u128(1));
+        assert_eq!(ApInt::one(BitWidth::new(192).unwrap()), ApInt::from([0_u64, 0, 1]));
+        assert_eq!(ApInt::one(BitWidth::new(256).unwrap()), ApInt::from([0_u64, 0, 0, 1]));
+    }
 
-	#[test]
-	fn all_unset_eq_zero() {
-		let test_widths =
-			[
-				1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
-				100, 128, 150, 200, 250, 255, 256
-			]
-			.into_iter()
-			.map(|&w| BitWidth::new(w).unwrap());
-		for width in test_widths {
-			assert_eq!(ApInt::zero(width), ApInt::all_unset(width));
-		}
-	}
+    #[test]
+    fn all_unset_eq_zero() {
+        let test_widths =
+            [
+                1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
+                100, 128, 150, 200, 250, 255, 256
+            ]
+            .into_iter()
+            .map(|&w| BitWidth::new(w).unwrap());
+        for width in test_widths {
+            assert_eq!(ApInt::zero(width), ApInt::all_unset(width));
+        }
+    }
 
-	#[test]
-	fn same_signed_unsigned() {
-		assert_eq!(ApInt::from_i8(-1), ApInt::from_u8(0xFF));
-		assert_eq!(ApInt::from_i16(-1), ApInt::from_u16(0xFFFF));
-		assert_eq!(ApInt::from_i32(-1), ApInt::from_u32(0xFFFF_FFFF));
-		assert_eq!(ApInt::from_i64(-1), ApInt::from_u64(0xFFFF_FFFF_FFFF_FFFF));
-		assert_eq!(ApInt::from_i128(-1), ApInt::from_u128(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF));
-	}
+    #[test]
+    fn same_signed_unsigned() {
+        assert_eq!(ApInt::from_i8(-1), ApInt::from_u8(0xFF));
+        assert_eq!(ApInt::from_i16(-1), ApInt::from_u16(0xFFFF));
+        assert_eq!(ApInt::from_i32(-1), ApInt::from_u32(0xFFFF_FFFF));
+        assert_eq!(ApInt::from_i64(-1), ApInt::from_u64(0xFFFF_FFFF_FFFF_FFFF));
+        assert_eq!(ApInt::from_i128(-1), ApInt::from_u128(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF));
+    }
 
-	#[test]
-	fn all_set() {
-		assert_eq!(ApInt::all_set(BitWidth::w1()), ApInt::from_bit(true));
-		assert_eq!(ApInt::all_set(BitWidth::w8()), ApInt::from_i8(-1));
-		assert_eq!(ApInt::all_set(BitWidth::w16()), ApInt::from_i16(-1));
-		assert_eq!(ApInt::all_set(BitWidth::w32()), ApInt::from_i32(-1));
-		assert_eq!(ApInt::all_set(BitWidth::w64()), ApInt::from_i64(-1));
-		assert_eq!(ApInt::all_set(BitWidth::w128()), ApInt::from_i128(-1));
-		assert_eq!(
-			ApInt::all_set(BitWidth::new(192).unwrap()),
-			ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
-		);
-		assert_eq!(
-			ApInt::all_set(BitWidth::new(256).unwrap()),
-			ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
-		);
-	}
+    #[test]
+    fn all_set() {
+        assert_eq!(ApInt::all_set(BitWidth::w1()), ApInt::from_bit(true));
+        assert_eq!(ApInt::all_set(BitWidth::w8()), ApInt::from_i8(-1));
+        assert_eq!(ApInt::all_set(BitWidth::w16()), ApInt::from_i16(-1));
+        assert_eq!(ApInt::all_set(BitWidth::w32()), ApInt::from_i32(-1));
+        assert_eq!(ApInt::all_set(BitWidth::w64()), ApInt::from_i64(-1));
+        assert_eq!(ApInt::all_set(BitWidth::w128()), ApInt::from_i128(-1));
+        assert_eq!(
+            ApInt::all_set(BitWidth::new(192).unwrap()),
+            ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
+        );
+        assert_eq!(
+            ApInt::all_set(BitWidth::new(256).unwrap()),
+            ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
+        );
+    }
 
-	#[test]
-	fn unsiged_min_value_eq_zero() {
-		let test_widths =
-			[
-				1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
-				100, 128, 150, 200, 250, 255, 256
-			]
-			.into_iter()
-			.map(|&w| BitWidth::new(w).unwrap());
-		for width in test_widths {
-			assert_eq!(ApInt::zero(width), ApInt::unsigned_min_value(width));
-		}
-	}
+    #[test]
+    fn unsiged_min_value_eq_zero() {
+        let test_widths =
+            [
+                1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
+                100, 128, 150, 200, 250, 255, 256
+            ]
+            .into_iter()
+            .map(|&w| BitWidth::new(w).unwrap());
+        for width in test_widths {
+            assert_eq!(ApInt::zero(width), ApInt::unsigned_min_value(width));
+        }
+    }
 
-	#[test]
-	fn unsiged_max_value_eq_all_set() {
-		let test_widths =
-			[
-				1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
-				100, 128, 150, 200, 250, 255, 256
-			]
-			.into_iter()
-			.map(|&w| BitWidth::new(w).unwrap());
-		for width in test_widths {
-			assert_eq!(ApInt::all_set(width), ApInt::unsigned_max_value(width));
-		}
-	}
+    #[test]
+    fn unsiged_max_value_eq_all_set() {
+        let test_widths =
+            [
+                1_usize, 2, 4, 8, 10, 16, 32, 50, 64,
+                100, 128, 150, 200, 250, 255, 256
+            ]
+            .into_iter()
+            .map(|&w| BitWidth::new(w).unwrap());
+        for width in test_widths {
+            assert_eq!(ApInt::all_set(width), ApInt::unsigned_max_value(width));
+        }
+    }
 
-	#[test]
-	fn signed_min_value() {
-		assert_eq!(ApInt::signed_min_value(BitWidth::w1()), ApInt::from_bit(true));
-		assert_eq!(ApInt::signed_min_value(BitWidth::w8()), ApInt::from_i8(i8::min_value()));
-		assert_eq!(ApInt::signed_min_value(BitWidth::w16()), ApInt::from_i16(i16::min_value()));
-		assert_eq!(ApInt::signed_min_value(BitWidth::w32()), ApInt::from_i32(i32::min_value()));
-		assert_eq!(ApInt::signed_min_value(BitWidth::w64()), ApInt::from_i64(i64::min_value()));
-		assert_eq!(ApInt::signed_min_value(BitWidth::w128()), ApInt::from_i128(i128::min_value()));
+    #[test]
+    fn signed_min_value() {
+        assert_eq!(ApInt::signed_min_value(BitWidth::w1()), ApInt::from_bit(true));
+        assert_eq!(ApInt::signed_min_value(BitWidth::w8()), ApInt::from_i8(i8::min_value()));
+        assert_eq!(ApInt::signed_min_value(BitWidth::w16()), ApInt::from_i16(i16::min_value()));
+        assert_eq!(ApInt::signed_min_value(BitWidth::w32()), ApInt::from_i32(i32::min_value()));
+        assert_eq!(ApInt::signed_min_value(BitWidth::w64()), ApInt::from_i64(i64::min_value()));
+        assert_eq!(ApInt::signed_min_value(BitWidth::w128()), ApInt::from_i128(i128::min_value()));
 
-		{
-			let w10 = BitWidth::new(10).unwrap();
-			assert_eq!(
-				ApInt::signed_min_value(w10), ApInt::new_inl(w10, Digit(0x0000_0000_0000_0200))
-			)
-		}
-		{
-			use std::i128;
-			assert_eq!(
-				ApInt::signed_min_value(BitWidth::w128()), ApInt::from(i128::MIN)
-			);
-			assert_eq!(
-				ApInt::signed_min_value(BitWidth::w128()), ApInt::from([0x8000_0000_0000_0000_u64, 0_u64])
-			);
-			let w256 = BitWidth::new(256).unwrap();
-			assert_eq!(
-				ApInt::signed_min_value(w256), ApInt::from([0x8000_0000_0000_0000_u64, 0_u64, 0_u64, 0_u64])
-			)
-		}
-	}
+        {
+            let w10 = BitWidth::new(10).unwrap();
+            assert_eq!(
+                ApInt::signed_min_value(w10), ApInt::new_inl(w10, Digit(0x0000_0000_0000_0200))
+            )
+        }
+        {
+            use std::i128;
+            assert_eq!(
+                ApInt::signed_min_value(BitWidth::w128()), ApInt::from(i128::MIN)
+            );
+            assert_eq!(
+                ApInt::signed_min_value(BitWidth::w128()), ApInt::from([0x8000_0000_0000_0000_u64, 0_u64])
+            );
+            let w256 = BitWidth::new(256).unwrap();
+            assert_eq!(
+                ApInt::signed_min_value(w256), ApInt::from([0x8000_0000_0000_0000_u64, 0_u64, 0_u64, 0_u64])
+            )
+        }
+    }
 
-	#[test]
-	fn signed_max_value() {
-		assert_eq!(ApInt::signed_max_value(BitWidth::w1()), ApInt::from_bit(false));
-		assert_eq!(ApInt::signed_max_value(BitWidth::w8()), ApInt::from_i8(i8::max_value()));
-		assert_eq!(ApInt::signed_max_value(BitWidth::w16()), ApInt::from_i16(i16::max_value()));
-		assert_eq!(ApInt::signed_max_value(BitWidth::w32()), ApInt::from_i32(i32::max_value()));
-		assert_eq!(ApInt::signed_max_value(BitWidth::w64()), ApInt::from_i64(i64::max_value()));
-		assert_eq!(ApInt::signed_max_value(BitWidth::w128()), ApInt::from_i128(i128::max_value()));
+    #[test]
+    fn signed_max_value() {
+        assert_eq!(ApInt::signed_max_value(BitWidth::w1()), ApInt::from_bit(false));
+        assert_eq!(ApInt::signed_max_value(BitWidth::w8()), ApInt::from_i8(i8::max_value()));
+        assert_eq!(ApInt::signed_max_value(BitWidth::w16()), ApInt::from_i16(i16::max_value()));
+        assert_eq!(ApInt::signed_max_value(BitWidth::w32()), ApInt::from_i32(i32::max_value()));
+        assert_eq!(ApInt::signed_max_value(BitWidth::w64()), ApInt::from_i64(i64::max_value()));
+        assert_eq!(ApInt::signed_max_value(BitWidth::w128()), ApInt::from_i128(i128::max_value()));
 
-		{
-			let w10 = BitWidth::new(10).unwrap();
-			assert_eq!(
-				ApInt::signed_max_value(w10), ApInt::new_inl(w10, Digit(0x0000_0000_0000_01FF))
-			)
-		}
-	}
+        {
+            let w10 = BitWidth::new(10).unwrap();
+            assert_eq!(
+                ApInt::signed_max_value(w10), ApInt::new_inl(w10, Digit(0x0000_0000_0000_01FF))
+            )
+        }
+    }
 }

--- a/src/apint/mod.rs
+++ b/src/apint/mod.rs
@@ -24,17 +24,17 @@ use std::ptr::NonNull;
 
 /// An arbitrary precision integer with modulo arithmetics similar to machine integers.
 pub struct ApInt {
-	/// The width in bits of this `ApInt`.
-	len : BitWidth,
-	/// The actual data (bits) of this `ApInt`.
-	data: ApIntData
+    /// The width in bits of this `ApInt`.
+    len : BitWidth,
+    /// The actual data (bits) of this `ApInt`.
+    data: ApIntData
 }
 
 union ApIntData {
-	/// Inline storage (up to 64 bits) for small-space optimization.
-	inl: Digit,
-	/// Extern storage (>64 bits) for larger `ApInt`s.
-	ext: NonNull<Digit>
+    /// Inline storage (up to 64 bits) for small-space optimization.
+    inl: Digit,
+    /// Extern storage (>64 bits) for larger `ApInt`s.
+    ext: NonNull<Digit>
 }
 
 /// `ApInt` is safe to send between threads since it does not own

--- a/src/apint/rand_impl.rs
+++ b/src/apint/rand_impl.rs
@@ -6,19 +6,19 @@ use rand;
 
 impl rand::Rand for Digit {
     /// Creates a random `Digit` using the given random number generator.
-	fn rand<R: rand::Rng>(rng: &mut R) -> Digit {
-		Digit(rng.next_u64())
-	}
+    fn rand<R: rand::Rng>(rng: &mut R) -> Digit {
+        Digit(rng.next_u64())
+    }
 }
 
 /// # Random Utilities using `rand` crate.
 impl ApInt {
-	/// Creates a new `ApInt` with the given `BitWidth` and random `Digit`s.
-	pub fn random_with_width(width: BitWidth) -> ApInt {
-		ApInt::random_with_width_using(width, &mut rand::weak_rng())
-	}
+    /// Creates a new `ApInt` with the given `BitWidth` and random `Digit`s.
+    pub fn random_with_width(width: BitWidth) -> ApInt {
+        ApInt::random_with_width_using(width, &mut rand::weak_rng())
+    }
 
-	/// Creates a new `ApInt` with the given `BitWidth` and random `Digit`s
+    /// Creates a new `ApInt` with the given `BitWidth` and random `Digit`s
     /// using the given random number generator.
     /// 
     /// **Note:** This is useful for cryptographic or testing purposes.

--- a/src/apint/relational.rs
+++ b/src/apint/relational.rs
@@ -1,6 +1,6 @@
 use apint::{ApInt};
 use apint::utils::{
-	ZipDataAccess
+    ZipDataAccess
 };
 use errors::{Result};
 use traits::Width;
@@ -12,12 +12,12 @@ use std::ops::Not;
 
 /// If `self` and `other` have unmatching bit widths, `false` will be returned.
 impl PartialEq for ApInt {
-	fn eq(&self, other: &ApInt) -> bool {
-		if self.len_bits() != other.len_bits() {
-			return false
-		}
-		self.as_digit_slice() == other.as_digit_slice()
-	}
+    fn eq(&self, other: &ApInt) -> bool {
+        if self.len_bits() != other.len_bits() {
+            return false
+        }
+        self.as_digit_slice() == other.as_digit_slice()
+    }
 }
 
 impl Eq for ApInt {}
@@ -25,251 +25,251 @@ impl Eq for ApInt {}
 /// # Comparison Operations
 impl ApInt {
 
-	/// Unsigned less-than (`ult`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self < rhs`.
-	/// - Interprets both `ApInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_ult(&self, rhs: &ApInt) -> Result<bool> {
-		match self
-			.zip_access_data(rhs)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on unsigned less-than (slt) comparison with `lhs < rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))?
-		{
-			ZipDataAccess::Inl(lhs, rhs) => {
-				Ok(lhs.repr() < rhs.repr())
-			}
-			ZipDataAccess::Ext(lhs, rhs) => {
-				for (l, r) in lhs.into_iter().rev()
-								 .zip(rhs.into_iter().rev())
-				{
-					match l.cmp(r) {
-						Ordering::Less    => return Ok(true),
-						Ordering::Greater => return Ok(false),
-						Ordering::Equal   => ()
-					}
-				}
-				Ok(false)
-			}
-		}
-	}
+    /// Unsigned less-than (`ult`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self < rhs`.
+    /// - Interprets both `ApInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn checked_ult(&self, rhs: &ApInt) -> Result<bool> {
+        match self
+            .zip_access_data(rhs)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on unsigned less-than (slt) comparison with `lhs < rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))?
+        {
+            ZipDataAccess::Inl(lhs, rhs) => {
+                Ok(lhs.repr() < rhs.repr())
+            }
+            ZipDataAccess::Ext(lhs, rhs) => {
+                for (l, r) in lhs.into_iter().rev()
+                                 .zip(rhs.into_iter().rev())
+                {
+                    match l.cmp(r) {
+                        Ordering::Less    => return Ok(true),
+                        Ordering::Greater => return Ok(false),
+                        Ordering::Equal   => ()
+                    }
+                }
+                Ok(false)
+            }
+        }
+    }
 
-	/// Unsigned less-equals (`ule`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self <= rhs`.
-	/// - Interprets both `ApInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_ule(&self, rhs: &ApInt) -> Result<bool> {
-		rhs.checked_ult(self).map(Not::not)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on unsigned less-than or equals (ule) comparison with `lhs <= rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Unsigned less-equals (`ule`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self <= rhs`.
+    /// - Interprets both `ApInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_ule(&self, rhs: &ApInt) -> Result<bool> {
+        rhs.checked_ult(self).map(Not::not)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on unsigned less-than or equals (ule) comparison with `lhs <= rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
-	/// Unsigned greater-than (`ugt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self > rhs`.
-	/// - Interprets both `ApInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_ugt(&self, rhs: &ApInt) -> Result<bool> {
-		rhs.checked_ult(self)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on unsigned greater-than (ugt) comparison with `lhs > rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Unsigned greater-than (`ugt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self > rhs`.
+    /// - Interprets both `ApInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_ugt(&self, rhs: &ApInt) -> Result<bool> {
+        rhs.checked_ult(self)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on unsigned greater-than (ugt) comparison with `lhs > rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
-	/// Unsigned greater-equals (`uge`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self >= rhs`.
-	/// - Interprets both `ApInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_uge(&self, rhs: &ApInt) -> Result<bool> {
-		self.checked_ult(rhs).map(Not::not)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on unsigned greater-than or equals (ule) comparison with `lhs >= rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Unsigned greater-equals (`uge`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self >= rhs`.
+    /// - Interprets both `ApInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_uge(&self, rhs: &ApInt) -> Result<bool> {
+        self.checked_ult(rhs).map(Not::not)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on unsigned greater-than or equals (ule) comparison with `lhs >= rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
-	/// Signed less-than (`slt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self < rhs`.
-	/// - Interprets both `ApInt` instances as **signed** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_slt(&self, rhs: &ApInt) -> Result<bool> {
-		let lhs = self;
-		lhs.zip_access_data(rhs).and_then(|zipped| {
-			match zipped {
-				ZipDataAccess::Inl(lhs, rhs) => {
-					let infate_abs = digit::BITS - self.width().to_usize();
-					let lhs = (lhs.repr() << infate_abs) as i64;
-					let rhs = (rhs.repr() << infate_abs) as i64;
-					Ok(lhs < rhs)
-				}
-				ZipDataAccess::Ext(_, _) => {
-					match (lhs.sign_bit(), rhs.sign_bit()) {
-						(Bit::Unset, Bit::Unset) => lhs.checked_ult(rhs),
-						(Bit::Unset, Bit::Set  ) => Ok(false),
-						(Bit::Set  , Bit::Unset) => Ok(true),
-						(Bit::Set  , Bit::Set  ) => rhs.checked_ugt(lhs)
-					}
-				}
-			}
-		})
-		.map_err(|err| err.with_annotation(format!(
-			"Error occured on signed less-than (slt) comparison with `lhs < rhs` where \
-				\n\tlhs = {:?}\
-				\n\trhs = {:?}",
-			self, rhs)
-		))
-	}
+    /// Signed less-than (`slt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self < rhs`.
+    /// - Interprets both `ApInt` instances as **signed** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn checked_slt(&self, rhs: &ApInt) -> Result<bool> {
+        let lhs = self;
+        lhs.zip_access_data(rhs).and_then(|zipped| {
+            match zipped {
+                ZipDataAccess::Inl(lhs, rhs) => {
+                    let infate_abs = digit::BITS - self.width().to_usize();
+                    let lhs = (lhs.repr() << infate_abs) as i64;
+                    let rhs = (rhs.repr() << infate_abs) as i64;
+                    Ok(lhs < rhs)
+                }
+                ZipDataAccess::Ext(_, _) => {
+                    match (lhs.sign_bit(), rhs.sign_bit()) {
+                        (Bit::Unset, Bit::Unset) => lhs.checked_ult(rhs),
+                        (Bit::Unset, Bit::Set  ) => Ok(false),
+                        (Bit::Set  , Bit::Unset) => Ok(true),
+                        (Bit::Set  , Bit::Set  ) => rhs.checked_ugt(lhs)
+                    }
+                }
+            }
+        })
+        .map_err(|err| err.with_annotation(format!(
+            "Error occured on signed less-than (slt) comparison with `lhs < rhs` where \
+                \n\tlhs = {:?}\
+                \n\trhs = {:?}",
+            self, rhs)
+        ))
+    }
 
-	/// Signed less-equals (`sle`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self <= rhs`.
-	/// - Interprets both `ApInt` instances as **signed** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_sle(&self, rhs: &ApInt) -> Result<bool> {
-		rhs.checked_slt(self).map(Not::not)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on signed less-than or equals (ule) comparison with `lhs <= rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Signed less-equals (`sle`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self <= rhs`.
+    /// - Interprets both `ApInt` instances as **signed** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_sle(&self, rhs: &ApInt) -> Result<bool> {
+        rhs.checked_slt(self).map(Not::not)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on signed less-than or equals (ule) comparison with `lhs <= rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
-	/// Signed greater-than (`sgt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self > rhs`.
-	/// - Interprets both `ApInt` instances as **signed** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_sgt(&self, rhs: &ApInt) -> Result<bool> {
-		rhs.checked_slt(self)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on signed greater-than (ugt) comparison with `lhs > rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Signed greater-than (`sgt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self > rhs`.
+    /// - Interprets both `ApInt` instances as **signed** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_sgt(&self, rhs: &ApInt) -> Result<bool> {
+        rhs.checked_slt(self)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on signed greater-than (ugt) comparison with `lhs > rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
-	/// Signed greater-equals (`sge`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self >= rhs`.
-	/// - Interprets both `ApInt` instances as **signed** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_sge(&self, rhs: &ApInt) -> Result<bool> {
-		self.checked_slt(rhs).map(Not::not)
-			.map_err(|err| err.with_annotation(format!(
-				"Error occured on signed greater-than or equals (ule) comparison with `lhs >= rhs` where \
-				 \n\tlhs = {:?}\
-				 \n\trhs = {:?}",
-				self, rhs)
-			))
-	}
+    /// Signed greater-equals (`sge`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self >= rhs`.
+    /// - Interprets both `ApInt` instances as **signed** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_sge(&self, rhs: &ApInt) -> Result<bool> {
+        self.checked_slt(rhs).map(Not::not)
+            .map_err(|err| err.with_annotation(format!(
+                "Error occured on signed greater-than or equals (ule) comparison with `lhs >= rhs` where \
+                 \n\tlhs = {:?}\
+                 \n\trhs = {:?}",
+                self, rhs)
+            ))
+    }
 
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	mod partial_eq {
-		use super::*;
+    mod partial_eq {
+        use super::*;
 
-		#[test]
-		fn simple_small() {
-			let a = ApInt::from_u8(42);
-			let b = ApInt::from_u8(42);
-			let c = ApInt::from_u8(77);
-			let d = ApInt::from_u16(42);
-			assert_eq!(a, b);
-			assert_ne!(a, c);
-			assert_ne!(a, d);
-			assert_ne!(b, c);
-			assert_ne!(b, d);
-			assert_ne!(c, d);
-		}
+        #[test]
+        fn simple_small() {
+            let a = ApInt::from_u8(42);
+            let b = ApInt::from_u8(42);
+            let c = ApInt::from_u8(77);
+            let d = ApInt::from_u16(42);
+            assert_eq!(a, b);
+            assert_ne!(a, c);
+            assert_ne!(a, d);
+            assert_ne!(b, c);
+            assert_ne!(b, d);
+            assert_ne!(c, d);
+        }
 
-		#[test]
-		fn simple_large() {
-			let a = ApInt::from_u128(42);
-			let b = ApInt::from_u128(42);
-			let c = ApInt::from_u128(1337);
-			let d = ApInt::from_u64(42);
-			assert_eq!(a, b);
-			assert_ne!(a, c);
-			assert_ne!(a, d);
-			assert_ne!(b, c);
-			assert_ne!(b, d);
-			assert_ne!(c, d);
-		}
-	}
+        #[test]
+        fn simple_large() {
+            let a = ApInt::from_u128(42);
+            let b = ApInt::from_u128(42);
+            let c = ApInt::from_u128(1337);
+            let d = ApInt::from_u64(42);
+            assert_eq!(a, b);
+            assert_ne!(a, c);
+            assert_ne!(a, d);
+            assert_ne!(b, c);
+            assert_ne!(b, d);
+            assert_ne!(c, d);
+        }
+    }
 }

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -6,592 +6,592 @@ use digit;
 use std::fmt;
 
 impl fmt::Binary for ApInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if self.is_zero() {
-			return write!(f, "0")
-		}
-		let mut ds = self.as_digit_slice().into_iter().rev();
-		while let Some(digit) = ds.next() {
-			if digit.is_zero() {
-				continue;
-			}
-			write!(f, "{:b}", digit)?;
-			break
-		}
-		for digit in ds {
-			write!(f, "{:064b}", digit)?
-		}
-		Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0")
+        }
+        let mut ds = self.as_digit_slice().into_iter().rev();
+        while let Some(digit) = ds.next() {
+            if digit.is_zero() {
+                continue;
+            }
+            write!(f, "{:b}", digit)?;
+            break
+        }
+        for digit in ds {
+            write!(f, "{:064b}", digit)?
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Octal for ApInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if self.is_zero() {
-			return write!(f, "0")
-		}
-		unimplemented!()
-		// Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0")
+        }
+        unimplemented!()
+        // Ok(())
+    }
 }
 
 impl fmt::LowerHex for ApInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if self.is_zero() {
-			return write!(f, "0")
-		}
-		let mut ds = self.as_digit_slice().into_iter().rev();
-		while let Some(digit) = ds.next() {
-			if digit.is_zero() {
-				continue;
-			}
-			write!(f, "{:x}", digit)?;
-			break
-		}
-		for digit in ds {
-			write!(f, "{:016x}", digit)?
-		}
-		Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0")
+        }
+        let mut ds = self.as_digit_slice().into_iter().rev();
+        while let Some(digit) = ds.next() {
+            if digit.is_zero() {
+                continue;
+            }
+            write!(f, "{:x}", digit)?;
+            break
+        }
+        for digit in ds {
+            write!(f, "{:016x}", digit)?
+        }
+        Ok(())
+    }
 }
 
 impl fmt::UpperHex for ApInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if self.is_zero() {
-			return write!(f, "0")
-		}
-		let mut ds = self.as_digit_slice().into_iter().rev();
-		while let Some(digit) = ds.next() {
-			if digit.is_zero() {
-				continue;
-			}
-			write!(f, "{:X}", digit)?;
-			break
-		}
-		for digit in ds {
-			write!(f, "{:016X}", digit)?
-		}
-		Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0")
+        }
+        let mut ds = self.as_digit_slice().into_iter().rev();
+        while let Some(digit) = ds.next() {
+            if digit.is_zero() {
+                continue;
+            }
+            write!(f, "{:X}", digit)?;
+            break
+        }
+        for digit in ds {
+            write!(f, "{:016X}", digit)?
+        }
+        Ok(())
+    }
 }
 
 /// # Deserialization
 impl ApInt {
-	/// Parses the given `input` `String` with the given `Radix` and returns an `ApInt`
-	/// with the given `target_width` `BitWidth`.
-	/// 
-	/// **Note:** The given `input` is parsed as big-endian value. This means, the most significant bit (MSB)
-	/// is the leftst bit in the string representation provided by the user.
-	/// 
-	/// The string is assumed to contain no whitespace and contain only values within a subset of the 
-	/// range of `0`..`9` and `a`..`z` depending on the given `radix`.
-	/// 
-	/// The string is assumed to have no sign as `ApInt` does not handle signdness.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `input` is empty.
-	/// - If `input` is not a valid representation for an `ApInt` for the given `radix`.
-	/// - If `input` has trailing zero characters (`0`), e.g. `"0042"` instead of `"42"`.
-	/// - If `input` represents an `ApInt` value that does not fit into the given `target_bitwidth`.
-	/// 
-	/// # Examples
-	/// 
-	/// ```no_run
-	/// # use apint::ApInt;
-	/// let a = ApInt::from_str_radix(10, "42");      // ok
-	/// let b = ApInt::from_str_radix( 2, "1011011"); // ok (dec. = 91)
-	/// let c = ApInt::from_str_radix(16, "ffcc00");  // ok (dec. = 16763904)
-	/// let c = ApInt::from_str_radix(10, "256");     // Error: 256 does not fit within 8 bits!
-	/// let d = ApInt::from_str_radix( 2, "01020");   // Error: Invalid digit '2' at position 3 for given radix.
-	/// let e = ApInt::from_str_radix(16, "hello");   // Error: "hello" is not a valid ApInt representation!
-	/// ```
-	pub fn from_str_radix<R, S>(radix: R, input: S) -> Result<ApInt>
-		where R: Into<Radix>,
-		      S: AsRef<str>
-	{
-		let radix = radix.into();
-		let input = input.as_ref();
+    /// Parses the given `input` `String` with the given `Radix` and returns an `ApInt`
+    /// with the given `target_width` `BitWidth`.
+    /// 
+    /// **Note:** The given `input` is parsed as big-endian value. This means, the most significant bit (MSB)
+    /// is the leftst bit in the string representation provided by the user.
+    /// 
+    /// The string is assumed to contain no whitespace and contain only values within a subset of the 
+    /// range of `0`..`9` and `a`..`z` depending on the given `radix`.
+    /// 
+    /// The string is assumed to have no sign as `ApInt` does not handle signdness.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `input` is empty.
+    /// - If `input` is not a valid representation for an `ApInt` for the given `radix`.
+    /// - If `input` has trailing zero characters (`0`), e.g. `"0042"` instead of `"42"`.
+    /// - If `input` represents an `ApInt` value that does not fit into the given `target_bitwidth`.
+    /// 
+    /// # Examples
+    /// 
+    /// ```no_run
+    /// # use apint::ApInt;
+    /// let a = ApInt::from_str_radix(10, "42");      // ok
+    /// let b = ApInt::from_str_radix( 2, "1011011"); // ok (dec. = 91)
+    /// let c = ApInt::from_str_radix(16, "ffcc00");  // ok (dec. = 16763904)
+    /// let c = ApInt::from_str_radix(10, "256");     // Error: 256 does not fit within 8 bits!
+    /// let d = ApInt::from_str_radix( 2, "01020");   // Error: Invalid digit '2' at position 3 for given radix.
+    /// let e = ApInt::from_str_radix(16, "hello");   // Error: "hello" is not a valid ApInt representation!
+    /// ```
+    pub fn from_str_radix<R, S>(radix: R, input: S) -> Result<ApInt>
+        where R: Into<Radix>,
+              S: AsRef<str>
+    {
+        let radix = radix.into();
+        let input = input.as_ref();
 
-		if input.is_empty() {
-			return Err(Error::invalid_string_repr(input, radix)
-				.with_annotation("Cannot parse an empty string into an ApInt."))
-		}
-		if input.starts_with('_') {
-			return Err(Error::invalid_string_repr(input, radix)
-				.with_annotation("The input string starts with an underscore ('_') instead of a number. \
-					              The use of underscores is explicitely for separation of digits."))
-		}
-		if input.ends_with('_') {
-			return Err(Error::invalid_string_repr(input, radix)
-				.with_annotation("The input string ends with an underscore ('_') instead of a number. \
-					              The use of underscores is explicitely for separation of digits."))
-		}
+        if input.is_empty() {
+            return Err(Error::invalid_string_repr(input, radix)
+                .with_annotation("Cannot parse an empty string into an ApInt."))
+        }
+        if input.starts_with('_') {
+            return Err(Error::invalid_string_repr(input, radix)
+                .with_annotation("The input string starts with an underscore ('_') instead of a number. \
+                                  The use of underscores is explicitely for separation of digits."))
+        }
+        if input.ends_with('_') {
+            return Err(Error::invalid_string_repr(input, radix)
+                .with_annotation("The input string ends with an underscore ('_') instead of a number. \
+                                  The use of underscores is explicitely for separation of digits."))
+        }
 
-		// First normalize all characters to plain digit values.
-		let mut v = Vec::with_capacity(input.len());
-		for (i, b) in input.bytes().enumerate() {
-			let d = match b {
-				b'0'...b'9' => b - b'0',
-				b'a'...b'z' => b - b'a' + 10,
-				b'A'...b'Z' => b - b'A' + 10,
-				b'_' => continue,
-				_ => ::std::u8::MAX
-			};
-			if !radix.is_valid_byte(d) {
-				return Err(Error::invalid_char_in_string_repr(input, radix, i, char::from(b)))
-			}
-			v.push(d);
-		}
+        // First normalize all characters to plain digit values.
+        let mut v = Vec::with_capacity(input.len());
+        for (i, b) in input.bytes().enumerate() {
+            let d = match b {
+                b'0'...b'9' => b - b'0',
+                b'a'...b'z' => b - b'a' + 10,
+                b'A'...b'Z' => b - b'A' + 10,
+                b'_' => continue,
+                _ => ::std::u8::MAX
+            };
+            if !radix.is_valid_byte(d) {
+                return Err(Error::invalid_char_in_string_repr(input, radix, i, char::from(b)))
+            }
+            v.push(d);
+        }
 
-		let result = match radix.exact_bits_per_digit() {
-			Some(bits) => {
-				v.reverse();
-				if digit::BITS % bits == 0 {
-					ApInt::from_bitwise_digits(&v, bits)
-				}
-				else {
-					ApInt::from_inexact_bitwise_digits(&v, bits)
-				}
-			}
-			None => {
-				ApInt::from_radix_digits(&v, radix)
-			}
-		};
+        let result = match radix.exact_bits_per_digit() {
+            Some(bits) => {
+                v.reverse();
+                if digit::BITS % bits == 0 {
+                    ApInt::from_bitwise_digits(&v, bits)
+                }
+                else {
+                    ApInt::from_inexact_bitwise_digits(&v, bits)
+                }
+            }
+            None => {
+                ApInt::from_radix_digits(&v, radix)
+            }
+        };
 
 
-		Ok(result)
-	}
+        Ok(result)
+    }
 
-	// Convert from a power of two radix (bits == ilog2(radix)) where bits evenly divides
-	// Digit::BITS.
-	// 
-	// Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L126
-	// 
-	// TODO: Better document what happens here and why.
-	fn from_bitwise_digits(v: &[u8], bits: usize) -> ApInt {
-		use digit;
-		use digit::{DigitRepr, Digit};
+    // Convert from a power of two radix (bits == ilog2(radix)) where bits evenly divides
+    // Digit::BITS.
+    // 
+    // Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L126
+    // 
+    // TODO: Better document what happens here and why.
+    fn from_bitwise_digits(v: &[u8], bits: usize) -> ApInt {
+        use digit;
+        use digit::{DigitRepr, Digit};
 
-	    debug_assert!(!v.is_empty() && bits <= 8 && digit::BITS % bits == 0);
-	    debug_assert!(v.iter().all(|&c| DigitRepr::from(c) < (1 << bits)));
+        debug_assert!(!v.is_empty() && bits <= 8 && digit::BITS % bits == 0);
+        debug_assert!(v.iter().all(|&c| DigitRepr::from(c) < (1 << bits)));
 
-	    let radix_digits_per_digit = digit::BITS / bits;
+        let radix_digits_per_digit = digit::BITS / bits;
 
-	    let data = v.chunks(radix_digits_per_digit)
-	                .map(|chunk| chunk.iter()
-	                	              .rev()
-	                	              .fold(0, |acc, &c| (acc << bits) | DigitRepr::from(c)))
-	                .map(Digit);
+        let data = v.chunks(radix_digits_per_digit)
+                    .map(|chunk| chunk.iter()
+                                      .rev()
+                                      .fold(0, |acc, &c| (acc << bits) | DigitRepr::from(c)))
+                    .map(Digit);
 
-	    ApInt::from_iter(data).unwrap()
-	}
+        ApInt::from_iter(data).unwrap()
+    }
 
-	// Convert from a power of two radix (bits == ilog2(radix)) where bits doesn't evenly divide
-	// Digit::BITS.
-	// 
-	// Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L143
-	// 
-	// TODO: Better document what happens here and why.
-	fn from_inexact_bitwise_digits(v: &[u8], bits: usize) -> ApInt {
-		use digit;
-		use digit::{DigitRepr, Digit};
+    // Convert from a power of two radix (bits == ilog2(radix)) where bits doesn't evenly divide
+    // Digit::BITS.
+    // 
+    // Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L143
+    // 
+    // TODO: Better document what happens here and why.
+    fn from_inexact_bitwise_digits(v: &[u8], bits: usize) -> ApInt {
+        use digit;
+        use digit::{DigitRepr, Digit};
 
-	    debug_assert!(!v.is_empty() && bits <= 8 && digit::BITS % bits != 0);
-	    debug_assert!(v.iter().all(|&c| (DigitRepr::from(c)) < (1 << bits)));
+        debug_assert!(!v.is_empty() && bits <= 8 && digit::BITS % bits != 0);
+        debug_assert!(v.iter().all(|&c| (DigitRepr::from(c)) < (1 << bits)));
 
-	    let len_digits = (v.len() * bits + digit::BITS - 1) / digit::BITS;
-	    let mut data = Vec::with_capacity(len_digits);
+        let len_digits = (v.len() * bits + digit::BITS - 1) / digit::BITS;
+        let mut data = Vec::with_capacity(len_digits);
 
-	    let mut d = 0;
-	    let mut dbits = 0; // Number of bits we currently have in d.
+        let mut d = 0;
+        let mut dbits = 0; // Number of bits we currently have in d.
 
-	    // Walk v accumulating bits in d; whenever we accumulate digit::BITS in d, spit out a digit:
-	    for &c in v {
-	        d |= (DigitRepr::from(c)) << dbits;
-	        dbits += bits;
+        // Walk v accumulating bits in d; whenever we accumulate digit::BITS in d, spit out a digit:
+        for &c in v {
+            d |= (DigitRepr::from(c)) << dbits;
+            dbits += bits;
 
-	        if dbits >= digit::BITS {
-	            data.push(Digit(d));
-	            dbits -= digit::BITS;
-	            // If `dbits` was greater than `digit::BITS`, we dropped some of the bits in c
-	            // (they couldn't fit in d) - grab the bits we lost here:
-	            d = (DigitRepr::from(c)) >> (bits - dbits);
-	        }
-	    }
+            if dbits >= digit::BITS {
+                data.push(Digit(d));
+                dbits -= digit::BITS;
+                // If `dbits` was greater than `digit::BITS`, we dropped some of the bits in c
+                // (they couldn't fit in d) - grab the bits we lost here:
+                d = (DigitRepr::from(c)) >> (bits - dbits);
+            }
+        }
 
-	    if dbits > 0 {
-	        debug_assert!(dbits < digit::BITS);
-	        data.push(Digit(d));
-	    }
+        if dbits > 0 {
+            debug_assert!(dbits < digit::BITS);
+            data.push(Digit(d));
+        }
 
-	    ApInt::from_iter(data).unwrap()
-	}
+        ApInt::from_iter(data).unwrap()
+    }
 
-	// Read little-endian radix digits.
-	// 
-	// Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L177
-	// 
-	// TODO: This does not work, yet. Some parts of the algorithm are
-	//       commented-out since the required functionality does not exist, yet.
-	fn from_radix_digits(v: &[u8], radix: Radix) -> ApInt {
-		use digit;
-		use digit::{DigitRepr, Digit};
+    // Read little-endian radix digits.
+    // 
+    // Forked from: https://github.com/rust-num/num/blob/master/bigint/src/biguint.rs#L177
+    // 
+    // TODO: This does not work, yet. Some parts of the algorithm are
+    //       commented-out since the required functionality does not exist, yet.
+    fn from_radix_digits(v: &[u8], radix: Radix) -> ApInt {
+        use digit;
+        use digit::{DigitRepr, Digit};
 
-	    debug_assert!(!v.is_empty() && !radix.is_power_of_two());
-	    debug_assert!(v.iter().all(|&c| radix.is_valid_byte(c)));
+        debug_assert!(!v.is_empty() && !radix.is_power_of_two());
+        debug_assert!(v.iter().all(|&c| radix.is_valid_byte(c)));
 
-	    // Estimate how big the result will be, so we can pre-allocate it.
-	    let bits = (f64::from(radix.to_u8())).log2() * v.len() as f64;
-	    let big_digits = (bits / digit::BITS as f64).ceil();
-	    let mut data = Vec::with_capacity(big_digits as usize);
+        // Estimate how big the result will be, so we can pre-allocate it.
+        let bits = (f64::from(radix.to_u8())).log2() * v.len() as f64;
+        let big_digits = (bits / digit::BITS as f64).ceil();
+        let mut data = Vec::with_capacity(big_digits as usize);
 
-	    let (_base, power) = radix.get_radix_base();
-	    let radix = DigitRepr::from(radix.to_u8());
+        let (_base, power) = radix.get_radix_base();
+        let radix = DigitRepr::from(radix.to_u8());
 
-	    let r = v.len() % power;
-	    let i = if r == 0 {
-	        power
-	    } else {
-	        r
-	    };
-	    let (head, tail) = v.split_at(i);
+        let r = v.len() % power;
+        let i = if r == 0 {
+            power
+        } else {
+            r
+        };
+        let (head, tail) = v.split_at(i);
 
-	    let first = head.iter().fold(0, |acc, &d| acc * radix + DigitRepr::from(d));
-	    data.push(first);
+        let first = head.iter().fold(0, |acc, &d| acc * radix + DigitRepr::from(d));
+        data.push(first);
 
-	    debug_assert!(tail.len() % power == 0);
-	    for chunk in tail.chunks(power) {
-	        if data.last() != Some(&0) {
-	            data.push(0);
-	        }
+        debug_assert!(tail.len() % power == 0);
+        for chunk in tail.chunks(power) {
+            if data.last() != Some(&0) {
+                data.push(0);
+            }
 
-	        let mut carry = 0;
-	        for _d in &mut data {
-	            // *d = mac_with_carry(0, *d, base, &mut carry); // TODO! This was commented out.
+            let mut carry = 0;
+            for _d in &mut data {
+                // *d = mac_with_carry(0, *d, base, &mut carry); // TODO! This was commented out.
 
-				// // fn carry_mul_add(a: Digit, b: Digit, c: Digit, carry: Digit) -> DigitAndCarry
-				// // Returns the result of `(a + (b * c)) + carry` and its implied carry value.
+                // // fn carry_mul_add(a: Digit, b: Digit, c: Digit, carry: Digit) -> DigitAndCarry
+                // // Returns the result of `(a + (b * c)) + carry` and its implied carry value.
 
-	            // let DigitAndCarry(d, carry) = carry_mul_add(digit::ZERO, *d, base, carry); // TODO! This was commented out.
-	        }
-	        debug_assert!(carry == 0);
+                // let DigitAndCarry(d, carry) = carry_mul_add(digit::ZERO, *d, base, carry); // TODO! This was commented out.
+            }
+            debug_assert!(carry == 0);
 
-	        let _n = chunk.iter().fold(0, |acc, &d| acc * radix + DigitRepr::from(d));
-	        // add2(&mut data, &[n]); // TODO: This was commented out.
-	    }
+            let _n = chunk.iter().fold(0, |acc, &d| acc * radix + DigitRepr::from(d));
+            // add2(&mut data, &[n]); // TODO: This was commented out.
+        }
 
-	    ApInt::from_iter(data.into_iter().map(Digit)).unwrap()
-	}
+        ApInt::from_iter(data.into_iter().map(Digit)).unwrap()
+    }
 }
 
 //  =======================================================================
 ///  Serialization
 /// =======================================================================
 impl ApInt {
-	/// Returns a `String` representation of the binary encoded `ApInt` for the given `Radix`.
-	pub fn to_string_radix<R>(&self, radix: R) -> String
-		where R: Into<Radix>
-	{
-		let _radix = radix.into();
+    /// Returns a `String` representation of the binary encoded `ApInt` for the given `Radix`.
+    pub fn to_string_radix<R>(&self, radix: R) -> String
+        where R: Into<Radix>
+    {
+        let _radix = radix.into();
 
-		unimplemented!();
-	}
+        unimplemented!();
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	use bitwidth::{BitWidth};
+    use bitwidth::{BitWidth};
 
-	mod binary {
-		use super::*;
+    mod binary {
+        use super::*;
 
-		fn assert_binary(val: ApInt, expected: &str) {
-			assert_eq!(
-				format!("{:b}", val),
-				expected
-			)
-		}
+        fn assert_binary(val: ApInt, expected: &str) {
+            assert_eq!(
+                format!("{:b}", val),
+                expected
+            )
+        }
 
-		#[test]
-		fn small() {
-			assert_binary(
-				ApInt::zero(BitWidth::w32()),
-				"0"
-			);
-			assert_binary(
-				ApInt::one(BitWidth::w32()),
-				"1"
-			);
-			assert_binary(
-				ApInt::from(0b_1010_0110_0110_1001_u32),
-				"1010011001101001"
-			);
-			assert_binary(
-				ApInt::all_set(BitWidth::w32()),
-				"11111111111111111111111111111111" // 32 ones
-			);
-			assert_binary(
-				ApInt::signed_min_value(BitWidth::w32()),
-				"10000000000000000000000000000000" // 31 zeros
-			);
-			assert_binary(
-				ApInt::signed_max_value(BitWidth::w32()),
-				"1111111111111111111111111111111"  // 31 ones
-			);
-		}
+        #[test]
+        fn small() {
+            assert_binary(
+                ApInt::zero(BitWidth::w32()),
+                "0"
+            );
+            assert_binary(
+                ApInt::one(BitWidth::w32()),
+                "1"
+            );
+            assert_binary(
+                ApInt::from(0b_1010_0110_0110_1001_u32),
+                "1010011001101001"
+            );
+            assert_binary(
+                ApInt::all_set(BitWidth::w32()),
+                "11111111111111111111111111111111" // 32 ones
+            );
+            assert_binary(
+                ApInt::signed_min_value(BitWidth::w32()),
+                "10000000000000000000000000000000" // 31 zeros
+            );
+            assert_binary(
+                ApInt::signed_max_value(BitWidth::w32()),
+                "1111111111111111111111111111111"  // 31 ones
+            );
+        }
 
-		#[test]
-		fn large() {
-			assert_binary(
-				ApInt::zero(BitWidth::w128()),
-				"0"
-			);
-			assert_binary(
-				ApInt::one(BitWidth::w128()),
-				"1"
-			);
-			assert_binary(
-				ApInt::from(0b_1010_0110_0110_1001_u128),
-				"1010011001101001"
-			);
-			assert_binary(
-				ApInt::all_set(BitWidth::w128()),
-				"11111111111111111111111111111111\
-				 11111111111111111111111111111111\
-				 11111111111111111111111111111111\
-				 11111111111111111111111111111111"
-			);
-			assert_binary(
-				ApInt::signed_min_value(BitWidth::w128()),
-				"10000000000000000000000000000000\
-				 00000000000000000000000000000000\
-				 00000000000000000000000000000000\
-				 00000000000000000000000000000000"
-			);
-			assert_binary(
-				ApInt::signed_max_value(BitWidth::w128()),
-				"1111111111111111111111111111111\
-				 11111111111111111111111111111111\
-				 11111111111111111111111111111111\
-				 11111111111111111111111111111111"
-			);
-		}
-	}
+        #[test]
+        fn large() {
+            assert_binary(
+                ApInt::zero(BitWidth::w128()),
+                "0"
+            );
+            assert_binary(
+                ApInt::one(BitWidth::w128()),
+                "1"
+            );
+            assert_binary(
+                ApInt::from(0b_1010_0110_0110_1001_u128),
+                "1010011001101001"
+            );
+            assert_binary(
+                ApInt::all_set(BitWidth::w128()),
+                "11111111111111111111111111111111\
+                 11111111111111111111111111111111\
+                 11111111111111111111111111111111\
+                 11111111111111111111111111111111"
+            );
+            assert_binary(
+                ApInt::signed_min_value(BitWidth::w128()),
+                "10000000000000000000000000000000\
+                 00000000000000000000000000000000\
+                 00000000000000000000000000000000\
+                 00000000000000000000000000000000"
+            );
+            assert_binary(
+                ApInt::signed_max_value(BitWidth::w128()),
+                "1111111111111111111111111111111\
+                 11111111111111111111111111111111\
+                 11111111111111111111111111111111\
+                 11111111111111111111111111111111"
+            );
+        }
+    }
 
-	mod hex {
-		use super::*;
+    mod hex {
+        use super::*;
 
-		fn assert_hex(val: ApInt, expected: &str) {
-			assert_eq!(
-				format!("{:x}", val),
-				expected.to_lowercase()
-			);
-			assert_eq!(
-				format!("{:X}", val),
-				expected.to_uppercase()
-			)
-		}
+        fn assert_hex(val: ApInt, expected: &str) {
+            assert_eq!(
+                format!("{:x}", val),
+                expected.to_lowercase()
+            );
+            assert_eq!(
+                format!("{:X}", val),
+                expected.to_uppercase()
+            )
+        }
 
-		#[test]
-		fn small() {
-			assert_hex(
-				ApInt::zero(BitWidth::w32()),
-				"0"
-			);
-			assert_hex(
-				ApInt::one(BitWidth::w32()),
-				"1"
-			);
-			assert_hex(
-				ApInt::from(0xFEDC_BA98_u32),
-				"FEDC\
-				 BA98"
-			);
-			assert_hex(
-				ApInt::all_set(BitWidth::w32()),
-				"FFFF\
-				 FFFF"
-			);
-			assert_hex(
-				ApInt::signed_min_value(BitWidth::w32()),
-				"8000\
-				 0000"
-			);
-			assert_hex(
-				ApInt::signed_max_value(BitWidth::w32()),
-				"7FFF\
-				 FFFF"
-			);
-		}
+        #[test]
+        fn small() {
+            assert_hex(
+                ApInt::zero(BitWidth::w32()),
+                "0"
+            );
+            assert_hex(
+                ApInt::one(BitWidth::w32()),
+                "1"
+            );
+            assert_hex(
+                ApInt::from(0xFEDC_BA98_u32),
+                "FEDC\
+                 BA98"
+            );
+            assert_hex(
+                ApInt::all_set(BitWidth::w32()),
+                "FFFF\
+                 FFFF"
+            );
+            assert_hex(
+                ApInt::signed_min_value(BitWidth::w32()),
+                "8000\
+                 0000"
+            );
+            assert_hex(
+                ApInt::signed_max_value(BitWidth::w32()),
+                "7FFF\
+                 FFFF"
+            );
+        }
 
-		#[test]
-		fn large() {
-			assert_hex(
-				ApInt::zero(BitWidth::w128()),
-				"0"
-			);
-			assert_hex(
-				ApInt::one(BitWidth::w128()),
-				"1"
-			);
-			assert_hex(
-				ApInt::from(0xFEDC_BA98_0A1B_7654_ABCD_0123_u128),
-				"FEDC\
-				 BA98\
-				 0A1B\
-				 7654\
-				 ABCD\
-				 0123"
-			);
-			assert_hex(
-				ApInt::all_set(BitWidth::w128()),
-				"FFFFFFFF\
-				 FFFFFFFF\
-				 FFFFFFFF\
-				 FFFFFFFF"
-			);
-			assert_hex(
-				ApInt::signed_min_value(BitWidth::w128()),
-				"80000000\
-				 00000000\
-				 00000000\
-				 00000000"
-			);
-			assert_hex(
-				ApInt::signed_max_value(BitWidth::w128()),
-				"7FFFFFFF\
-				 FFFFFFFF\
-				 FFFFFFFF\
-				 FFFFFFFF"
-			);
-		}
-	}
+        #[test]
+        fn large() {
+            assert_hex(
+                ApInt::zero(BitWidth::w128()),
+                "0"
+            );
+            assert_hex(
+                ApInt::one(BitWidth::w128()),
+                "1"
+            );
+            assert_hex(
+                ApInt::from(0xFEDC_BA98_0A1B_7654_ABCD_0123_u128),
+                "FEDC\
+                 BA98\
+                 0A1B\
+                 7654\
+                 ABCD\
+                 0123"
+            );
+            assert_hex(
+                ApInt::all_set(BitWidth::w128()),
+                "FFFFFFFF\
+                 FFFFFFFF\
+                 FFFFFFFF\
+                 FFFFFFFF"
+            );
+            assert_hex(
+                ApInt::signed_min_value(BitWidth::w128()),
+                "80000000\
+                 00000000\
+                 00000000\
+                 00000000"
+            );
+            assert_hex(
+                ApInt::signed_max_value(BitWidth::w128()),
+                "7FFFFFFF\
+                 FFFFFFFF\
+                 FFFFFFFF\
+                 FFFFFFFF"
+            );
+        }
+    }
 
-	mod from_str_radix {
+    mod from_str_radix {
 
-		use super::*;
+        use super::*;
 
-		fn test_radices() -> impl Iterator<Item=Radix> {
-			[2, 4, 8, 16, 32, 7, 10, 36].into_iter().map(|&r| Radix::new(r).unwrap())
-		}
+        fn test_radices() -> impl Iterator<Item=Radix> {
+            [2, 4, 8, 16, 32, 7, 10, 36].into_iter().map(|&r| Radix::new(r).unwrap())
+        }
 
-		#[test]
-		fn empty() {
-			for radix in test_radices() {
-				assert_eq!(
-					ApInt::from_str_radix(radix, ""),
-					Err(Error::invalid_string_repr("", radix)
-						.with_annotation("Cannot parse an empty string into an ApInt."))
-				)
-			}
-		}
+        #[test]
+        fn empty() {
+            for radix in test_radices() {
+                assert_eq!(
+                    ApInt::from_str_radix(radix, ""),
+                    Err(Error::invalid_string_repr("", radix)
+                        .with_annotation("Cannot parse an empty string into an ApInt."))
+                )
+            }
+        }
 
-		#[test]
-		fn starts_with_underscore() {
-			for radix in test_radices() {
-				for &input in &["_0", "_123", "__", "_1_0"] {
-					assert_eq!(
-						ApInt::from_str_radix(radix, input),
-						Err(Error::invalid_string_repr(input, radix)
-						    .with_annotation("The input string starts with an underscore ('_') instead of a number. \
-						                      The use of underscores is explicitely for separation of digits."))
-					)
-				}
-			}
-		}
+        #[test]
+        fn starts_with_underscore() {
+            for radix in test_radices() {
+                for &input in &["_0", "_123", "__", "_1_0"] {
+                    assert_eq!(
+                        ApInt::from_str_radix(radix, input),
+                        Err(Error::invalid_string_repr(input, radix)
+                            .with_annotation("The input string starts with an underscore ('_') instead of a number. \
+                                              The use of underscores is explicitely for separation of digits."))
+                    )
+                }
+            }
+        }
 
-		#[test]
-		fn ends_with_underscore() {
-			for radix in test_radices() {
-				for &input in &["0_", "123_", "1_0_"] {
-					assert_eq!(
-						ApInt::from_str_radix(radix, input),
-						Err(Error::invalid_string_repr(input, radix)
-						    .with_annotation("The input string ends with an underscore ('_') instead of a number. \
-						                      The use of underscores is explicitely for separation of digits."))
-					)
-				}
-			}
-		}
+        #[test]
+        fn ends_with_underscore() {
+            for radix in test_radices() {
+                for &input in &["0_", "123_", "1_0_"] {
+                    assert_eq!(
+                        ApInt::from_str_radix(radix, input),
+                        Err(Error::invalid_string_repr(input, radix)
+                            .with_annotation("The input string ends with an underscore ('_') instead of a number. \
+                                              The use of underscores is explicitely for separation of digits."))
+                    )
+                }
+            }
+        }
 
-		#[test]
-		fn zero() {
-			for radix in test_radices() {
-				assert_eq!(
-					ApInt::from_str_radix(radix, "0"),
-					Ok(ApInt::zero(BitWidth::new(64).unwrap()))
-				)
-			}
-		}
+        #[test]
+        fn zero() {
+            for radix in test_radices() {
+                assert_eq!(
+                    ApInt::from_str_radix(radix, "0"),
+                    Ok(ApInt::zero(BitWidth::new(64).unwrap()))
+                )
+            }
+        }
 
-		#[test]
-		fn small_values() {
-			use std::u64;
-			let samples = vec![
-				// (Radix, Input String, Expected ApInt)
+        #[test]
+        fn small_values() {
+            use std::u64;
+            let samples = vec![
+                // (Radix, Input String, Expected ApInt)
 
-				( 2,  "0",  0),
-				( 8,  "0",  0),
-				(10,  "0",  0),
-				(16,  "0",  0),
+                ( 2,  "0",  0),
+                ( 8,  "0",  0),
+                (10,  "0",  0),
+                (16,  "0",  0),
 
-				( 2,  "1",  1),
-				( 8,  "1",  1),
-				(10,  "1",  1),
-				(16,  "1",  1),
+                ( 2,  "1",  1),
+                ( 8,  "1",  1),
+                (10,  "1",  1),
+                (16,  "1",  1),
 
-				( 2, "10",  2),
-				( 8, "10",  8),
-				(10, "10", 10),
-				(16, "10", 16),
+                ( 2, "10",  2),
+                ( 8, "10",  8),
+                (10, "10", 10),
+                (16, "10", 16),
 
-				( 2, "11",  3),
-				( 8, "11",  9),
-				(10, "11", 11),
-				(16, "11", 17),
+                ( 2, "11",  3),
+                ( 8, "11",  9),
+                (10, "11", 11),
+                (16, "11", 17),
 
-				( 2, "1001_0011", 0b1001_0011),
-				( 2, "0001_0001_0001_0001", 0x1111),
-				( 2, "0101_0101_0101_0101", 0x5555),
-				( 2, "1010_1010_1010_1010", 0xAAAA),
-				( 2, "1111_1111_1111_1111", 0xFFFF),
-				( 2, "1111_1111_1111_1111\
-					  1111_1111_1111_1111\
-					  1111_1111_1111_1111\
-					  1111_1111_1111_1111", u64::max_value()),
+                ( 2, "1001_0011", 0b1001_0011),
+                ( 2, "0001_0001_0001_0001", 0x1111),
+                ( 2, "0101_0101_0101_0101", 0x5555),
+                ( 2, "1010_1010_1010_1010", 0xAAAA),
+                ( 2, "1111_1111_1111_1111", 0xFFFF),
+                ( 2, "1111_1111_1111_1111\
+                      1111_1111_1111_1111\
+                      1111_1111_1111_1111\
+                      1111_1111_1111_1111", u64::max_value()),
 
-				( 8, "7654_3210", 0o7654_3210),
-				( 8, "0123_4567", 0o0123_4567),
-				( 8, "777_747_666", 0o777_747_666),
-				( 8, "111", 0b001_001_001),
-				( 8,  "7_7777_7777_7777_7777_7777", u64::max_value() / 2),
-				// ( 8, "17_7777_7777_7777_7777_7777", u64::max_value()), // Does not work, yet! Should it work?
+                ( 8, "7654_3210", 0o7654_3210),
+                ( 8, "0123_4567", 0o0123_4567),
+                ( 8, "777_747_666", 0o777_747_666),
+                ( 8, "111", 0b001_001_001),
+                ( 8,  "7_7777_7777_7777_7777_7777", u64::max_value() / 2),
+                // ( 8, "17_7777_7777_7777_7777_7777", u64::max_value()), // Does not work, yet! Should it work?
 
-				(10, "100", 100),
-				(10, "42", 42),
-				(10, "1337", 1337),
-				(10, "5_000_000", 5_000_000),
-				// (10, "18_446_744_073_709_551_615", u64::max_value()), // Does not work, yet!
+                (10, "100", 100),
+                (10, "42", 42),
+                (10, "1337", 1337),
+                (10, "5_000_000", 5_000_000),
+                // (10, "18_446_744_073_709_551_615", u64::max_value()), // Does not work, yet!
 
-				(16, "100", 0x100),
-				(16, "42", 0x42),
-				(16, "1337", 0x1337),
-				(16, "1111", 0x1111),
-				(16, "5555", 0x5555),
-				(16, "FFFF", 0xFFFF),
-				(16, "0123_4567_89AB_CDEF", 0x0123_4567_89AB_CDEF),
-				(16, "FEDC_BA98_7654_3210", 0xFEDC_BA98_7654_3210)
-			];
-			for sample in &samples {
-				let radix = Radix::new(sample.0).unwrap();
-				let input = sample.1;
-				let result = ApInt::from_str_radix(radix, input).unwrap();
-				let expected = ApInt::from_u64(sample.2);
-				assert_eq!(result, expected)
-			}
-		}
-	}
+                (16, "100", 0x100),
+                (16, "42", 0x42),
+                (16, "1337", 0x1337),
+                (16, "1111", 0x1111),
+                (16, "5555", 0x5555),
+                (16, "FFFF", 0xFFFF),
+                (16, "0123_4567_89AB_CDEF", 0x0123_4567_89AB_CDEF),
+                (16, "FEDC_BA98_7654_3210", 0xFEDC_BA98_7654_3210)
+            ];
+            for sample in &samples {
+                let radix = Radix::new(sample.0).unwrap();
+                let input = sample.1;
+                let result = ApInt::from_str_radix(radix, input).unwrap();
+                let expected = ApInt::from_u64(sample.2);
+                assert_eq!(result, expected)
+            }
+        }
+    }
 }

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -132,9 +132,9 @@ impl ApInt {
         let mut v = Vec::with_capacity(input.len());
         for (i, b) in input.bytes().enumerate() {
             let d = match b {
-                b'0'...b'9' => b - b'0',
-                b'a'...b'z' => b - b'a' + 10,
-                b'A'...b'Z' => b - b'A' + 10,
+                b'0'..=b'9' => b - b'0',
+                b'a'..=b'z' => b - b'a' + 10,
+                b'A'..=b'Z' => b - b'A' + 10,
                 b'_' => continue,
                 _ => ::std::u8::MAX
             };

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -16,552 +16,552 @@ use utils::{try_forward_bin_mut_impl};
 pub struct ShiftAmount(usize);
 
 impl ShiftAmount {
-	/// Returns the internal shift amount representation as `usize`.
-	#[inline]
-	pub fn to_usize(self) -> usize {
-		self.0
-	}
+    /// Returns the internal shift amount representation as `usize`.
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0
+    }
 
-	/// Returns the number of digits this `ShiftAmount` will leap over.
-	/// 
-	/// # Examples
-	/// 
-	/// - `ShiftAmount(50)` leaps over zero digits.
-	/// - `ShiftAmount(64)` leaps exactly over one digit.
-	/// - `ShiftAmount(100)` leaps over 1 digit.
-	/// - `ShiftAmount(150)` leaps over 2 digits.
-	#[inline]
-	pub(in apint) fn digit_steps(self) -> usize {
-		self.to_usize() / digit::BITS
-	}
+    /// Returns the number of digits this `ShiftAmount` will leap over.
+    /// 
+    /// # Examples
+    /// 
+    /// - `ShiftAmount(50)` leaps over zero digits.
+    /// - `ShiftAmount(64)` leaps exactly over one digit.
+    /// - `ShiftAmount(100)` leaps over 1 digit.
+    /// - `ShiftAmount(150)` leaps over 2 digits.
+    #[inline]
+    pub(in apint) fn digit_steps(self) -> usize {
+        self.to_usize() / digit::BITS
+    }
 
-	/// Returns the number of bits within a single digit this
-	/// `ShiftAmount` will leap over.
-	/// 
-	/// # TODO
-	/// 
-	/// Maybe adding `left_bit_steps` and `right_bit_steps` is better?
-	/// 
-	/// # Examples
-	/// 
-	/// - `ShiftAmount(50)` leaps over `50` bits.
-	/// - `ShiftAmount(64)` leaps exactly over `0` bits.
-	/// - `ShiftAmount(100)` leaps over `28` bits.
-	/// - `ShiftAmount(150)` leaps over `22` bits.
-	#[inline]
-	pub(in apint) fn bit_steps(self) -> usize {
-		self.to_usize() % digit::BITS
-	}
+    /// Returns the number of bits within a single digit this
+    /// `ShiftAmount` will leap over.
+    /// 
+    /// # TODO
+    /// 
+    /// Maybe adding `left_bit_steps` and `right_bit_steps` is better?
+    /// 
+    /// # Examples
+    /// 
+    /// - `ShiftAmount(50)` leaps over `50` bits.
+    /// - `ShiftAmount(64)` leaps exactly over `0` bits.
+    /// - `ShiftAmount(100)` leaps over `28` bits.
+    /// - `ShiftAmount(150)` leaps over `22` bits.
+    #[inline]
+    pub(in apint) fn bit_steps(self) -> usize {
+        self.to_usize() % digit::BITS
+    }
 }
 
 impl From<usize> for ShiftAmount {
-	/// Returns a new `ShiftAmount` from the given `usize`.
-	#[inline]
-	fn from(val: usize) -> ShiftAmount {
-		ShiftAmount(val)
-	}
+    /// Returns a new `ShiftAmount` from the given `usize`.
+    #[inline]
+    fn from(val: usize) -> ShiftAmount {
+        ShiftAmount(val)
+    }
 }
 
 /// # Shift Operations
 impl ApInt {
 
-	/// Shift this `ApInt` left by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		let shift_amount = shift_amount.into();
-		checks::verify_shift_amount(self, shift_amount)?;
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => {
-				*digit.repr_mut() <<= shift_amount.to_usize();
-			}
-			DataAccessMut::Ext(digits) => {
-				let digit_steps = shift_amount.digit_steps();
-				if digit_steps != 0 {
-					let digits_len  = digits.len();
-					{
-						use std::ptr;
-						let src_ptr = digits.as_mut_ptr();
-						unsafe {
-							let dst_ptr = src_ptr.offset(digit_steps as isize);
-							ptr::copy(src_ptr, dst_ptr, digits_len - digit_steps)
-						}
-					}
-					digits.iter_mut()
-						  .take(digit_steps)
-						  .for_each(|d| *d = Digit::zero());
-				}
-				let bit_steps = shift_amount.bit_steps();
-				if bit_steps != 0 {
-					let mut carry = 0;
-					for elem in digits[digit_steps..].iter_mut() {
-						let repr = elem.repr();
-						let new_carry = repr >> (digit::BITS - bit_steps);
-						*elem = Digit((repr << bit_steps) | carry);
-						carry = new_carry;
-					}
-				}
-			}
-		}
-		self.clear_unused_bits();
-		Ok(())
-	}
+    /// Shift this `ApInt` left by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        let shift_amount = shift_amount.into();
+        checks::verify_shift_amount(self, shift_amount)?;
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => {
+                *digit.repr_mut() <<= shift_amount.to_usize();
+            }
+            DataAccessMut::Ext(digits) => {
+                let digit_steps = shift_amount.digit_steps();
+                if digit_steps != 0 {
+                    let digits_len  = digits.len();
+                    {
+                        use std::ptr;
+                        let src_ptr = digits.as_mut_ptr();
+                        unsafe {
+                            let dst_ptr = src_ptr.offset(digit_steps as isize);
+                            ptr::copy(src_ptr, dst_ptr, digits_len - digit_steps)
+                        }
+                    }
+                    digits.iter_mut()
+                          .take(digit_steps)
+                          .for_each(|d| *d = Digit::zero());
+                }
+                let bit_steps = shift_amount.bit_steps();
+                if bit_steps != 0 {
+                    let mut carry = 0;
+                    for elem in digits[digit_steps..].iter_mut() {
+                        let repr = elem.repr();
+                        let new_carry = repr >> (digit::BITS - bit_steps);
+                        *elem = Digit((repr << bit_steps) | carry);
+                        carry = new_carry;
+                    }
+                }
+            }
+        }
+        self.clear_unused_bits();
+        Ok(())
+    }
 
-	/// Shift this `ApInt` left by the given `shift_amount` bits and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<ApInt>
-		where S: Into<ShiftAmount>
-	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_shl_assign)
-	}
+    /// Shift this `ApInt` left by the given `shift_amount` bits and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<ApInt>
+        where S: Into<ShiftAmount>
+    {
+        try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_shl_assign)
+    }
 
-	/// Logically right-shifts this `ApInt` by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn wrapping_lshr_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		let shift_amount = shift_amount.into();
-		checks::verify_shift_amount(self, shift_amount)?;
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => {
-				*digit.repr_mut() >>= shift_amount.to_usize();
-			}
-			DataAccessMut::Ext(digits) => {
-				let digit_steps = shift_amount.digit_steps();
-				if digit_steps != 0 {
-					digits.rotate_left(digit_steps);
-					digits.iter_mut()
-						  .rev()
-						  .take(digit_steps)
-						  .for_each(|d| *d = Digit::zero());
-				}
-				let bit_steps = shift_amount.bit_steps();
-				if bit_steps > 0 {
-					let mut borrow = 0;
-					for elem in digits.iter_mut().rev() {
-						let repr = elem.repr();
-						let new_borrow = repr << (digit::BITS - bit_steps);
-						*elem = Digit((repr >> bit_steps) | borrow);
-						borrow = new_borrow;
-					}
-				}
-			}
-		}
-		Ok(())
-	}
+    /// Logically right-shifts this `ApInt` by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn wrapping_lshr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        let shift_amount = shift_amount.into();
+        checks::verify_shift_amount(self, shift_amount)?;
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => {
+                *digit.repr_mut() >>= shift_amount.to_usize();
+            }
+            DataAccessMut::Ext(digits) => {
+                let digit_steps = shift_amount.digit_steps();
+                if digit_steps != 0 {
+                    digits.rotate_left(digit_steps);
+                    digits.iter_mut()
+                          .rev()
+                          .take(digit_steps)
+                          .for_each(|d| *d = Digit::zero());
+                }
+                let bit_steps = shift_amount.bit_steps();
+                if bit_steps > 0 {
+                    let mut borrow = 0;
+                    for elem in digits.iter_mut().rev() {
+                        let repr = elem.repr();
+                        let new_borrow = repr << (digit::BITS - bit_steps);
+                        *elem = Digit((repr >> bit_steps) | borrow);
+                        borrow = new_borrow;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 
-	/// Logically right-shifts this `ApInt` by the given `shift_amount` bits
-	/// and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_wrapping_lshr<S>(self, shift_amount: S) -> Result<ApInt>
-		where S: Into<ShiftAmount>
-	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_lshr_assign)
-	}
+    /// Logically right-shifts this `ApInt` by the given `shift_amount` bits
+    /// and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn into_wrapping_lshr<S>(self, shift_amount: S) -> Result<ApInt>
+        where S: Into<ShiftAmount>
+    {
+        try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_lshr_assign)
+    }
 
-	/// Arithmetically right-shifts this `ApInt` by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Note
-	/// 
-	/// Arithmetic shifting copies the sign bit instead of filling up with zeros.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn wrapping_ashr_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		if self.sign_bit() == Bit::Unset {
-			return self.wrapping_lshr_assign(shift_amount)
-		}
-		let shift_amount = shift_amount.into();
-		checks::verify_shift_amount(self, shift_amount)?;
-		let width = self.width();
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => {
-				let mut signed = digit.clone();
-				signed.sign_extend_from(width).unwrap();
-				let signed = signed.repr() as i64;
-				let shifted = signed >> shift_amount.to_usize();
-				*digit.repr_mut() = shifted as u64;
-			}
-			DataAccessMut::Ext(digits) => {
-				let digit_steps = shift_amount.digit_steps();
-				if digit_steps != 0 {
-					digits.rotate_left(digit_steps);
-					digits.iter_mut()
-						  .rev()
-						  .take(digit_steps)
-						  .for_each(|d| *d = Digit::all_set());
-				}
-				let bit_steps = shift_amount.bit_steps();
-				if bit_steps > 0 {
-					let mut borrow = 0xFFFF_FFFF_FFFF_FFFF << (digit::BITS - bit_steps);
-					for elem in digits.iter_mut().rev().skip(digit_steps) {
-						let repr = elem.repr();
-						let new_borrow = repr << (digit::BITS - bit_steps);
-						*elem = Digit((repr >> bit_steps) | borrow);
-						borrow = new_borrow;
-					}
-				}
-			}
-		}
-		self.clear_unused_bits();
-		Ok(())
-	}
+    /// Arithmetically right-shifts this `ApInt` by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Note
+    /// 
+    /// Arithmetic shifting copies the sign bit instead of filling up with zeros.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn wrapping_ashr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        if self.sign_bit() == Bit::Unset {
+            return self.wrapping_lshr_assign(shift_amount)
+        }
+        let shift_amount = shift_amount.into();
+        checks::verify_shift_amount(self, shift_amount)?;
+        let width = self.width();
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => {
+                let mut signed = digit.clone();
+                signed.sign_extend_from(width).unwrap();
+                let signed = signed.repr() as i64;
+                let shifted = signed >> shift_amount.to_usize();
+                *digit.repr_mut() = shifted as u64;
+            }
+            DataAccessMut::Ext(digits) => {
+                let digit_steps = shift_amount.digit_steps();
+                if digit_steps != 0 {
+                    digits.rotate_left(digit_steps);
+                    digits.iter_mut()
+                          .rev()
+                          .take(digit_steps)
+                          .for_each(|d| *d = Digit::all_set());
+                }
+                let bit_steps = shift_amount.bit_steps();
+                if bit_steps > 0 {
+                    let mut borrow = 0xFFFF_FFFF_FFFF_FFFF << (digit::BITS - bit_steps);
+                    for elem in digits.iter_mut().rev().skip(digit_steps) {
+                        let repr = elem.repr();
+                        let new_borrow = repr << (digit::BITS - bit_steps);
+                        *elem = Digit((repr >> bit_steps) | borrow);
+                        borrow = new_borrow;
+                    }
+                }
+            }
+        }
+        self.clear_unused_bits();
+        Ok(())
+    }
 
-	/// Arithmetically right-shifts this `ApInt` by the given `shift_amount` bits
-	/// and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Note
-	/// 
-	/// Arithmetic shifting copies the sign bit instead of filling up with zeros.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
-	pub fn into_wrapping_ashr<S>(self, shift_amount: S) -> Result<ApInt>
-		where S: Into<ShiftAmount>
-	{
-		try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_ashr_assign)
-	}
+    /// Arithmetically right-shifts this `ApInt` by the given `shift_amount` bits
+    /// and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Note
+    /// 
+    /// Arithmetic shifting copies the sign bit instead of filling up with zeros.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `ApInt`.
+    pub fn into_wrapping_ashr<S>(self, shift_amount: S) -> Result<ApInt>
+        where S: Into<ShiftAmount>
+    {
+        try_forward_bin_mut_impl(self, shift_amount, ApInt::wrapping_ashr_assign)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	fn test_reprs_w64() -> impl Iterator<Item = u64> {
-		vec![
-			0x0123_4567_89AB_CDEF,
-			0xFEDC_BA98_7654_3210,
-			0x0000_0000_0000_0000,
-			0x5555_5555_5555_5555,
-			0xAAAA_AAAA_AAAA_AAAA,
-			0xFFFF_FFFF_FFFF_FFFF,
-		]
-		.into_iter()
-	}
+    fn test_reprs_w64() -> impl Iterator<Item = u64> {
+        vec![
+            0x0123_4567_89AB_CDEF,
+            0xFEDC_BA98_7654_3210,
+            0x0000_0000_0000_0000,
+            0x5555_5555_5555_5555,
+            0xAAAA_AAAA_AAAA_AAAA,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ]
+        .into_iter()
+    }
 
-	fn test_apints_w64() -> impl Iterator<Item = ApInt> {
-		test_reprs_w64().map(ApInt::from_u64)
-	}
+    fn test_apints_w64() -> impl Iterator<Item = ApInt> {
+        test_reprs_w64().map(ApInt::from_u64)
+    }
 
-	fn test_reprs_w128() -> impl Iterator<Item = u128> {
-		vec![
-			0x0123_4567_89AB_CDEF_0011_2233_4455_6677,
-			0xFEDC_BA98_7654_3210_7766_5544_3322_1100,
-			0x0000_0000_0000_0000_0000_0000_0000_0001,
-			0x8000_0000_0000_0000_0000_0000_0000_0000,
-			0x0000_0000_0000_0000_0000_0000_0000_0000,
-			0x5555_5555_5555_5555_5555_5555_5555_5555,
-			0xAAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA,
-			0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
-		]
-		.into_iter()
-	}
+    fn test_reprs_w128() -> impl Iterator<Item = u128> {
+        vec![
+            0x0123_4567_89AB_CDEF_0011_2233_4455_6677,
+            0xFEDC_BA98_7654_3210_7766_5544_3322_1100,
+            0x0000_0000_0000_0000_0000_0000_0000_0001,
+            0x8000_0000_0000_0000_0000_0000_0000_0000,
+            0x0000_0000_0000_0000_0000_0000_0000_0000,
+            0x5555_5555_5555_5555_5555_5555_5555_5555,
+            0xAAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA,
+            0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+        ]
+        .into_iter()
+    }
 
-	fn test_apints_w128() -> impl Iterator<Item = ApInt> {
-		test_reprs_w128().map(ApInt::from_u128)
-	}
+    fn test_apints_w128() -> impl Iterator<Item = ApInt> {
+        test_reprs_w128().map(ApInt::from_u128)
+    }
 
-	mod shl {
-		use super::*;
+    mod shl {
+        use super::*;
 
-		#[test]
-		fn assign_small_ok() {
-			for repr in test_reprs_w64() {
-				for shamt in 0..64 {
-					let mut result = ApInt::from_u64(repr);
-					result.wrapping_shl_assign(shamt).unwrap();
-					let expected = ApInt::from_u64(repr << shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_small_ok() {
+            for repr in test_reprs_w64() {
+                for shamt in 0..64 {
+                    let mut result = ApInt::from_u64(repr);
+                    result.wrapping_shl_assign(shamt).unwrap();
+                    let expected = ApInt::from_u64(repr << shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_large_ok() {
-			for repr in test_reprs_w128() {
-				for shamt in 0..128 {
-					let mut result = ApInt::from_u128(repr);
-					result.wrapping_shl_assign(shamt).unwrap();
-					let expected = ApInt::from_u128(repr << shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_large_ok() {
+            for repr in test_reprs_w128() {
+                for shamt in 0..128 {
+                    let mut result = ApInt::from_u128(repr);
+                    result.wrapping_shl_assign(shamt).unwrap();
+                    let expected = ApInt::from_u128(repr << shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_xtra_large_ok() {
-			use digit;
-			let d0 = 0xFEDC_BA98_7654_3210;
-			let d1 = 0x5555_5555_4444_4444;
-			let d2 = 0xAAAA_AAAA_CCCC_CCCC;
-			let d3 = 0xFFFF_7777_7777_FFFF;
-			let input: [u64; 4] = [d0, d1, d2, d3];
-			{
-				let shamt = 100;
-				let digit_steps = shamt / 64;
-				let bit_steps = shamt % 64;
-				assert_eq!(digit_steps, 1);
-				assert_eq!(bit_steps, 36);
-				let result = ApInt::from(input)
-					.into_wrapping_shl(shamt)
-					.unwrap();
-				let expected: [u64; 4] = [
-					(d1 << bit_steps) | (d2 >> (digit::BITS - bit_steps)),
-					(d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
-					(d3 << bit_steps),
-					0
-				];
-				let expected = ApInt::from(expected);
-				assert_eq!(result, expected);
-			}
-			{
-				let shamt = 150;
-				let digit_steps = shamt / 64;
-				let bit_steps = shamt % 64;
-				assert_eq!(digit_steps, 2);
-				assert_eq!(bit_steps, 22);
-				let result = ApInt::from(input)
-					.into_wrapping_shl(shamt)
-					.unwrap();
-				let expected: [u64; 4] = [
-					(d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
-					(d3 << bit_steps),
-					0,
-					0
-				];
-				let expected = ApInt::from(expected);
-				assert_eq!(result, expected);
-			}
-			{
-				let shamt = 200;
-				let digit_steps = shamt / 64;
-				let bit_steps = shamt % 64;
-				assert_eq!(digit_steps, 3);
-				assert_eq!(bit_steps, 8);
-				let result = ApInt::from(input)
-					.into_wrapping_shl(shamt)
-					.unwrap();
-				let expected: [u64; 4] = [
-					(d3 << bit_steps),
-					0,
-					0,
-					0
-				];
-				let expected = ApInt::from(expected);
-				assert_eq!(result, expected);
-			}
-		}
+        #[test]
+        fn assign_xtra_large_ok() {
+            use digit;
+            let d0 = 0xFEDC_BA98_7654_3210;
+            let d1 = 0x5555_5555_4444_4444;
+            let d2 = 0xAAAA_AAAA_CCCC_CCCC;
+            let d3 = 0xFFFF_7777_7777_FFFF;
+            let input: [u64; 4] = [d0, d1, d2, d3];
+            {
+                let shamt = 100;
+                let digit_steps = shamt / 64;
+                let bit_steps = shamt % 64;
+                assert_eq!(digit_steps, 1);
+                assert_eq!(bit_steps, 36);
+                let result = ApInt::from(input)
+                    .into_wrapping_shl(shamt)
+                    .unwrap();
+                let expected: [u64; 4] = [
+                    (d1 << bit_steps) | (d2 >> (digit::BITS - bit_steps)),
+                    (d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
+                    (d3 << bit_steps),
+                    0
+                ];
+                let expected = ApInt::from(expected);
+                assert_eq!(result, expected);
+            }
+            {
+                let shamt = 150;
+                let digit_steps = shamt / 64;
+                let bit_steps = shamt % 64;
+                assert_eq!(digit_steps, 2);
+                assert_eq!(bit_steps, 22);
+                let result = ApInt::from(input)
+                    .into_wrapping_shl(shamt)
+                    .unwrap();
+                let expected: [u64; 4] = [
+                    (d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
+                    (d3 << bit_steps),
+                    0,
+                    0
+                ];
+                let expected = ApInt::from(expected);
+                assert_eq!(result, expected);
+            }
+            {
+                let shamt = 200;
+                let digit_steps = shamt / 64;
+                let bit_steps = shamt % 64;
+                assert_eq!(digit_steps, 3);
+                assert_eq!(bit_steps, 8);
+                let result = ApInt::from(input)
+                    .into_wrapping_shl(shamt)
+                    .unwrap();
+                let expected: [u64; 4] = [
+                    (d3 << bit_steps),
+                    0,
+                    0,
+                    0
+                ];
+                let expected = ApInt::from(expected);
+                assert_eq!(result, expected);
+            }
+        }
 
-		#[test]
-		fn assign_small_fail() {
-			for mut apint in test_apints_w64() {
-				assert!(apint.wrapping_shl_assign(64).is_err())
-			}
-		}
+        #[test]
+        fn assign_small_fail() {
+            for mut apint in test_apints_w64() {
+                assert!(apint.wrapping_shl_assign(64).is_err())
+            }
+        }
 
-		#[test]
-		fn assign_large_fail() {
-			for mut apint in test_apints_w128() {
-				assert!(apint.wrapping_shl_assign(128).is_err())
-			}
-		}
+        #[test]
+        fn assign_large_fail() {
+            for mut apint in test_apints_w128() {
+                assert!(apint.wrapping_shl_assign(128).is_err())
+            }
+        }
 
-		#[test]
-		fn into_equivalent_small() {
-			for apint in test_apints_w64() {
-				for shamt in 0..64 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_shl_assign(shamt).unwrap();
-					let y = y.into_wrapping_shl(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
+        #[test]
+        fn into_equivalent_small() {
+            for apint in test_apints_w64() {
+                for shamt in 0..64 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_shl_assign(shamt).unwrap();
+                    let y = y.into_wrapping_shl(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
 
-		#[test]
-		fn into_equivalent_large() {
-			for apint in test_apints_w128() {
-				for shamt in 0..128 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_shl_assign(shamt).unwrap();
-					let y = y.into_wrapping_shl(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
-	}
+        #[test]
+        fn into_equivalent_large() {
+            for apint in test_apints_w128() {
+                for shamt in 0..128 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_shl_assign(shamt).unwrap();
+                    let y = y.into_wrapping_shl(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
+    }
 
-	mod lshr {
-		use super::*;
+    mod lshr {
+        use super::*;
 
-		#[test]
-		fn assign_small_ok() {
-			for repr in test_reprs_w64() {
-				for shamt in 0..64 {
-					let mut result = ApInt::from_u64(repr);
-					result.wrapping_lshr_assign(shamt).unwrap();
-					let expected = ApInt::from_u64(repr >> shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_small_ok() {
+            for repr in test_reprs_w64() {
+                for shamt in 0..64 {
+                    let mut result = ApInt::from_u64(repr);
+                    result.wrapping_lshr_assign(shamt).unwrap();
+                    let expected = ApInt::from_u64(repr >> shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_large_ok() {
-			for repr in test_reprs_w128() {
-				for shamt in 0..128 {
-					let mut result = ApInt::from_u128(repr);
-					result.wrapping_lshr_assign(shamt).unwrap();
-					let expected = ApInt::from_u128(repr >> shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_large_ok() {
+            for repr in test_reprs_w128() {
+                for shamt in 0..128 {
+                    let mut result = ApInt::from_u128(repr);
+                    result.wrapping_lshr_assign(shamt).unwrap();
+                    let expected = ApInt::from_u128(repr >> shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_small_fail() {
-			for mut apint in test_apints_w64() {
-				assert!(apint.wrapping_lshr_assign(64).is_err())
-			}
-		}
+        #[test]
+        fn assign_small_fail() {
+            for mut apint in test_apints_w64() {
+                assert!(apint.wrapping_lshr_assign(64).is_err())
+            }
+        }
 
-		#[test]
-		fn assign_large_fail() {
-			for mut apint in test_apints_w128() {
-				assert!(apint.wrapping_lshr_assign(128).is_err())
-			}
-		}
+        #[test]
+        fn assign_large_fail() {
+            for mut apint in test_apints_w128() {
+                assert!(apint.wrapping_lshr_assign(128).is_err())
+            }
+        }
 
-		#[test]
-		fn into_equivalent_small() {
-			for apint in test_apints_w64() {
-				for shamt in 0..64 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_lshr_assign(shamt).unwrap();
-					let y = y.into_wrapping_lshr(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
+        #[test]
+        fn into_equivalent_small() {
+            for apint in test_apints_w64() {
+                for shamt in 0..64 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_lshr_assign(shamt).unwrap();
+                    let y = y.into_wrapping_lshr(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
 
-		#[test]
-		fn into_equivalent_large() {
-			for apint in test_apints_w128() {
-				for shamt in 0..128 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_lshr_assign(shamt).unwrap();
-					let y = y.into_wrapping_lshr(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
-	}
+        #[test]
+        fn into_equivalent_large() {
+            for apint in test_apints_w128() {
+                for shamt in 0..128 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_lshr_assign(shamt).unwrap();
+                    let y = y.into_wrapping_lshr(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
+    }
 
-	mod ashr {
-		use super::*;
+    mod ashr {
+        use super::*;
 
-		#[test]
-		fn regression_stevia_01() {
-			let input = ApInt::from_i32(-8);
-			let expected = ApInt::from_u32(0x_FFFF_FFFE);
-			assert_eq!(input.into_wrapping_ashr(ShiftAmount::from(2)).unwrap(), expected);
-		}
+        #[test]
+        fn regression_stevia_01() {
+            let input = ApInt::from_i32(-8);
+            let expected = ApInt::from_u32(0x_FFFF_FFFE);
+            assert_eq!(input.into_wrapping_ashr(ShiftAmount::from(2)).unwrap(), expected);
+        }
 
-		#[test]
-		fn assign_small_ok() {
-			for repr in test_reprs_w64() {
-				for shamt in 0..64 {
-					let mut result = ApInt::from_u64(repr);
-					result.wrapping_ashr_assign(shamt).unwrap();
-					let expected = ApInt::from_i64((repr as i64) >> shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_small_ok() {
+            for repr in test_reprs_w64() {
+                for shamt in 0..64 {
+                    let mut result = ApInt::from_u64(repr);
+                    result.wrapping_ashr_assign(shamt).unwrap();
+                    let expected = ApInt::from_i64((repr as i64) >> shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_large_ok() {
-			for repr in test_reprs_w128() {
-				for shamt in 0..128 {
-					let mut result = ApInt::from_u128(repr);
-					result.wrapping_ashr_assign(shamt).unwrap();
-					let expected = ApInt::from_i128((repr as i128) >> shamt);
-					assert_eq!(result, expected);
-				}
-			}
-		}
+        #[test]
+        fn assign_large_ok() {
+            for repr in test_reprs_w128() {
+                for shamt in 0..128 {
+                    let mut result = ApInt::from_u128(repr);
+                    result.wrapping_ashr_assign(shamt).unwrap();
+                    let expected = ApInt::from_i128((repr as i128) >> shamt);
+                    assert_eq!(result, expected);
+                }
+            }
+        }
 
-		#[test]
-		fn assign_small_fail() {
-			for mut apint in test_apints_w64() {
-				assert!(apint.wrapping_ashr_assign(64).is_err())
-			}
-		}
+        #[test]
+        fn assign_small_fail() {
+            for mut apint in test_apints_w64() {
+                assert!(apint.wrapping_ashr_assign(64).is_err())
+            }
+        }
 
-		#[test]
-		fn assign_large_fail() {
-			for mut apint in test_apints_w128() {
-				assert!(apint.wrapping_ashr_assign(128).is_err())
-			}
-		}
+        #[test]
+        fn assign_large_fail() {
+            for mut apint in test_apints_w128() {
+                assert!(apint.wrapping_ashr_assign(128).is_err())
+            }
+        }
 
-		#[test]
-		fn into_equivalent_small() {
-			for apint in test_apints_w64() {
-				for shamt in 0..64 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_ashr_assign(shamt).unwrap();
-					let y = y.into_wrapping_ashr(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
+        #[test]
+        fn into_equivalent_small() {
+            for apint in test_apints_w64() {
+                for shamt in 0..64 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_ashr_assign(shamt).unwrap();
+                    let y = y.into_wrapping_ashr(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
 
-		#[test]
-		fn into_equivalent_large() {
-			for apint in test_apints_w128() {
-				for shamt in 0..128 {
-					let mut x = apint.clone();
-					let     y = apint.clone();
-					x.wrapping_ashr_assign(shamt).unwrap();
-					let y = y.into_wrapping_ashr(shamt).unwrap();
-					assert_eq!(x, y);
-				}
-			}
-		}
-	}
+        #[test]
+        fn into_equivalent_large() {
+            for apint in test_apints_w128() {
+                for shamt in 0..128 {
+                    let mut x = apint.clone();
+                    let     y = apint.clone();
+                    x.wrapping_ashr_assign(shamt).unwrap();
+                    let y = y.into_wrapping_ashr(shamt).unwrap();
+                    assert_eq!(x, y);
+                }
+            }
+        }
+    }
 }

--- a/src/apint/to_primitive.rs
+++ b/src/apint/to_primitive.rs
@@ -11,1056 +11,1056 @@ use traits::{Width};
 /// error reporting.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PrimitiveTy {
-	/// Represents Rust's `bool`.
-	Bool,
-	/// Represents Rust's `i8`.
-	I8,
-	/// Represents Rust's `u8`.
-	U8,
-	/// Represents Rust's `i16`.
-	I16,
-	/// Represents Rust's `u16`.
-	U16,
-	/// Represents Rust's `i32`.
-	I32,
-	/// Represents Rust's `u32`.
-	U32,
-	/// Represents Rust's `i64`.
-	I64,
-	/// Represents Rust's `u64`.
-	U64,
-	/// Represents Rust's `i128`.
-	I128,
-	/// Represents Rust's `u128`.
-	U128
+    /// Represents Rust's `bool`.
+    Bool,
+    /// Represents Rust's `i8`.
+    I8,
+    /// Represents Rust's `u8`.
+    U8,
+    /// Represents Rust's `i16`.
+    I16,
+    /// Represents Rust's `u16`.
+    U16,
+    /// Represents Rust's `i32`.
+    I32,
+    /// Represents Rust's `u32`.
+    U32,
+    /// Represents Rust's `i64`.
+    I64,
+    /// Represents Rust's `u64`.
+    U64,
+    /// Represents Rust's `i128`.
+    I128,
+    /// Represents Rust's `u128`.
+    U128
 }
 
 impl PrimitiveTy {
-	/// Returns `true` if the given `value` is a valid representation
-	/// for this `PrimitiveTy`.
-	/// 
-	/// # Example
-	/// 
-	/// If this `PrimitiveTy` was `U8` then `200` is a valid representation
-	/// but `256` is not since it is not representable by `8` bits. Only
-	/// unsigned values are considered in this regard.
-	#[inline]
-	pub(crate) fn is_valid_repr(self, value: u64) -> bool {
-		use self::PrimitiveTy::*;
-		match self {
-			Bool      => (value == 0) || (value == 1),
-			I8  | U8  => value < (0x1 << 8),
-			I16 | U16 => value < (0x1 << 16),
-			I32 | U32 => value < (0x1 << 32),
-			I64 | U64 | I128 | U128 => {
-				true
-			}
-		}
-	}
+    /// Returns `true` if the given `value` is a valid representation
+    /// for this `PrimitiveTy`.
+    /// 
+    /// # Example
+    /// 
+    /// If this `PrimitiveTy` was `U8` then `200` is a valid representation
+    /// but `256` is not since it is not representable by `8` bits. Only
+    /// unsigned values are considered in this regard.
+    #[inline]
+    pub(crate) fn is_valid_repr(self, value: u64) -> bool {
+        use self::PrimitiveTy::*;
+        match self {
+            Bool      => (value == 0) || (value == 1),
+            I8  | U8  => value < (0x1 << 8),
+            I16 | U16 => value < (0x1 << 16),
+            I32 | U32 => value < (0x1 << 32),
+            I64 | U64 | I128 | U128 => {
+                true
+            }
+        }
+    }
 
-	/// Returns `true` if the given `value` is a valid double-digit
-	/// representation for this `PrimitiveTy`.
-	/// 
-	/// # Example
-	/// 
-	/// If this `PrimitiveTy` was `U8` then `200` is a valid representation
-	/// but `256` is not since it is not representable by `8` bits. Only
-	/// unsigned values are considered in this regard.
-	/// 
-	/// # Note
-	/// 
-	/// This functionality is currently only used by local unit tests.
-	#[inline]
-	#[cfg(test)]
-	pub(crate) fn is_valid_dd(self, value: u128) -> bool {
-		use self::PrimitiveTy::*;
-		match self {
-			Bool        => (value == 0) || (value == 1),
-			I8  | U8    => value < (0x1 << 8),
-			I16 | U16   => value < (0x1 << 16),
-			I32 | U32   => value < (0x1 << 32),
-			I64 | U64   => value < (0x1 << 64),
-			I128 | U128 => true
-		}
-	}
+    /// Returns `true` if the given `value` is a valid double-digit
+    /// representation for this `PrimitiveTy`.
+    /// 
+    /// # Example
+    /// 
+    /// If this `PrimitiveTy` was `U8` then `200` is a valid representation
+    /// but `256` is not since it is not representable by `8` bits. Only
+    /// unsigned values are considered in this regard.
+    /// 
+    /// # Note
+    /// 
+    /// This functionality is currently only used by local unit tests.
+    #[inline]
+    #[cfg(test)]
+    pub(crate) fn is_valid_dd(self, value: u128) -> bool {
+        use self::PrimitiveTy::*;
+        match self {
+            Bool        => (value == 0) || (value == 1),
+            I8  | U8    => value < (0x1 << 8),
+            I16 | U16   => value < (0x1 << 16),
+            I32 | U32   => value < (0x1 << 32),
+            I64 | U64   => value < (0x1 << 64),
+            I128 | U128 => true
+        }
+    }
 
-	/// Returns `true` if this `PrimitiveTy` can represent signedness.
-	#[inline]
-	pub(crate) fn is_signed(self) -> bool {
-		use self::PrimitiveTy::*;
-		match self {
-			I8   |
-			I16  |
-			I32  |
-			I64  |
-			I128 => true,
-			_    => false
-		}
-	}
+    /// Returns `true` if this `PrimitiveTy` can represent signedness.
+    #[inline]
+    pub(crate) fn is_signed(self) -> bool {
+        use self::PrimitiveTy::*;
+        match self {
+            I8   |
+            I16  |
+            I32  |
+            I64  |
+            I128 => true,
+            _    => false
+        }
+    }
 
-	/// Returns the associated `BitWidth` to this `PrimitiveTy`.
-	/// 
-	/// # Example
-	/// 
-	/// For `i32` the associated `BitWidth` is `32 bits` and for
-	/// `u64` it is `64 bits`.
-	#[inline]
-	pub(crate) fn associated_width(self) -> BitWidth {
-		use self::PrimitiveTy::*;
-		match self {
-			Bool => BitWidth::w1(),
-			I8 | U8 => BitWidth::w8(),
-			I16 | U16 => BitWidth::w16(),
-			I32 | U32 => BitWidth::w32(),
-			I64 | U64 => BitWidth::w64(),
-			I128 | U128 => BitWidth::w128(),
-		}
-	}
+    /// Returns the associated `BitWidth` to this `PrimitiveTy`.
+    /// 
+    /// # Example
+    /// 
+    /// For `i32` the associated `BitWidth` is `32 bits` and for
+    /// `u64` it is `64 bits`.
+    #[inline]
+    pub(crate) fn associated_width(self) -> BitWidth {
+        use self::PrimitiveTy::*;
+        match self {
+            Bool => BitWidth::w1(),
+            I8 | U8 => BitWidth::w8(),
+            I16 | U16 => BitWidth::w16(),
+            I32 | U32 => BitWidth::w32(),
+            I64 | U64 => BitWidth::w64(),
+            I128 | U128 => BitWidth::w128(),
+        }
+    }
 }
 
 /// # Operations to lossful cast to primitive number types.
 impl ApInt {
 
-	/// Resizes the given `ApInt` to the given `PrimitiveTy`.
-	/// 
-	/// This will truncate the bits of the `ApInt` if it has a greater bit
-	/// width than the target bit width or will sign-extend the bits of the
-	/// `ApInt` if its bit width is less than the target bit width.
-	/// 
-	/// This operation cannot fail and is the generic foundation for the
-	/// greater part of the `ApInt::resize_to_*` methods.
-	fn resize_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Digit {
-		debug_assert_ne!(prim_ty, PrimitiveTy::U128);
-		debug_assert_ne!(prim_ty, PrimitiveTy::I128);
-		let mut lsd = self.least_significant_digit();
-		let actual_width = self.width();
-		let target_width = prim_ty.associated_width();
-		if prim_ty.is_signed() {
-			if actual_width < target_width {
-				lsd.sign_extend_from(actual_width)
-				   .expect("We already asserted that `actual_width` < `target_width` \
-							and since `target_width` is always less than or equal to \
-							`64` bits calling `Digit::sign_extend_from` is safe for it.");
-			}
-		}
-		if target_width < BitWidth::w64() {
-			lsd.truncate_to(target_width)
-				.expect("Since `target_width` is always less than or equal to \
-						`64` bits calling `Digit::sign_extend_from` is safe for it.");
-		}
-		lsd
-	}
+    /// Resizes the given `ApInt` to the given `PrimitiveTy`.
+    /// 
+    /// This will truncate the bits of the `ApInt` if it has a greater bit
+    /// width than the target bit width or will sign-extend the bits of the
+    /// `ApInt` if its bit width is less than the target bit width.
+    /// 
+    /// This operation cannot fail and is the generic foundation for the
+    /// greater part of the `ApInt::resize_to_*` methods.
+    fn resize_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Digit {
+        debug_assert_ne!(prim_ty, PrimitiveTy::U128);
+        debug_assert_ne!(prim_ty, PrimitiveTy::I128);
+        let mut lsd = self.least_significant_digit();
+        let actual_width = self.width();
+        let target_width = prim_ty.associated_width();
+        if prim_ty.is_signed() {
+            if actual_width < target_width {
+                lsd.sign_extend_from(actual_width)
+                   .expect("We already asserted that `actual_width` < `target_width` \
+                            and since `target_width` is always less than or equal to \
+                            `64` bits calling `Digit::sign_extend_from` is safe for it.");
+            }
+        }
+        if target_width < BitWidth::w64() {
+            lsd.truncate_to(target_width)
+                .expect("Since `target_width` is always less than or equal to \
+                        `64` bits calling `Digit::sign_extend_from` is safe for it.");
+        }
+        lsd
+    }
 
-	/// Resizes this `ApInt` to a `bool` primitive type.
-	/// 
-	/// Bits in this `ApInt` that are not within the bounds
-	/// of the `bool` are being ignored.
-	/// 
-	/// # Note
-	/// 
-	/// - Basically this returns `true` if the least significant
-	///   bit of this `ApInt` is `1` and `false` otherwise.
-	pub fn resize_to_bool(&self) -> bool {
-		match self.resize_to_primitive_ty(PrimitiveTy::Bool) {
-			Digit(0) => false,
-			Digit(1) => true,
-			_ => unreachable!()
-		}
-	}
+    /// Resizes this `ApInt` to a `bool` primitive type.
+    /// 
+    /// Bits in this `ApInt` that are not within the bounds
+    /// of the `bool` are being ignored.
+    /// 
+    /// # Note
+    /// 
+    /// - Basically this returns `true` if the least significant
+    ///   bit of this `ApInt` is `1` and `false` otherwise.
+    pub fn resize_to_bool(&self) -> bool {
+        match self.resize_to_primitive_ty(PrimitiveTy::Bool) {
+            Digit(0) => false,
+            Digit(1) => true,
+            _ => unreachable!()
+        }
+    }
 
-	/// Resizes this `ApInt` to a `i8` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `8` bits the value is
-	///   sign extended to the target bit width.
-	/// - All bits but the least significant `8` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i8(&self) -> i8 {
-		self.resize_to_primitive_ty(PrimitiveTy::I8).repr() as i8
-	}
+    /// Resizes this `ApInt` to a `i8` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `8` bits the value is
+    ///   sign extended to the target bit width.
+    /// - All bits but the least significant `8` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i8(&self) -> i8 {
+        self.resize_to_primitive_ty(PrimitiveTy::I8).repr() as i8
+    }
 
-	/// Resizes this `ApInt` to a `u8` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - All bits but the least significant `8` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u8(&self) -> u8 {
-		self.resize_to_primitive_ty(PrimitiveTy::U8).repr() as u8
-	}
+    /// Resizes this `ApInt` to a `u8` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - All bits but the least significant `8` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u8(&self) -> u8 {
+        self.resize_to_primitive_ty(PrimitiveTy::U8).repr() as u8
+    }
 
-	/// Resizes this `ApInt` to a `i16` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `16` bits the value is
-	///   sign extended to the target bit width.
-	/// - All bits but the least significant `16` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i16(&self) -> i16 {
-		self.resize_to_primitive_ty(PrimitiveTy::I16).repr() as i16
-	}
+    /// Resizes this `ApInt` to a `i16` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `16` bits the value is
+    ///   sign extended to the target bit width.
+    /// - All bits but the least significant `16` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i16(&self) -> i16 {
+        self.resize_to_primitive_ty(PrimitiveTy::I16).repr() as i16
+    }
 
-	/// Resizes this `ApInt` to a `u16` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - All bits but the least significant `16` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u16(&self) -> u16 {
-		self.resize_to_primitive_ty(PrimitiveTy::U16).repr() as u16
-	}
+    /// Resizes this `ApInt` to a `u16` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - All bits but the least significant `16` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u16(&self) -> u16 {
+        self.resize_to_primitive_ty(PrimitiveTy::U16).repr() as u16
+    }
 
-	/// Resizes this `ApInt` to a `i32` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `32` bits the value is
-	///   sign extended to the target bit width.
-	/// - All bits but the least significant `32` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i32(&self) -> i32 {
-		self.resize_to_primitive_ty(PrimitiveTy::I32).repr() as i32
-	}
+    /// Resizes this `ApInt` to a `i32` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `32` bits the value is
+    ///   sign extended to the target bit width.
+    /// - All bits but the least significant `32` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i32(&self) -> i32 {
+        self.resize_to_primitive_ty(PrimitiveTy::I32).repr() as i32
+    }
 
-	/// Resizes this `ApInt` to a `u32` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - All bits but the least significant `32` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u32(&self) -> u32 {
-		self.resize_to_primitive_ty(PrimitiveTy::U32).repr() as u32
-	}
+    /// Resizes this `ApInt` to a `u32` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - All bits but the least significant `32` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u32(&self) -> u32 {
+        self.resize_to_primitive_ty(PrimitiveTy::U32).repr() as u32
+    }
 
-	/// Resizes this `ApInt` to a `i64` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `64` bits the value is
-	///   sign extended to the target bit width.
-	/// - All bits but the least significant `64` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i64(&self) -> i64 {
-		self.resize_to_primitive_ty(PrimitiveTy::I64).repr() as i64
-	}
+    /// Resizes this `ApInt` to a `i64` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `64` bits the value is
+    ///   sign extended to the target bit width.
+    /// - All bits but the least significant `64` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i64(&self) -> i64 {
+        self.resize_to_primitive_ty(PrimitiveTy::I64).repr() as i64
+    }
 
-	/// Resizes this `ApInt` to a `u64` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - All bits but the least significant `64` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u64(&self) -> u64 {
-		self.resize_to_primitive_ty(PrimitiveTy::U64).repr() as u64
-	}
+    /// Resizes this `ApInt` to a `u64` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - All bits but the least significant `64` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u64(&self) -> u64 {
+        self.resize_to_primitive_ty(PrimitiveTy::U64).repr() as u64
+    }
 
-	/// Resizes this `ApInt` to a `i128` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `128` bits the value is
-	///   sign extended to the target bit width.
-	/// - All bits but the least significant `128` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i128(&self) -> i128 {
-		let ( lsd_0, rest) = self.split_least_significant_digit();
-		let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
-		let mut result: i128 =
-			(i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
-		let actual_width = self.width();
-		let target_width = BitWidth::w128();
+    /// Resizes this `ApInt` to a `i128` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `128` bits the value is
+    ///   sign extended to the target bit width.
+    /// - All bits but the least significant `128` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i128(&self) -> i128 {
+        let ( lsd_0, rest) = self.split_least_significant_digit();
+        let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
+        let mut result: i128 =
+            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+        let actual_width = self.width();
+        let target_width = BitWidth::w128();
 
-		if actual_width < target_width {
-			// Sign extend the `i128`. Fill up with `1` up to `128` bits 
-			// starting from the sign bit position.
-			let b = actual_width.to_usize(); // Number of bits representing the number in x.
-			let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
-			result = (result ^ m) - m;       // Resulting sign-extended number.
-		}
+        if actual_width < target_width {
+            // Sign extend the `i128`. Fill up with `1` up to `128` bits 
+            // starting from the sign bit position.
+            let b = actual_width.to_usize(); // Number of bits representing the number in x.
+            let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
+            result = (result ^ m) - m;       // Resulting sign-extended number.
+        }
 
-		result
-	}
+        result
+    }
 
-	/// Resizes this `ApInt` to a `u128` primitive type.
-	/// 
-	/// # Note
-	/// 
-	/// - All bits but the least significant `128` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u128(&self) -> u128 {
-		let ( lsd_0, rest) = self.split_least_significant_digit();
-		let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
-		let result: u128 =
-			(u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
-		result
-	}
+    /// Resizes this `ApInt` to a `u128` primitive type.
+    /// 
+    /// # Note
+    /// 
+    /// - All bits but the least significant `128` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u128(&self) -> u128 {
+        let ( lsd_0, rest) = self.split_least_significant_digit();
+        let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
+        let result: u128 =
+            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+        result
+    }
 }
 
 /// # Operations to lossless cast to primitive number types.
 impl ApInt {
-	/// Verifies if this `ApInt` can be casted into the given primitive type
-	/// without loss of information and returns the least significant `Digit`
-	/// of this `ApInt` upon success.
-	/// 
-	/// # Note
-	/// 
-	/// If the given `PrimitiveTy` represents a signed integer type the 
-	/// returned `Digit` is also sign extended accordingly. 
-	/// This sign extension behaves equal to how in Rust a negative signed
-	/// `i32` is extended to an `i64` and correctly preserves the negative value.
-	/// 
-	/// # Errors
-	/// 
-	/// If it is not possible to cast this `ApInt` without loss of information.
-	fn try_cast_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Result<Digit> {
-		debug_assert_ne!(prim_ty, PrimitiveTy::U128);
-		debug_assert_ne!(prim_ty, PrimitiveTy::I128);
-		let (mut lsd, rest) = self.split_least_significant_digit();
-		if !prim_ty.is_valid_repr(lsd.repr())
-		   || rest.into_iter().any(|d| d.repr() != 0)
-		{
-			return Error::encountered_unrepresentable_value(
-				self.clone(), prim_ty).into()
-		}
-		if prim_ty.is_signed() {
-			let actual_width = self.width();
-			let target_width = prim_ty.associated_width();
-			if actual_width < target_width {
-				lsd.sign_extend_from(actual_width)
-				   .expect("We already asserted that `actual_width` < `target_width` \
-							and since `target_width` is always less than or equal to \
-							`64` bits calling `Digit::sign_extend_from` is safe for it.");
-				if target_width < BitWidth::w64() {
-					lsd.truncate_to(target_width)
-						.expect("Since `target_width` is always less than or equal to \
-								`64` bits calling `Digit::sign_extend_from` is safe for it.");
-				}
-			}
-		}
-		Ok(lsd)
-	}
+    /// Verifies if this `ApInt` can be casted into the given primitive type
+    /// without loss of information and returns the least significant `Digit`
+    /// of this `ApInt` upon success.
+    /// 
+    /// # Note
+    /// 
+    /// If the given `PrimitiveTy` represents a signed integer type the 
+    /// returned `Digit` is also sign extended accordingly. 
+    /// This sign extension behaves equal to how in Rust a negative signed
+    /// `i32` is extended to an `i64` and correctly preserves the negative value.
+    /// 
+    /// # Errors
+    /// 
+    /// If it is not possible to cast this `ApInt` without loss of information.
+    fn try_cast_to_primitive_ty(&self, prim_ty: PrimitiveTy) -> Result<Digit> {
+        debug_assert_ne!(prim_ty, PrimitiveTy::U128);
+        debug_assert_ne!(prim_ty, PrimitiveTy::I128);
+        let (mut lsd, rest) = self.split_least_significant_digit();
+        if !prim_ty.is_valid_repr(lsd.repr())
+           || rest.into_iter().any(|d| d.repr() != 0)
+        {
+            return Error::encountered_unrepresentable_value(
+                self.clone(), prim_ty).into()
+        }
+        if prim_ty.is_signed() {
+            let actual_width = self.width();
+            let target_width = prim_ty.associated_width();
+            if actual_width < target_width {
+                lsd.sign_extend_from(actual_width)
+                   .expect("We already asserted that `actual_width` < `target_width` \
+                            and since `target_width` is always less than or equal to \
+                            `64` bits calling `Digit::sign_extend_from` is safe for it.");
+                if target_width < BitWidth::w64() {
+                    lsd.truncate_to(target_width)
+                        .expect("Since `target_width` is always less than or equal to \
+                                `64` bits calling `Digit::sign_extend_from` is safe for it.");
+                }
+            }
+        }
+        Ok(lsd)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `bool`.
-	/// 
-	/// # Note
-	/// 
-	/// This returns `true` if the value represented by this `ApInt`
-	/// is `1`, returns `false` if the value represented by this
-	/// `ApInt` is `0` and returns an error otherwise.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `bool`.
-	pub fn try_to_bool(&self) -> Result<bool> {
-		match self.try_cast_to_primitive_ty(PrimitiveTy::Bool)? {
-			Digit(0) => Ok(false),
-			Digit(1) => Ok(true),
-		   _ => unreachable!()
-		}
-	}
+    /// Tries to represent the value of this `ApInt` as a `bool`.
+    /// 
+    /// # Note
+    /// 
+    /// This returns `true` if the value represented by this `ApInt`
+    /// is `1`, returns `false` if the value represented by this
+    /// `ApInt` is `0` and returns an error otherwise.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `bool`.
+    pub fn try_to_bool(&self) -> Result<bool> {
+        match self.try_cast_to_primitive_ty(PrimitiveTy::Bool)? {
+            Digit(0) => Ok(false),
+            Digit(1) => Ok(true),
+           _ => unreachable!()
+        }
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `i8`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `8` bits the value is
-	///   sign extended to the target bit width.
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u8`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `i8`.
-	pub fn try_to_i8(&self) -> Result<i8> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::I8).map(|d| d.repr() as i8)
-	}
+    /// Tries to represent the value of this `ApInt` as a `i8`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `8` bits the value is
+    ///   sign extended to the target bit width.
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u8`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `i8`.
+    pub fn try_to_i8(&self) -> Result<i8> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::I8).map(|d| d.repr() as i8)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `u8`.
-	/// 
-	/// # Note
-	/// 
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u8`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `u8`.
-	pub fn try_to_u8(&self) -> Result<u8> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::U8).map(|d| d.repr() as u8)
-	}
+    /// Tries to represent the value of this `ApInt` as a `u8`.
+    /// 
+    /// # Note
+    /// 
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u8`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `u8`.
+    pub fn try_to_u8(&self) -> Result<u8> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::U8).map(|d| d.repr() as u8)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `i16`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `16` bits the value is
-	///   sign extended to the target bit width.
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u16`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `i16`.
-	pub fn try_to_i16(&self) -> Result<i16> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::I16).map(|d| d.repr() as i16)
-	}
+    /// Tries to represent the value of this `ApInt` as a `i16`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `16` bits the value is
+    ///   sign extended to the target bit width.
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u16`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `i16`.
+    pub fn try_to_i16(&self) -> Result<i16> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::I16).map(|d| d.repr() as i16)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `u16`.
-	/// 
-	/// # Note
-	/// 
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u16`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `u16`.
-	pub fn try_to_u16(&self) -> Result<u16> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::U16).map(|d| d.repr() as u16)
-	}
+    /// Tries to represent the value of this `ApInt` as a `u16`.
+    /// 
+    /// # Note
+    /// 
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u16`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `u16`.
+    pub fn try_to_u16(&self) -> Result<u16> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::U16).map(|d| d.repr() as u16)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `i32`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `32` bits the value is
-	///   sign extended to the target bit width.
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u32`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `i32`.
-	pub fn try_to_i32(&self) -> Result<i32> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::I32).map(|d| d.repr() as i32)
-	}
+    /// Tries to represent the value of this `ApInt` as a `i32`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `32` bits the value is
+    ///   sign extended to the target bit width.
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u32`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `i32`.
+    pub fn try_to_i32(&self) -> Result<i32> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::I32).map(|d| d.repr() as i32)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `u32`.
-	/// 
-	/// # Note
-	/// 
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u32`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `u32`.
-	pub fn try_to_u32(&self) -> Result<u32> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::U32).map(|d| d.repr() as u32)
-	}
+    /// Tries to represent the value of this `ApInt` as a `u32`.
+    /// 
+    /// # Note
+    /// 
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u32`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `u32`.
+    pub fn try_to_u32(&self) -> Result<u32> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::U32).map(|d| d.repr() as u32)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `i64`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `64` bits the value is
-	///   sign extended to the target bit width.
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u64`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `i64`.
-	pub fn try_to_i64(&self) -> Result<i64> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::I64).map(|d| d.repr() as i64)
-	}
+    /// Tries to represent the value of this `ApInt` as a `i64`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `64` bits the value is
+    ///   sign extended to the target bit width.
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u64`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `i64`.
+    pub fn try_to_i64(&self) -> Result<i64> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::I64).map(|d| d.repr() as i64)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `u64`.
-	/// 
-	/// # Note
-	/// 
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u64`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `u64`.
-	pub fn try_to_u64(&self) -> Result<u64> {
-		self.try_cast_to_primitive_ty(PrimitiveTy::U64).map(|d| d.repr() as u64)
-	}
+    /// Tries to represent the value of this `ApInt` as a `u64`.
+    /// 
+    /// # Note
+    /// 
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u64`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `u64`.
+    pub fn try_to_u64(&self) -> Result<u64> {
+        self.try_cast_to_primitive_ty(PrimitiveTy::U64).map(|d| d.repr() as u64)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `i128`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will conserve the signedness of the
-	///   value. This means that for `ApInt` instances with
-	///   a `BitWidth` less than `128` bits the value is
-	///   sign extended to the target bit width.
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u128`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `i128`.
-	pub fn try_to_i128(&self) -> Result<i128> {
-		let ( lsd_0, rest) = self.split_least_significant_digit();
-		let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
-		if rest.into_iter().any(|d| d.repr() != 0) {
-			return Error::encountered_unrepresentable_value(
-				self.clone(), PrimitiveTy::I128).into()
-		}
-		let mut result: i128 =
-			(i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+    /// Tries to represent the value of this `ApInt` as a `i128`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will conserve the signedness of the
+    ///   value. This means that for `ApInt` instances with
+    ///   a `BitWidth` less than `128` bits the value is
+    ///   sign extended to the target bit width.
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u128`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `i128`.
+    pub fn try_to_i128(&self) -> Result<i128> {
+        let ( lsd_0, rest) = self.split_least_significant_digit();
+        let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
+        if rest.into_iter().any(|d| d.repr() != 0) {
+            return Error::encountered_unrepresentable_value(
+                self.clone(), PrimitiveTy::I128).into()
+        }
+        let mut result: i128 =
+            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
 
-		let actual_width = self.width();
-		let target_width = BitWidth::w128();
-		if actual_width < target_width {
-			// Sign extend the `i128`. Fill up with `1` up to `128` bits 
-			// starting from the sign bit position.
-			let b = actual_width.to_usize(); // Number of bits representing the number in x.
-			let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
-			result = (result ^ m).wrapping_sub(m);       // Resulting sign-extended number.
-		}
+        let actual_width = self.width();
+        let target_width = BitWidth::w128();
+        if actual_width < target_width {
+            // Sign extend the `i128`. Fill up with `1` up to `128` bits 
+            // starting from the sign bit position.
+            let b = actual_width.to_usize(); // Number of bits representing the number in x.
+            let m: i128 = 1 << (b - 1);      // Mask can be pre-computed if b is fixed.
+            result = (result ^ m).wrapping_sub(m);       // Resulting sign-extended number.
+        }
 
-		Ok(result)
-	}
+        Ok(result)
+    }
 
-	/// Tries to represent the value of this `ApInt` as a `u128`.
-	/// 
-	/// # Note
-	/// 
-	/// - This conversion is possible as long as the value represented
-	///   by this `ApInt` does not exceed the maximum value of `u128`.
-	/// 
-	/// # Complexity
-	/// 
-	/// - 𝒪(n) where n is the number of digits of this `ApInt`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the value represented by this `ApInt` can not be
-	///   represented by a `u128`.
-	pub fn try_to_u128(&self) -> Result<u128> {
-		let ( lsd_0, rest) = self.split_least_significant_digit();
-		let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
-		if rest.into_iter().any(|d| d.repr() != 0) {
-			return Error::encountered_unrepresentable_value(
-				self.clone(), PrimitiveTy::U128).into()
-		}
-		let result: u128 =
-			(u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
-		Ok(result)
-	}
+    /// Tries to represent the value of this `ApInt` as a `u128`.
+    /// 
+    /// # Note
+    /// 
+    /// - This conversion is possible as long as the value represented
+    ///   by this `ApInt` does not exceed the maximum value of `u128`.
+    /// 
+    /// # Complexity
+    /// 
+    /// - 𝒪(n) where n is the number of digits of this `ApInt`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the value represented by this `ApInt` can not be
+    ///   represented by a `u128`.
+    pub fn try_to_u128(&self) -> Result<u128> {
+        let ( lsd_0, rest) = self.split_least_significant_digit();
+        let (&lsd_1, rest) = rest.split_first().unwrap_or((&Digit(0), &[]));
+        if rest.into_iter().any(|d| d.repr() != 0) {
+            return Error::encountered_unrepresentable_value(
+                self.clone(), PrimitiveTy::U128).into()
+        }
+        let result: u128 =
+            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	use itertools::Itertools;
+    use itertools::Itertools;
 
-	/// Returns a bunch of interesting test values for the
-	/// `to_primitive` method tests.
-	fn unsigned_test_values() -> impl Iterator<Item = i64> {
-		vec![
-			0_u64, 1, 2, 3, 5, 7, 10, 11, 13, 42, 63, 64, 65,
-			100, 127, 128, 129, 254, 255, 256, 257,
-			1337, 2047, 2048, 2049, 8001, 9999,
-			0xFEDC_BA98_7654_3210, 0xF0F0_F0F0_F0F0_F0F0,
-			0x8000_0000_0000_0000, 0x1010_1010_1010_1010,
-			0xFFFF_FFFF_0000_0000, 0x0000_FFFF_FFFF_0000,
-			0xFFFF_0000_0000_FFFF, 0xFFFF_0000_FFFF_0000,
-			0x0000_FFFF_0000_FFFF
-		].into_iter().map(|v| v as i64)
-	}
+    /// Returns a bunch of interesting test values for the
+    /// `to_primitive` method tests.
+    fn unsigned_test_values() -> impl Iterator<Item = i64> {
+        vec![
+            0_u64, 1, 2, 3, 5, 7, 10, 11, 13, 42, 63, 64, 65,
+            100, 127, 128, 129, 254, 255, 256, 257,
+            1337, 2047, 2048, 2049, 8001, 9999,
+            0xFEDC_BA98_7654_3210, 0xF0F0_F0F0_F0F0_F0F0,
+            0x8000_0000_0000_0000, 0x1010_1010_1010_1010,
+            0xFFFF_FFFF_0000_0000, 0x0000_FFFF_FFFF_0000,
+            0xFFFF_0000_0000_FFFF, 0xFFFF_0000_FFFF_0000,
+            0x0000_FFFF_0000_FFFF
+        ].into_iter().map(|v| v as i64)
+    }
 
-	/// Returns negated mirror values of `unsigned_test_values` thus doubeling
-	/// the test values count.
-	fn signed_test_values() -> impl Iterator<Item = i64> {
-		unsigned_test_values().map(|v| v.wrapping_neg())
-	}
+    /// Returns negated mirror values of `unsigned_test_values` thus doubeling
+    /// the test values count.
+    fn signed_test_values() -> impl Iterator<Item = i64> {
+        unsigned_test_values().map(|v| v.wrapping_neg())
+    }
 
-	/// Unifies signed and unsigned test values into a single iterator.
-	fn test_values() -> impl Iterator<Item = i64> {
-		unsigned_test_values().chain(signed_test_values())
-	}
+    /// Unifies signed and unsigned test values into a single iterator.
+    fn test_values() -> impl Iterator<Item = i64> {
+        unsigned_test_values().chain(signed_test_values())
+    }
 
-	/// Which `PrimitiveTy` instances shall be tested. Basically we test all
-	/// if no problems occure.
-	fn test_primitive_tys() -> impl Iterator<Item = PrimitiveTy> + Clone {
-		use self::PrimitiveTy::*;
-		vec![
-			Bool,
-			I8,
-			U8,
-			I16,
-			U16,
-			I32,
-			U32,
-			I64,
-			U64,
-			I128,
-			U128
-		].into_iter()
-	}
+    /// Which `PrimitiveTy` instances shall be tested. Basically we test all
+    /// if no problems occure.
+    fn test_primitive_tys() -> impl Iterator<Item = PrimitiveTy> + Clone {
+        use self::PrimitiveTy::*;
+        vec![
+            Bool,
+            I8,
+            U8,
+            I16,
+            U16,
+            I32,
+            U32,
+            I64,
+            U64,
+            I128,
+            U128
+        ].into_iter()
+    }
 
-	/// Uses `test_values` to iterate over already constructed `ApInt` instances.
-	fn test_vals_and_apints() -> impl Iterator<Item = (u128, ApInt)> {
-		test_values()
-			.cartesian_product(test_primitive_tys())
-			.map(|(val, prim_ty)| {
-				use self::PrimitiveTy::*;
-				match prim_ty {
-					Bool => {
-						let val = val != 0;
-						(val as u128, ApInt::from_bit(val))
-					}
-					I8 => {
-						let val = val as i8;
-						(val as u8 as u128, ApInt::from_i8(val))
-					}
-					U8 => {
-						let val = val as u8;
-						(val as u128, ApInt::from_u8(val))
-					}
-					I16 => {
-						let val = val as i16;
-						(val as u16 as u128, ApInt::from_i16(val))
-					}
-					U16 => {
-						let val = val as u16;
-						(val as u128, ApInt::from_u16(val))
-					}
-					I32 => {
-						let val = val as i32;
-						(val as u32 as u128, ApInt::from_i32(val))
-					}
-					U32 => {
-						let val = val as u32;
-						(val as u128, ApInt::from_u32(val))
-					}
-					I64 => {
-						let val = val as i64;
-						(val as u64 as u128, ApInt::from_i64(val))
-					}
-					U64 => {
-						let val = val as u64;
-						(val as u128, ApInt::from_u64(val))
-					}
-					I128 => {
-						let val = val as i128;
-						(val as u128, ApInt::from_i128(val))
-					}
-					U128 => {
-						let val = val as u128;
-						(val, ApInt::from_u128(val))
-					}
-				}
-			})
-	}
+    /// Uses `test_values` to iterate over already constructed `ApInt` instances.
+    fn test_vals_and_apints() -> impl Iterator<Item = (u128, ApInt)> {
+        test_values()
+            .cartesian_product(test_primitive_tys())
+            .map(|(val, prim_ty)| {
+                use self::PrimitiveTy::*;
+                match prim_ty {
+                    Bool => {
+                        let val = val != 0;
+                        (val as u128, ApInt::from_bit(val))
+                    }
+                    I8 => {
+                        let val = val as i8;
+                        (val as u8 as u128, ApInt::from_i8(val))
+                    }
+                    U8 => {
+                        let val = val as u8;
+                        (val as u128, ApInt::from_u8(val))
+                    }
+                    I16 => {
+                        let val = val as i16;
+                        (val as u16 as u128, ApInt::from_i16(val))
+                    }
+                    U16 => {
+                        let val = val as u16;
+                        (val as u128, ApInt::from_u16(val))
+                    }
+                    I32 => {
+                        let val = val as i32;
+                        (val as u32 as u128, ApInt::from_i32(val))
+                    }
+                    U32 => {
+                        let val = val as u32;
+                        (val as u128, ApInt::from_u32(val))
+                    }
+                    I64 => {
+                        let val = val as i64;
+                        (val as u64 as u128, ApInt::from_i64(val))
+                    }
+                    U64 => {
+                        let val = val as u64;
+                        (val as u128, ApInt::from_u64(val))
+                    }
+                    I128 => {
+                        let val = val as i128;
+                        (val as u128, ApInt::from_i128(val))
+                    }
+                    U128 => {
+                        let val = val as u128;
+                        (val, ApInt::from_u128(val))
+                    }
+                }
+            })
+    }
 
-	mod resize {
-		use super::*;
+    mod resize {
+        use super::*;
 
-		#[test]
-		fn count_test_apints() {
-			assert_eq!(test_vals_and_apints().count(), 792);
-		}
+        #[test]
+        fn count_test_apints() {
+            assert_eq!(test_vals_and_apints().count(), 792);
+        }
 
-		#[test]
-		fn to_bool_true() {
-			assert_eq!(ApInt::from(true).resize_to_bool(), true);
-			assert_eq!(ApInt::from(1_u8).resize_to_bool(), true);
-			assert_eq!(ApInt::from(1_u16).resize_to_bool(), true);
-			assert_eq!(ApInt::from(1_u32).resize_to_bool(), true);
-			assert_eq!(ApInt::from(1_u64).resize_to_bool(), true);
-			assert_eq!(ApInt::from(1_u128).resize_to_bool(), true);
-		}
+        #[test]
+        fn to_bool_true() {
+            assert_eq!(ApInt::from(true).resize_to_bool(), true);
+            assert_eq!(ApInt::from(1_u8).resize_to_bool(), true);
+            assert_eq!(ApInt::from(1_u16).resize_to_bool(), true);
+            assert_eq!(ApInt::from(1_u32).resize_to_bool(), true);
+            assert_eq!(ApInt::from(1_u64).resize_to_bool(), true);
+            assert_eq!(ApInt::from(1_u128).resize_to_bool(), true);
+        }
 
-		#[test]
-		fn to_bool_odd() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(val % 2 == 0, apint.is_even());
-				assert_eq!(val % 2 != 0, apint.is_odd());
-				assert_eq!(apint.resize_to_bool(), apint.is_odd())
-			}
-		}
+        #[test]
+        fn to_bool_odd() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(val % 2 == 0, apint.is_even());
+                assert_eq!(val % 2 != 0, apint.is_odd());
+                assert_eq!(apint.resize_to_bool(), apint.is_odd())
+            }
+        }
 
-		#[test]
-		fn to_i8() {
-			for (val, apint) in test_vals_and_apints() {
-				let actual_width = apint.width();
-				let target_width = PrimitiveTy::I8.associated_width();
-				if actual_width < target_width {
-					let mut digit = Digit(val as u64);
-					digit.sign_extend_from(actual_width).unwrap();
-					digit.truncate_to(target_width).unwrap();
-					assert_eq!(apint.resize_to_i8(), digit.repr() as i8);
-				}
-				else {
-					assert_eq!(apint.resize_to_i8(), val as i8)
-				}
-			}
-		}
+        #[test]
+        fn to_i8() {
+            for (val, apint) in test_vals_and_apints() {
+                let actual_width = apint.width();
+                let target_width = PrimitiveTy::I8.associated_width();
+                if actual_width < target_width {
+                    let mut digit = Digit(val as u64);
+                    digit.sign_extend_from(actual_width).unwrap();
+                    digit.truncate_to(target_width).unwrap();
+                    assert_eq!(apint.resize_to_i8(), digit.repr() as i8);
+                }
+                else {
+                    assert_eq!(apint.resize_to_i8(), val as i8)
+                }
+            }
+        }
 
-		#[test]
-		fn to_u8() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(apint.resize_to_u8(), val as u8)
-			}
-		}
+        #[test]
+        fn to_u8() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(apint.resize_to_u8(), val as u8)
+            }
+        }
 
-		#[test]
-		fn to_i16() {
-			for (val, apint) in test_vals_and_apints() {
-				let actual_width = apint.width();
-				let target_width = PrimitiveTy::I16.associated_width();
-				if actual_width < target_width {
-					let mut digit = Digit(val as u64);
-					digit.sign_extend_from(actual_width).unwrap();
-					digit.truncate_to(target_width).unwrap();
-					assert_eq!(apint.resize_to_i16(), digit.repr() as i16);
-				}
-				else {
-					assert_eq!(apint.resize_to_i16(), val as i16)
-				}
-			}
-		}
+        #[test]
+        fn to_i16() {
+            for (val, apint) in test_vals_and_apints() {
+                let actual_width = apint.width();
+                let target_width = PrimitiveTy::I16.associated_width();
+                if actual_width < target_width {
+                    let mut digit = Digit(val as u64);
+                    digit.sign_extend_from(actual_width).unwrap();
+                    digit.truncate_to(target_width).unwrap();
+                    assert_eq!(apint.resize_to_i16(), digit.repr() as i16);
+                }
+                else {
+                    assert_eq!(apint.resize_to_i16(), val as i16)
+                }
+            }
+        }
 
-		#[test]
-		fn to_u16() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(apint.resize_to_u16(), val as u16)
-			}
-		}
+        #[test]
+        fn to_u16() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(apint.resize_to_u16(), val as u16)
+            }
+        }
 
-		#[test]
-		fn to_i32() {
-			for (val, apint) in test_vals_and_apints() {
-				let actual_width = apint.width();
-				let target_width = PrimitiveTy::I32.associated_width();
-				if actual_width < target_width {
-					let mut digit = Digit(val as u64);
-					digit.sign_extend_from(actual_width).unwrap();
-					digit.truncate_to(target_width).unwrap();
-					assert_eq!(apint.resize_to_i32(), digit.repr() as i32);
-				}
-				else {
-					assert_eq!(apint.resize_to_i32(), val as i32)
-				}
-			}
-		}
+        #[test]
+        fn to_i32() {
+            for (val, apint) in test_vals_and_apints() {
+                let actual_width = apint.width();
+                let target_width = PrimitiveTy::I32.associated_width();
+                if actual_width < target_width {
+                    let mut digit = Digit(val as u64);
+                    digit.sign_extend_from(actual_width).unwrap();
+                    digit.truncate_to(target_width).unwrap();
+                    assert_eq!(apint.resize_to_i32(), digit.repr() as i32);
+                }
+                else {
+                    assert_eq!(apint.resize_to_i32(), val as i32)
+                }
+            }
+        }
 
-		#[test]
-		fn to_u32() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(apint.resize_to_u32(), val as u32)
-			}
-		}
+        #[test]
+        fn to_u32() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(apint.resize_to_u32(), val as u32)
+            }
+        }
 
-		#[test]
-		fn to_i64() {
-			for (val, apint) in test_vals_and_apints() {
-				let actual_width = apint.width();
-				let target_width = PrimitiveTy::I64.associated_width();
-				if actual_width < target_width {
-					let mut digit = Digit(val as u64);
-					digit.sign_extend_from(actual_width).unwrap();
-					assert_eq!(apint.resize_to_i64(), digit.repr() as i64);
-				}
-				else {
-					assert_eq!(apint.resize_to_i64(), val as i64)
-				}
-			}
-		}
+        #[test]
+        fn to_i64() {
+            for (val, apint) in test_vals_and_apints() {
+                let actual_width = apint.width();
+                let target_width = PrimitiveTy::I64.associated_width();
+                if actual_width < target_width {
+                    let mut digit = Digit(val as u64);
+                    digit.sign_extend_from(actual_width).unwrap();
+                    assert_eq!(apint.resize_to_i64(), digit.repr() as i64);
+                }
+                else {
+                    assert_eq!(apint.resize_to_i64(), val as i64)
+                }
+            }
+        }
 
-		#[test]
-		fn to_u64() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(apint.resize_to_u64(), val as u64)
-			}
-		}
+        #[test]
+        fn to_u64() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(apint.resize_to_u64(), val as u64)
+            }
+        }
 
-		#[test]
-		fn to_i128() {
-			for (val, apint) in test_vals_and_apints() {
-				let actual_width = apint.width();
-				let target_width = PrimitiveTy::I128.associated_width();
-				if actual_width < target_width {
-					let mut digit = Digit(val as u64);
-					digit.sign_extend_from(actual_width).unwrap();
-					assert_eq!(apint.resize_to_i128(), digit.repr() as i64 as i128);
-				}
-				else {
-					assert_eq!(apint.resize_to_i128(), val as i128)
-				}
-			}
-		}
+        #[test]
+        fn to_i128() {
+            for (val, apint) in test_vals_and_apints() {
+                let actual_width = apint.width();
+                let target_width = PrimitiveTy::I128.associated_width();
+                if actual_width < target_width {
+                    let mut digit = Digit(val as u64);
+                    digit.sign_extend_from(actual_width).unwrap();
+                    assert_eq!(apint.resize_to_i128(), digit.repr() as i64 as i128);
+                }
+                else {
+                    assert_eq!(apint.resize_to_i128(), val as i128)
+                }
+            }
+        }
 
-		#[test]
-		fn to_u128() {
-			for (val, apint) in test_vals_and_apints() {
-				assert_eq!(apint.resize_to_u128(), val)
-			}
-		}
+        #[test]
+        fn to_u128() {
+            for (val, apint) in test_vals_and_apints() {
+                assert_eq!(apint.resize_to_u128(), val)
+            }
+        }
 
-		#[test]
-		fn one_to_i8() {
-			assert_eq!(ApInt::from(true).resize_to_i8(), -1);
+        #[test]
+        fn one_to_i8() {
+            assert_eq!(ApInt::from(true).resize_to_i8(), -1);
 
-			assert_eq!(ApInt::from(1_u8).resize_to_i8(), 1);
-			assert_eq!(ApInt::from(1_u16).resize_to_i8(), 1);
-			assert_eq!(ApInt::from(1_u32).resize_to_i8(), 1);
-			assert_eq!(ApInt::from(1_u64).resize_to_i8(), 1);
-			assert_eq!(ApInt::from(1_u128).resize_to_i8(), 1);
+            assert_eq!(ApInt::from(1_u8).resize_to_i8(), 1);
+            assert_eq!(ApInt::from(1_u16).resize_to_i8(), 1);
+            assert_eq!(ApInt::from(1_u32).resize_to_i8(), 1);
+            assert_eq!(ApInt::from(1_u64).resize_to_i8(), 1);
+            assert_eq!(ApInt::from(1_u128).resize_to_i8(), 1);
 
-			assert_eq!(ApInt::from(-1_i8).resize_to_i8(), -1);
-			assert_eq!(ApInt::from(-1_i16).resize_to_i8(), -1);
-			assert_eq!(ApInt::from(-1_i32).resize_to_i8(), -1);
-			assert_eq!(ApInt::from(-1_i64).resize_to_i8(), -1);
-			assert_eq!(ApInt::from(-1_i128).resize_to_i8(), -1);
-		}
-	}
+            assert_eq!(ApInt::from(-1_i8).resize_to_i8(), -1);
+            assert_eq!(ApInt::from(-1_i16).resize_to_i8(), -1);
+            assert_eq!(ApInt::from(-1_i32).resize_to_i8(), -1);
+            assert_eq!(ApInt::from(-1_i64).resize_to_i8(), -1);
+            assert_eq!(ApInt::from(-1_i128).resize_to_i8(), -1);
+        }
+    }
 
-	mod try {
-		use super::*;
+    mod try {
+        use super::*;
 
-		#[test]
-		fn to_bool_true() {
-			assert_eq!(ApInt::from(true).try_to_bool(), Ok(true));
-			assert_eq!(ApInt::from(1_u8).try_to_bool(), Ok(true));
-			assert_eq!(ApInt::from(1_u16).try_to_bool(), Ok(true));
-			assert_eq!(ApInt::from(1_u32).try_to_bool(), Ok(true));
-			assert_eq!(ApInt::from(1_u64).try_to_bool(), Ok(true));
-			assert_eq!(ApInt::from(1_u128).try_to_bool(), Ok(true));
-		}
+        #[test]
+        fn to_bool_true() {
+            assert_eq!(ApInt::from(true).try_to_bool(), Ok(true));
+            assert_eq!(ApInt::from(1_u8).try_to_bool(), Ok(true));
+            assert_eq!(ApInt::from(1_u16).try_to_bool(), Ok(true));
+            assert_eq!(ApInt::from(1_u32).try_to_bool(), Ok(true));
+            assert_eq!(ApInt::from(1_u64).try_to_bool(), Ok(true));
+            assert_eq!(ApInt::from(1_u128).try_to_bool(), Ok(true));
+        }
 
-		#[test]
-		fn to_bool_false() {
-			assert_eq!(ApInt::from(false).try_to_bool(), Ok(false));
-			assert_eq!(ApInt::from(0_u8).try_to_bool(), Ok(false));
-			assert_eq!(ApInt::from(0_u16).try_to_bool(), Ok(false));
-			assert_eq!(ApInt::from(0_u32).try_to_bool(), Ok(false));
-			assert_eq!(ApInt::from(0_u64).try_to_bool(), Ok(false));
-			assert_eq!(ApInt::from(0_u128).try_to_bool(), Ok(false));
-		}
+        #[test]
+        fn to_bool_false() {
+            assert_eq!(ApInt::from(false).try_to_bool(), Ok(false));
+            assert_eq!(ApInt::from(0_u8).try_to_bool(), Ok(false));
+            assert_eq!(ApInt::from(0_u16).try_to_bool(), Ok(false));
+            assert_eq!(ApInt::from(0_u32).try_to_bool(), Ok(false));
+            assert_eq!(ApInt::from(0_u64).try_to_bool(), Ok(false));
+            assert_eq!(ApInt::from(0_u128).try_to_bool(), Ok(false));
+        }
 
-		#[test]
-		fn to_bool_fail() {
-			assert!(ApInt::from(2_u8).try_to_bool().is_err());
-			assert!(ApInt::from(-1_i16).try_to_bool().is_err());
-			assert!(ApInt::from(42_u32).try_to_bool().is_err());
-			assert!(ApInt::from(1337_u64).try_to_bool().is_err());
-			assert!(ApInt::from(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_u128)
-				.try_to_bool()
-				.is_err()
-			);
-		}
+        #[test]
+        fn to_bool_fail() {
+            assert!(ApInt::from(2_u8).try_to_bool().is_err());
+            assert!(ApInt::from(-1_i16).try_to_bool().is_err());
+            assert!(ApInt::from(42_u32).try_to_bool().is_err());
+            assert!(ApInt::from(1337_u64).try_to_bool().is_err());
+            assert!(ApInt::from(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_u128)
+                .try_to_bool()
+                .is_err()
+            );
+        }
 
-		#[test]
-		fn to_i8() {
-			for (val, apint) in test_vals_and_apints() {
-				if PrimitiveTy::I8.is_valid_dd(val) {
-					let actual_width = apint.width();
-					let target_width = PrimitiveTy::I8.associated_width();
-					if actual_width < target_width {
-						let mut digit = Digit(val as u64);
-						digit.sign_extend_from(actual_width).unwrap();
-						digit.truncate_to(target_width).unwrap();
-						assert_eq!(apint.try_to_i8(), Ok(digit.repr() as i8));
-					}
-					else {
-						assert_eq!(apint.try_to_i8(), Ok(val as i8))
-					}
-				}
-				else {
-					assert!(apint.try_to_i8().is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_i8() {
+            for (val, apint) in test_vals_and_apints() {
+                if PrimitiveTy::I8.is_valid_dd(val) {
+                    let actual_width = apint.width();
+                    let target_width = PrimitiveTy::I8.associated_width();
+                    if actual_width < target_width {
+                        let mut digit = Digit(val as u64);
+                        digit.sign_extend_from(actual_width).unwrap();
+                        digit.truncate_to(target_width).unwrap();
+                        assert_eq!(apint.try_to_i8(), Ok(digit.repr() as i8));
+                    }
+                    else {
+                        assert_eq!(apint.try_to_i8(), Ok(val as i8))
+                    }
+                }
+                else {
+                    assert!(apint.try_to_i8().is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_i16() {
-			for (val, apint) in test_vals_and_apints() {
-				if PrimitiveTy::I16.is_valid_dd(val) {
-					let actual_width = apint.width();
-					let target_width = PrimitiveTy::I16.associated_width();
-					if actual_width < target_width {
-						let mut digit = Digit(val as u64);
-						digit.sign_extend_from(actual_width).unwrap();
-						digit.truncate_to(target_width).unwrap();
-						assert_eq!(apint.try_to_i16(), Ok(digit.repr() as i16));
-					}
-					else {
-						assert_eq!(apint.try_to_i16(), Ok(val as i16))
-					}
-				}
-				else {
-					assert!(apint.try_to_i16().is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_i16() {
+            for (val, apint) in test_vals_and_apints() {
+                if PrimitiveTy::I16.is_valid_dd(val) {
+                    let actual_width = apint.width();
+                    let target_width = PrimitiveTy::I16.associated_width();
+                    if actual_width < target_width {
+                        let mut digit = Digit(val as u64);
+                        digit.sign_extend_from(actual_width).unwrap();
+                        digit.truncate_to(target_width).unwrap();
+                        assert_eq!(apint.try_to_i16(), Ok(digit.repr() as i16));
+                    }
+                    else {
+                        assert_eq!(apint.try_to_i16(), Ok(val as i16))
+                    }
+                }
+                else {
+                    assert!(apint.try_to_i16().is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_i32() {
-			for (val, apint) in test_vals_and_apints() {
-				if PrimitiveTy::I32.is_valid_dd(val) {
-					let actual_width = apint.width();
-					let target_width = PrimitiveTy::I32.associated_width();
-					if actual_width < target_width {
-						let mut digit = Digit(val as u64);
-						digit.sign_extend_from(actual_width).unwrap();
-						digit.truncate_to(target_width).unwrap();
-						assert_eq!(apint.try_to_i32(), Ok(digit.repr() as i32));
-					}
-					else {
-						assert_eq!(apint.try_to_i32(), Ok(val as i32))
-					}
-				}
-				else {
-					assert!(apint.try_to_i32().is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_i32() {
+            for (val, apint) in test_vals_and_apints() {
+                if PrimitiveTy::I32.is_valid_dd(val) {
+                    let actual_width = apint.width();
+                    let target_width = PrimitiveTy::I32.associated_width();
+                    if actual_width < target_width {
+                        let mut digit = Digit(val as u64);
+                        digit.sign_extend_from(actual_width).unwrap();
+                        digit.truncate_to(target_width).unwrap();
+                        assert_eq!(apint.try_to_i32(), Ok(digit.repr() as i32));
+                    }
+                    else {
+                        assert_eq!(apint.try_to_i32(), Ok(val as i32))
+                    }
+                }
+                else {
+                    assert!(apint.try_to_i32().is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_i64() {
-			for (val, apint) in test_vals_and_apints() {
-				if PrimitiveTy::I64.is_valid_dd(val) {
-					let actual_width = apint.width();
-					let target_width = PrimitiveTy::I64.associated_width();
-					if actual_width < target_width {
-						let mut digit = Digit(val as u64);
-						digit.sign_extend_from(actual_width).unwrap();
-						assert_eq!(apint.try_to_i64(), Ok(digit.repr() as i64));
-					}
-					else {
-						assert_eq!(apint.try_to_i64(), Ok(val as i64))
-					}
-				}
-				else {
-					assert!(apint.try_to_i64().is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_i64() {
+            for (val, apint) in test_vals_and_apints() {
+                if PrimitiveTy::I64.is_valid_dd(val) {
+                    let actual_width = apint.width();
+                    let target_width = PrimitiveTy::I64.associated_width();
+                    if actual_width < target_width {
+                        let mut digit = Digit(val as u64);
+                        digit.sign_extend_from(actual_width).unwrap();
+                        assert_eq!(apint.try_to_i64(), Ok(digit.repr() as i64));
+                    }
+                    else {
+                        assert_eq!(apint.try_to_i64(), Ok(val as i64))
+                    }
+                }
+                else {
+                    assert!(apint.try_to_i64().is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_i128() {
-			for (val, apint) in test_vals_and_apints() {
-				if PrimitiveTy::I128.is_valid_dd(val) {
+        #[test]
+        fn to_i128() {
+            for (val, apint) in test_vals_and_apints() {
+                if PrimitiveTy::I128.is_valid_dd(val) {
 
-					let actual_width = apint.width();
-					let target_width = BitWidth::w128();
-					let mut result: i128 = val as i128;
-					if actual_width < target_width {
-						// Sign extend the `i128`. Fill up with `1` up to `128` bits 
-						// starting from the sign bit position.
-						let b = actual_width.to_usize();       // Number of bits representing the number in x.
-						let m: i128 = 1 << (b - 1);            // Mask can be pre-computed if b is fixed.
-						result = (result ^ m).wrapping_sub(m); // Resulting sign-extended number.
-					}
-					assert_eq!(apint.try_to_i128(), Ok(result))
-				}
-				else {
-					assert!(apint.try_to_i128().is_err())
-				}
-			}
-		}
+                    let actual_width = apint.width();
+                    let target_width = BitWidth::w128();
+                    let mut result: i128 = val as i128;
+                    if actual_width < target_width {
+                        // Sign extend the `i128`. Fill up with `1` up to `128` bits 
+                        // starting from the sign bit position.
+                        let b = actual_width.to_usize();       // Number of bits representing the number in x.
+                        let m: i128 = 1 << (b - 1);            // Mask can be pre-computed if b is fixed.
+                        result = (result ^ m).wrapping_sub(m); // Resulting sign-extended number.
+                    }
+                    assert_eq!(apint.try_to_i128(), Ok(result))
+                }
+                else {
+                    assert!(apint.try_to_i128().is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_u8() {
-			for (val, apint) in test_vals_and_apints() {
-				let result = apint.try_to_u8();
-				if PrimitiveTy::U8.is_valid_dd(val) {
-					assert_eq!(result, Ok(val as u8))
-				}
-				else {
-					assert!(result.is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_u8() {
+            for (val, apint) in test_vals_and_apints() {
+                let result = apint.try_to_u8();
+                if PrimitiveTy::U8.is_valid_dd(val) {
+                    assert_eq!(result, Ok(val as u8))
+                }
+                else {
+                    assert!(result.is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_u16() {
-			for (val, apint) in test_vals_and_apints() {
-				let result = apint.try_to_u16();
-				if PrimitiveTy::U16.is_valid_dd(val) {
-					assert_eq!(result, Ok(val as u16))
-				}
-				else {
-					assert!(result.is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_u16() {
+            for (val, apint) in test_vals_and_apints() {
+                let result = apint.try_to_u16();
+                if PrimitiveTy::U16.is_valid_dd(val) {
+                    assert_eq!(result, Ok(val as u16))
+                }
+                else {
+                    assert!(result.is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_u32() {
-			for (val, apint) in test_vals_and_apints() {
-				let result = apint.try_to_u32();
-				if PrimitiveTy::U32.is_valid_dd(val) {
-					assert_eq!(result, Ok(val as u32))
-				}
-				else {
-					assert!(result.is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_u32() {
+            for (val, apint) in test_vals_and_apints() {
+                let result = apint.try_to_u32();
+                if PrimitiveTy::U32.is_valid_dd(val) {
+                    assert_eq!(result, Ok(val as u32))
+                }
+                else {
+                    assert!(result.is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_u64() {
-			for (val, apint) in test_vals_and_apints() {
-				let result = apint.try_to_u64();
-				if PrimitiveTy::U64.is_valid_dd(val) {
-					assert_eq!(result, Ok(val as u64))
-				}
-				else {
-					assert!(result.is_err())
-				}
-			}
-		}
+        #[test]
+        fn to_u64() {
+            for (val, apint) in test_vals_and_apints() {
+                let result = apint.try_to_u64();
+                if PrimitiveTy::U64.is_valid_dd(val) {
+                    assert_eq!(result, Ok(val as u64))
+                }
+                else {
+                    assert!(result.is_err())
+                }
+            }
+        }
 
-		#[test]
-		fn to_u128() {
-			for (val, apint) in test_vals_and_apints() {
-				let result = apint.try_to_u128();
-				if PrimitiveTy::U128.is_valid_dd(val) {
-					assert_eq!(result, Ok(val as u128))
-				}
-				else {
-					assert!(result.is_err())
-				}
-			}
-		}
-	}
+        #[test]
+        fn to_u128() {
+            for (val, apint) in test_vals_and_apints() {
+                let result = apint.try_to_u128();
+                if PrimitiveTy::U128.is_valid_dd(val) {
+                    assert_eq!(result, Ok(val as u128))
+                }
+                else {
+                    assert!(result.is_err())
+                }
+            }
+        }
+    }
 }

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -6,402 +6,402 @@ use errors::{Error, Result};
 use traits::Width;
 use bitwidth::BitWidth;
 use digit_seq::{
-	ContiguousDigitSeq,
-	ContiguousDigitSeqMut
+    ContiguousDigitSeq,
+    ContiguousDigitSeqMut
 };
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
 impl fmt::Debug for ApInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		f.debug_struct("ApInt")
-		 .field("len", &self.width())
-		 .field("digits", &self.as_digit_slice())
-		 .finish()
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ApInt")
+         .field("len", &self.width())
+         .field("digits", &self.as_digit_slice())
+         .finish()
+    }
 }
 
 impl Hash for ApInt {
-	fn hash<H: Hasher>(&self, state: &mut H) {
-		self.len.hash(state);
-		self.as_digit_slice().hash(state);
-	}
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len.hash(state);
+        self.as_digit_slice().hash(state);
+    }
 }
 
 // ============================================================================
 
 impl ApInt {
-	pub(in apint) fn digits(&self) -> ContiguousDigitSeq {
-		ContiguousDigitSeq::from(self.as_digit_slice())
-	}
+    pub(in apint) fn digits(&self) -> ContiguousDigitSeq {
+        ContiguousDigitSeq::from(self.as_digit_slice())
+    }
 
-	pub(in apint) fn digits_mut(&mut self) -> ContiguousDigitSeqMut {
-		ContiguousDigitSeqMut::from(self.as_digit_slice_mut())
-	}
+    pub(in apint) fn digits_mut(&mut self) -> ContiguousDigitSeqMut {
+        ContiguousDigitSeqMut::from(self.as_digit_slice_mut())
+    }
 }
 
 // ============================================================================
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum DataAccess<'a> {
-	Inl(Digit),
-	Ext(&'a [Digit])
+    Inl(Digit),
+    Ext(&'a [Digit])
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum DataAccessMut<'a> {
-	Inl(&'a mut Digit),
-	Ext(&'a mut [Digit])
+    Inl(&'a mut Digit),
+    Ext(&'a mut [Digit])
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum ZipDataAccess<'a, 'b> {
-	Inl(Digit, Digit),
-	Ext(&'a [Digit], &'b [Digit])
+    Inl(Digit, Digit),
+    Ext(&'a [Digit], &'b [Digit])
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ZipDataAccessMut<'a, 'b> {
-	Inl(&'a mut Digit, Digit),
-	Ext(&'a mut [Digit], &'b [Digit])
+    Inl(&'a mut Digit, Digit),
+    Ext(&'a mut [Digit], &'b [Digit])
 }
 
 // ============================================================================
 
 impl Width for ApInt {
-	/// Returns the `BitWidth` of this `ApInt`.
-	#[inline]
-	fn width(&self) -> BitWidth {
-		BitWidth::new(self.len_bits()).unwrap()
-	}
+    /// Returns the `BitWidth` of this `ApInt`.
+    #[inline]
+    fn width(&self) -> BitWidth {
+        BitWidth::new(self.len_bits()).unwrap()
+    }
 }
 
 /// # Utility & Helper Methods
 impl ApInt {
-	/// Returns the number of bits of the bit width of this `ApInt`.
-	#[inline]
-	pub(in apint) fn len_bits(&self) -> usize {
-		self.len.to_usize()
-	}
+    /// Returns the number of bits of the bit width of this `ApInt`.
+    #[inline]
+    pub(in apint) fn len_bits(&self) -> usize {
+        self.len.to_usize()
+    }
 
-	/// Returns the number of digits used internally for the value
-	/// representation of this `ApInt`.
-	#[inline]
-	pub(in apint) fn len_digits(&self) -> usize {
-		self.len.required_digits()
-	}
+    /// Returns the number of digits used internally for the value
+    /// representation of this `ApInt`.
+    #[inline]
+    pub(in apint) fn len_digits(&self) -> usize {
+        self.len.required_digits()
+    }
 
-	/// Returns the storage specifier of this `ApInt`.
-	/// 
-	/// This is `Storage::Inl` for `ApInt` instances that can be stored
-	/// entirely on the stack and `Storage::Ext` otherwise.
-	#[inline]
-	pub(in apint) fn storage(&self) -> Storage {
-		self.len.storage()
-	}
+    /// Returns the storage specifier of this `ApInt`.
+    /// 
+    /// This is `Storage::Inl` for `ApInt` instances that can be stored
+    /// entirely on the stack and `Storage::Ext` otherwise.
+    #[inline]
+    pub(in apint) fn storage(&self) -> Storage {
+        self.len.storage()
+    }
 
-	/// Accesses the internal `Digit` data of this `ApInt` in a safe way.
-	#[inline]
-	pub(in apint) fn access_data(&self) -> DataAccess {
-		match self.storage() {
-			Storage::Inl => DataAccess::Inl(unsafe{self.data.inl}),
-			Storage::Ext => DataAccess::Ext(self.as_digit_slice())
-		}
-	}
+    /// Accesses the internal `Digit` data of this `ApInt` in a safe way.
+    #[inline]
+    pub(in apint) fn access_data(&self) -> DataAccess {
+        match self.storage() {
+            Storage::Inl => DataAccess::Inl(unsafe{self.data.inl}),
+            Storage::Ext => DataAccess::Ext(self.as_digit_slice())
+        }
+    }
 
-	/// Mutably accesses the internal `Digit` data of this `ApInt` in a safe way.
-	#[inline]
-	pub(in apint) fn access_data_mut(&mut self) -> DataAccessMut {
-		match self.storage() {
-			Storage::Inl => DataAccessMut::Inl(unsafe{&mut self.data.inl}),
-			Storage::Ext => DataAccessMut::Ext(self.as_digit_slice_mut())
-		}
-	}
+    /// Mutably accesses the internal `Digit` data of this `ApInt` in a safe way.
+    #[inline]
+    pub(in apint) fn access_data_mut(&mut self) -> DataAccessMut {
+        match self.storage() {
+            Storage::Inl => DataAccessMut::Inl(unsafe{&mut self.data.inl}),
+            Storage::Ext => DataAccessMut::Ext(self.as_digit_slice_mut())
+        }
+    }
 
-	/// Zips both given `ApInt` instances and tries to access their data in a safe way.
-	/// 
-	/// # Errors
-	/// 
-	/// - If both given `ApInt` instances have non-matching bit widths.
-	pub(in apint) fn zip_access_data<'a, 'b>(&'a self, other: &'b ApInt) -> Result<ZipDataAccess<'a, 'b>> {
-		if self.width() != other.width() {
-			return Error::unmatching_bitwidths(self.width(), other.width()).into()
-		}
-		Ok(match self.storage() {
-			Storage::Inl => {
-				ZipDataAccess::Inl(
-					unsafe{ self.data.inl},
-					unsafe{other.data.inl})
-			},
-			Storage::Ext => {
-				ZipDataAccess::Ext(
-					self.as_digit_slice(),
-					other.as_digit_slice())
-			}
-		})
-	}
+    /// Zips both given `ApInt` instances and tries to access their data in a safe way.
+    /// 
+    /// # Errors
+    /// 
+    /// - If both given `ApInt` instances have non-matching bit widths.
+    pub(in apint) fn zip_access_data<'a, 'b>(&'a self, other: &'b ApInt) -> Result<ZipDataAccess<'a, 'b>> {
+        if self.width() != other.width() {
+            return Error::unmatching_bitwidths(self.width(), other.width()).into()
+        }
+        Ok(match self.storage() {
+            Storage::Inl => {
+                ZipDataAccess::Inl(
+                    unsafe{ self.data.inl},
+                    unsafe{other.data.inl})
+            },
+            Storage::Ext => {
+                ZipDataAccess::Ext(
+                    self.as_digit_slice(),
+                    other.as_digit_slice())
+            }
+        })
+    }
 
-	/// Zips both given `ApInt` instances and tries to mutably access their data in a safe way.
-	/// 
-	/// # Errors
-	/// 
-	/// - If both given `ApInt` instances have non-matching bit widths.
-	pub(in apint) fn zip_access_data_mut<'a, 'b>(&'a mut self, other: &'b ApInt) -> Result<ZipDataAccessMut<'a, 'b>> {
-		if self.width() != other.width() {
-			return Error::unmatching_bitwidths(self.width(), other.width()).into()
-		}
-		Ok(match self.storage() {
-			Storage::Inl => {
-				ZipDataAccessMut::Inl(
-					unsafe{&mut self.data.inl},
-					unsafe{other.data.inl})
-			},
-			Storage::Ext => {
-				ZipDataAccessMut::Ext(
-					self.as_digit_slice_mut(),
-					other.as_digit_slice())
-			}
-		})
-	}
+    /// Zips both given `ApInt` instances and tries to mutably access their data in a safe way.
+    /// 
+    /// # Errors
+    /// 
+    /// - If both given `ApInt` instances have non-matching bit widths.
+    pub(in apint) fn zip_access_data_mut<'a, 'b>(&'a mut self, other: &'b ApInt) -> Result<ZipDataAccessMut<'a, 'b>> {
+        if self.width() != other.width() {
+            return Error::unmatching_bitwidths(self.width(), other.width()).into()
+        }
+        Ok(match self.storage() {
+            Storage::Inl => {
+                ZipDataAccessMut::Inl(
+                    unsafe{&mut self.data.inl},
+                    unsafe{other.data.inl})
+            },
+            Storage::Ext => {
+                ZipDataAccessMut::Ext(
+                    self.as_digit_slice_mut(),
+                    other.as_digit_slice())
+            }
+        })
+    }
 
-	/// Computes the given operation on all digits of this `ApInt`.
-	/// 
-	/// # Note
-	/// 
-	/// Prefer this utility method if you want to perform the same
-	/// operation for all digits within this `ApInt` as this operation
-	/// uses the most efficient way to do so.
-	pub(in apint) fn modify_digits<F>(&mut self, f: F)
-		where F: Fn(&mut Digit)
-	{
-		use self::DataAccessMut::*;
-		match self.access_data_mut() {
-			Inl(digit) => f(digit),
-			Ext(digits) => {
-				for digit in digits {
-					f(digit)
-				}
-			}
-		}
-	}
+    /// Computes the given operation on all digits of this `ApInt`.
+    /// 
+    /// # Note
+    /// 
+    /// Prefer this utility method if you want to perform the same
+    /// operation for all digits within this `ApInt` as this operation
+    /// uses the most efficient way to do so.
+    pub(in apint) fn modify_digits<F>(&mut self, f: F)
+        where F: Fn(&mut Digit)
+    {
+        use self::DataAccessMut::*;
+        match self.access_data_mut() {
+            Inl(digit) => f(digit),
+            Ext(digits) => {
+                for digit in digits {
+                    f(digit)
+                }
+            }
+        }
+    }
 
-	/// Computes the given operation on all digits of this `ApInt`
-	/// zipped with the digits of `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// Prefer this utility method for these use cases since this operation
-	/// uses the most efficient way to perform the specified task.
-	pub(in apint) fn modify_zipped_digits<F>(&mut self, rhs: &ApInt, f: F) -> Result<()>
-		where F: Fn(&mut Digit, Digit)
-	{
-		use self::ZipDataAccessMut::*;
-		match self.zip_access_data_mut(rhs)? {
-			Inl(lhs, rhs) => f(lhs, rhs),
-			Ext(lhs, rhs) => {
-				for (l, &r) in lhs.into_iter().zip(rhs) {
-					f(l, r)
-				}
-			}
-		}
-		Ok(())
-	}
+    /// Computes the given operation on all digits of this `ApInt`
+    /// zipped with the digits of `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// Prefer this utility method for these use cases since this operation
+    /// uses the most efficient way to perform the specified task.
+    pub(in apint) fn modify_zipped_digits<F>(&mut self, rhs: &ApInt, f: F) -> Result<()>
+        where F: Fn(&mut Digit, Digit)
+    {
+        use self::ZipDataAccessMut::*;
+        match self.zip_access_data_mut(rhs)? {
+            Inl(lhs, rhs) => f(lhs, rhs),
+            Ext(lhs, rhs) => {
+                for (l, &r) in lhs.into_iter().zip(rhs) {
+                    f(l, r)
+                }
+            }
+        }
+        Ok(())
+    }
 
-	/// Returns a slice over the `Digit`s of this `ApInt` in little-endian order.
-	pub(in apint) fn as_digit_slice(&self) -> &[Digit] {
-		use std::slice;
-		match self.len.storage() {
-			Storage::Inl => unsafe {
-				slice::from_raw_parts(&self.data.inl, 1)
-			},
-			Storage::Ext => unsafe {
-				slice::from_raw_parts(self.data.ext.as_ptr(), self.len_digits())
-			}
-		}
-	}
+    /// Returns a slice over the `Digit`s of this `ApInt` in little-endian order.
+    pub(in apint) fn as_digit_slice(&self) -> &[Digit] {
+        use std::slice;
+        match self.len.storage() {
+            Storage::Inl => unsafe {
+                slice::from_raw_parts(&self.data.inl, 1)
+            },
+            Storage::Ext => unsafe {
+                slice::from_raw_parts(self.data.ext.as_ptr(), self.len_digits())
+            }
+        }
+    }
 
-	/// Returns a mutable slice over the `Digit`s of this `ApInt` in little-endian order.
-	pub(in apint) fn as_digit_slice_mut(&mut self) -> &mut [Digit] {
-		use std::slice;
-		match self.len.storage() {
-			Storage::Inl => unsafe {
-				slice::from_raw_parts_mut(&mut self.data.inl, 1)
-			},
-			Storage::Ext => unsafe {
-				slice::from_raw_parts_mut(self.data.ext.as_ptr(), self.len_digits())
-			}
-		}
-	}
+    /// Returns a mutable slice over the `Digit`s of this `ApInt` in little-endian order.
+    pub(in apint) fn as_digit_slice_mut(&mut self) -> &mut [Digit] {
+        use std::slice;
+        match self.len.storage() {
+            Storage::Inl => unsafe {
+                slice::from_raw_parts_mut(&mut self.data.inl, 1)
+            },
+            Storage::Ext => unsafe {
+                slice::from_raw_parts_mut(self.data.ext.as_ptr(), self.len_digits())
+            }
+        }
+    }
 
-	/// Returns the most significant `Digit` of this `ApInt`.
-	pub(in apint) fn most_significant_digit(&self) -> Digit {
-		match self.access_data() {
-			DataAccess::Inl(digit) => digit,
-			DataAccess::Ext(digits) => {
-				*digits.last().unwrap()
-			}
-		}
-	}
+    /// Returns the most significant `Digit` of this `ApInt`.
+    pub(in apint) fn most_significant_digit(&self) -> Digit {
+        match self.access_data() {
+            DataAccess::Inl(digit) => digit,
+            DataAccess::Ext(digits) => {
+                *digits.last().unwrap()
+            }
+        }
+    }
 
-	/// Returns a mutable reference to the most significant `Digit` of this `ApInt`.
-	pub(in apint) fn most_significant_digit_mut(&mut self) -> &mut Digit {
-		match self.access_data_mut() {
-			DataAccessMut::Inl(digit) => digit,
-			DataAccessMut::Ext(digits) => {
-				digits.last_mut().unwrap()
-			}
-		}
-	}
+    /// Returns a mutable reference to the most significant `Digit` of this `ApInt`.
+    pub(in apint) fn most_significant_digit_mut(&mut self) -> &mut Digit {
+        match self.access_data_mut() {
+            DataAccessMut::Inl(digit) => digit,
+            DataAccessMut::Ext(digits) => {
+                digits.last_mut().unwrap()
+            }
+        }
+    }
 
-	/// Returns the least significant `Digit` of this `ApInt`.
-	pub(in apint) fn least_significant_digit(&self) -> Digit {
-		match self.access_data() {
-			DataAccess::Inl(digit) => digit,
-			DataAccess::Ext(digits) => digits[0]
-		}
-	}
+    /// Returns the least significant `Digit` of this `ApInt`.
+    pub(in apint) fn least_significant_digit(&self) -> Digit {
+        match self.access_data() {
+            DataAccess::Inl(digit) => digit,
+            DataAccess::Ext(digits) => digits[0]
+        }
+    }
 
-	/// Returns `Bit::Set` if the most significant bit of this `ApInt` is set
-	/// and `Bit::Unset` otherwise.
-	pub(in apint) fn most_significant_bit(&self) -> Bit {
-		let sign_bit_pos = self.width().sign_bit_pos();
-		self.most_significant_digit()
-			.get(sign_bit_pos.to_pos_within_digit())
-			.expect("`BitWidth::excess_bits` returns a number that \
-			         is always a valid `BitPos` for a `Digit` so this \
-			         operation cannot fail.")
-	}
+    /// Returns `Bit::Set` if the most significant bit of this `ApInt` is set
+    /// and `Bit::Unset` otherwise.
+    pub(in apint) fn most_significant_bit(&self) -> Bit {
+        let sign_bit_pos = self.width().sign_bit_pos();
+        self.most_significant_digit()
+            .get(sign_bit_pos.to_pos_within_digit())
+            .expect("`BitWidth::excess_bits` returns a number that \
+                     is always a valid `BitPos` for a `Digit` so this \
+                     operation cannot fail.")
+    }
 
-	/// Returns `Bit::Set` if the least significant bit of this `ApInt` is set
-	/// and `Bit::Unset` otherwise.
-	pub(in apint) fn least_significant_bit(&self) -> Bit {
-		self.least_significant_digit().least_significant_bit()
-	}
+    /// Returns `Bit::Set` if the least significant bit of this `ApInt` is set
+    /// and `Bit::Unset` otherwise.
+    pub(in apint) fn least_significant_bit(&self) -> Bit {
+        self.least_significant_digit().least_significant_bit()
+    }
 
-	/// Clears unused bits of this `ApInt`.
-	/// 
-	/// # Example
-	/// 
-	/// An `ApInt` with a `BitWidth` of `100` bits requires
-	/// 2 `Digit`s for its internal value representation,
-	/// each having 64-bits which totals in `128` bits for the
-	/// `ApInt` instance.
-	/// So upon a call to `ApInt::clear_unused_bits` the upper
-	/// `128-100 = 28` bits are cleared (set to zero (`0`)).
-	pub(in apint) fn clear_unused_bits(&mut self) {
-		if let Some(bits) = self.width().excess_bits() {
-			self.most_significant_digit_mut()
-			    .retain_last_n(bits)
-			    .expect("`BitWidth::excess_bits` always returns a number of \
-				         bits that can safely forwarded to `Digit::retain_last_n`.");
-		}
-	}
+    /// Clears unused bits of this `ApInt`.
+    /// 
+    /// # Example
+    /// 
+    /// An `ApInt` with a `BitWidth` of `100` bits requires
+    /// 2 `Digit`s for its internal value representation,
+    /// each having 64-bits which totals in `128` bits for the
+    /// `ApInt` instance.
+    /// So upon a call to `ApInt::clear_unused_bits` the upper
+    /// `128-100 = 28` bits are cleared (set to zero (`0`)).
+    pub(in apint) fn clear_unused_bits(&mut self) {
+        if let Some(bits) = self.width().excess_bits() {
+            self.most_significant_digit_mut()
+                .retain_last_n(bits)
+                .expect("`BitWidth::excess_bits` always returns a number of \
+                         bits that can safely forwarded to `Digit::retain_last_n`.");
+        }
+    }
 
-	/// Returns `true` if this `ApInt` represents the value zero (`0`).
-	/// 
-	/// # Note
-	/// 
-	/// - Zero (`0`) is also called the additive neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `ApInt` for the same reason.
-	pub fn is_zero(&self) -> bool {
-		match self.access_data() {
-			DataAccess::Inl(digit) => digit.is_zero(),
-			DataAccess::Ext(digits) => {
-				digits.into_iter().all(|digit| digit.is_zero())
-			}
-		}
-	}
+    /// Returns `true` if this `ApInt` represents the value zero (`0`).
+    /// 
+    /// # Note
+    /// 
+    /// - Zero (`0`) is also called the additive neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `ApInt` for the same reason.
+    pub fn is_zero(&self) -> bool {
+        match self.access_data() {
+            DataAccess::Inl(digit) => digit.is_zero(),
+            DataAccess::Ext(digits) => {
+                digits.into_iter().all(|digit| digit.is_zero())
+            }
+        }
+    }
 
-	/// Returns `true` if this `ApInt` represents the value one (`1`).
-	/// 
-	/// # Note
-	/// 
-	/// - One (`1`) is also called the multiplicative neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `ApInt` for the same reason.
-	pub fn is_one(&self) -> bool {
-		match self.access_data() {
-			DataAccess::Inl(digit) => digit == Digit::one(),
-			DataAccess::Ext(digits) => {
-				let (last, rest) = digits.split_last()
-					.expect("An `ApInt` always has at least one digit so calling \
-					         `split_last` on a slice of its digits will never \
-					         return `None`.");
-				last.is_one() && rest.into_iter().all(|digit| digit.is_zero())
-			}
-		}
-	}
+    /// Returns `true` if this `ApInt` represents the value one (`1`).
+    /// 
+    /// # Note
+    /// 
+    /// - One (`1`) is also called the multiplicative neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `ApInt` for the same reason.
+    pub fn is_one(&self) -> bool {
+        match self.access_data() {
+            DataAccess::Inl(digit) => digit == Digit::one(),
+            DataAccess::Ext(digits) => {
+                let (last, rest) = digits.split_last()
+                    .expect("An `ApInt` always has at least one digit so calling \
+                             `split_last` on a slice of its digits will never \
+                             return `None`.");
+                last.is_one() && rest.into_iter().all(|digit| digit.is_zero())
+            }
+        }
+    }
 
-	/// Returns `true` if this `ApInt` represents an even number.
-	#[inline]
-	pub fn is_even(&self) -> bool {
-		self.least_significant_bit() == Bit::Unset
-	}
+    /// Returns `true` if this `ApInt` represents an even number.
+    #[inline]
+    pub fn is_even(&self) -> bool {
+        self.least_significant_bit() == Bit::Unset
+    }
 
-	/// Returns `true` if this `ApInt` represents an odd number.
-	#[inline]
-	pub fn is_odd(&self) -> bool {
-		self.least_significant_bit() == Bit::Set
-	}
+    /// Returns `true` if this `ApInt` represents an odd number.
+    #[inline]
+    pub fn is_odd(&self) -> bool {
+        self.least_significant_bit() == Bit::Set
+    }
 
-	/// Splits the least significant digits from the rest of the digit slice
-	/// and returns it as well as the remaining part of the digit slice.
-	pub(in apint) fn split_least_significant_digit(&self) -> (Digit, &[Digit]) {
-		match self.access_data() {
-			DataAccess::Inl(digit) => (digit, &[]),
-			DataAccess::Ext(digits) => {
-				let (lsd, rest) = digits.split_first()
-					.expect("An `ApInt` always has at least one digit so calling \
-					         `split_first` on a slice of its digits will never \
-					         return `None`.");
-				(*lsd, rest)
-			}
-		}
-	}
+    /// Splits the least significant digits from the rest of the digit slice
+    /// and returns it as well as the remaining part of the digit slice.
+    pub(in apint) fn split_least_significant_digit(&self) -> (Digit, &[Digit]) {
+        match self.access_data() {
+            DataAccess::Inl(digit) => (digit, &[]),
+            DataAccess::Ext(digits) => {
+                let (lsd, rest) = digits.split_first()
+                    .expect("An `ApInt` always has at least one digit so calling \
+                             `split_first` on a slice of its digits will never \
+                             return `None`.");
+                (*lsd, rest)
+            }
+        }
+    }
 
-	/// Splits the most significant digits from the rest of the digit slice
-	/// and returns it as well as the remaining part of the digit slice.
-	pub(in apint) fn split_most_significant_digit(&self) -> (Digit, &[Digit]) {
-		match self.access_data() {
-			DataAccess::Inl(digit) => (digit, &[]),
-			DataAccess::Ext(digits) => {
-				let (lsd, rest) = digits.split_last()
-					.expect("An `ApInt` always has at least one digit so calling \
-					         `split_last` on a slice of its digits will never \
-					         return `None`.");
-				(*lsd, rest)
-			}
-		}
-	}
+    /// Splits the most significant digits from the rest of the digit slice
+    /// and returns it as well as the remaining part of the digit slice.
+    pub(in apint) fn split_most_significant_digit(&self) -> (Digit, &[Digit]) {
+        match self.access_data() {
+            DataAccess::Inl(digit) => (digit, &[]),
+            DataAccess::Ext(digits) => {
+                let (lsd, rest) = digits.split_last()
+                    .expect("An `ApInt` always has at least one digit so calling \
+                             `split_last` on a slice of its digits will never \
+                             return `None`.");
+                (*lsd, rest)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn most_significant_bit() {
-		assert_eq!(Bit::Unset,
-			ApInt::from_bit(false).most_significant_bit());
-		assert_eq!(Bit::Set,
-			ApInt::from_bit(true).most_significant_bit());
-		assert_eq!(Bit::Unset,
-			ApInt::from_u8(0b0101_0101).most_significant_bit());
-		assert_eq!(Bit::Set,
-			ApInt::from_u8(0b1101_0101).most_significant_bit());
-		assert_eq!(Bit::Unset,
-			ApInt::from_u16(0b0111_1000_1101_0101).most_significant_bit());
-		assert_eq!(Bit::Set,
-			ApInt::from_u16(0b1011_0001_0101_0101).most_significant_bit());
-		assert_eq!(Bit::Unset,
-			ApInt::from_u32(0x7000_0000).most_significant_bit());
-		assert_eq!(Bit::Set,
-			ApInt::from_u32(0x8000_0000).most_significant_bit());
-		assert_eq!(Bit::Unset,
-			ApInt::from_u64(0x70FC_A875_4321_1234).most_significant_bit());
-		assert_eq!(Bit::Set,
-			ApInt::from_u64(0x8765_4321_5555_6666).most_significant_bit());
-	}
+    #[test]
+    fn most_significant_bit() {
+        assert_eq!(Bit::Unset,
+            ApInt::from_bit(false).most_significant_bit());
+        assert_eq!(Bit::Set,
+            ApInt::from_bit(true).most_significant_bit());
+        assert_eq!(Bit::Unset,
+            ApInt::from_u8(0b0101_0101).most_significant_bit());
+        assert_eq!(Bit::Set,
+            ApInt::from_u8(0b1101_0101).most_significant_bit());
+        assert_eq!(Bit::Unset,
+            ApInt::from_u16(0b0111_1000_1101_0101).most_significant_bit());
+        assert_eq!(Bit::Set,
+            ApInt::from_u16(0b1011_0001_0101_0101).most_significant_bit());
+        assert_eq!(Bit::Unset,
+            ApInt::from_u32(0x7000_0000).most_significant_bit());
+        assert_eq!(Bit::Set,
+            ApInt::from_u32(0x8000_0000).most_significant_bit());
+        assert_eq!(Bit::Unset,
+            ApInt::from_u64(0x70FC_A875_4321_1234).most_significant_bit());
+        assert_eq!(Bit::Set,
+            ApInt::from_u64(0x8765_4321_5555_6666).most_significant_bit());
+    }
 }

--- a/src/bitpos.rs
+++ b/src/bitpos.rs
@@ -14,87 +14,87 @@ pub struct BitPos(usize);
 pub type DigitPos = usize;
 
 impl BitPos {
-	/// Returns the `usize` representation of this `BitPos`.
-	#[inline]
-	pub fn to_usize(self) -> usize {
-		self.0
-	}
+    /// Returns the `usize` representation of this `BitPos`.
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0
+    }
 
-	/// Returns a `BitPos` representing the given bit position.
-	/// 
-	/// # Errors
-	/// 
-	/// - This operation cannot fail but may do so in future version of this library.
-	#[inline]
-	pub fn new(pos: usize) -> Result<BitPos> {
-		Ok(BitPos(pos))
-	}
+    /// Returns a `BitPos` representing the given bit position.
+    /// 
+    /// # Errors
+    /// 
+    /// - This operation cannot fail but may do so in future version of this library.
+    #[inline]
+    pub fn new(pos: usize) -> Result<BitPos> {
+        Ok(BitPos(pos))
+    }
 
-	/// Converts this `BitPos` into its associated `BitPos` that is usable to operate
-	/// on `Digit` instances.
-	#[inline]
-	pub(crate) fn to_pos_within_digit(self) -> BitPos {
-		BitPos(self.0 % digit::BITS)
-	}
+    /// Converts this `BitPos` into its associated `BitPos` that is usable to operate
+    /// on `Digit` instances.
+    #[inline]
+    pub(crate) fn to_pos_within_digit(self) -> BitPos {
+        BitPos(self.0 % digit::BITS)
+    }
 
-	/// Splits this `BitPos` that may range over several `Digit`s within an `ApInt`
-	/// into the associated `Digit` offset and its `Digit`-relative bit position.
-	#[inline]
-	pub(crate) fn to_digit_and_bit_pos(self) -> (DigitPos, BitPos) {
-		let digit_pos = DigitPos::from(self.0 / digit::BITS);
-		let bit_pos = BitPos::from(self.0 % digit::BITS);
-		(digit_pos, bit_pos)
-	}
+    /// Splits this `BitPos` that may range over several `Digit`s within an `ApInt`
+    /// into the associated `Digit` offset and its `Digit`-relative bit position.
+    #[inline]
+    pub(crate) fn to_digit_and_bit_pos(self) -> (DigitPos, BitPos) {
+        let digit_pos = DigitPos::from(self.0 / digit::BITS);
+        let bit_pos = BitPos::from(self.0 % digit::BITS);
+        (digit_pos, bit_pos)
+    }
 }
 
 impl From<usize> for BitPos {
-	#[inline]
-	fn from(pos: usize) -> BitPos {
-		BitPos(pos)
-	}
+    #[inline]
+    fn from(pos: usize) -> BitPos {
+        BitPos(pos)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	mod to_digit_and_bit_pos {
-		use super::*;
+    mod to_digit_and_bit_pos {
+        use super::*;
 
-		#[test]
-		fn powers_of_two() {
-			assert_eq!(
-				BitPos::new(64).unwrap().to_digit_and_bit_pos(),
-				(1, BitPos::new(0).unwrap())
-			);
-			assert_eq!(
-				BitPos::new(256).unwrap().to_digit_and_bit_pos(),
-				(4, BitPos::new(0).unwrap())
-			)
-		}
+        #[test]
+        fn powers_of_two() {
+            assert_eq!(
+                BitPos::new(64).unwrap().to_digit_and_bit_pos(),
+                (1, BitPos::new(0).unwrap())
+            );
+            assert_eq!(
+                BitPos::new(256).unwrap().to_digit_and_bit_pos(),
+                (4, BitPos::new(0).unwrap())
+            )
+        }
 
-		#[test]
-		fn zero() {
-			assert_eq!(
-				BitPos::new(0).unwrap().to_digit_and_bit_pos(),
-				(0, BitPos::new(0).unwrap())
-			)
-		}
+        #[test]
+        fn zero() {
+            assert_eq!(
+                BitPos::new(0).unwrap().to_digit_and_bit_pos(),
+                (0, BitPos::new(0).unwrap())
+            )
+        }
 
-		#[test]
-		fn odds() {
-			assert_eq!(
-				BitPos::new(1).unwrap().to_digit_and_bit_pos(),
-				(0, BitPos::new(1).unwrap())
-			);
-			assert_eq!(
-				BitPos::new(63).unwrap().to_digit_and_bit_pos(),
-				(0, BitPos::new(63).unwrap())
-			);
-			assert_eq!(
-				BitPos::new(255).unwrap().to_digit_and_bit_pos(),
-				(3, BitPos::new(63).unwrap())
-			)
-		}
-	}
+        #[test]
+        fn odds() {
+            assert_eq!(
+                BitPos::new(1).unwrap().to_digit_and_bit_pos(),
+                (0, BitPos::new(1).unwrap())
+            );
+            assert_eq!(
+                BitPos::new(63).unwrap().to_digit_and_bit_pos(),
+                (0, BitPos::new(63).unwrap())
+            );
+            assert_eq!(
+                BitPos::new(255).unwrap().to_digit_and_bit_pos(),
+                (3, BitPos::new(63).unwrap())
+            )
+        }
+    }
 }

--- a/src/bitwidth.rs
+++ b/src/bitwidth.rs
@@ -15,153 +15,153 @@ pub struct BitWidth(usize);
 ///  Constructors
 /// ===========================================================================
 impl BitWidth {
-	/// Creates a `BitWidth` that represents a bit-width of `1` bit.
-	#[inline]
-	pub fn w1() -> Self { BitWidth(1) }
+    /// Creates a `BitWidth` that represents a bit-width of `1` bit.
+    #[inline]
+    pub fn w1() -> Self { BitWidth(1) }
 
-	/// Creates a `BitWidth` that represents a bit-width of `8` bits.
-	#[inline]
-	pub fn w8() -> Self { BitWidth(8) }
+    /// Creates a `BitWidth` that represents a bit-width of `8` bits.
+    #[inline]
+    pub fn w8() -> Self { BitWidth(8) }
 
-	/// Creates a `BitWidth` that represents a bit-width of `16` bits.
-	#[inline]
-	pub fn w16() -> Self { BitWidth(16) }
+    /// Creates a `BitWidth` that represents a bit-width of `16` bits.
+    #[inline]
+    pub fn w16() -> Self { BitWidth(16) }
 
-	/// Creates a `BitWidth` that represents a bit-width of `32` bits.
-	#[inline]
-	pub fn w32() -> Self { BitWidth(32) }
+    /// Creates a `BitWidth` that represents a bit-width of `32` bits.
+    #[inline]
+    pub fn w32() -> Self { BitWidth(32) }
 
-	/// Creates a `BitWidth` that represents a bit-width of `64` bits.
-	#[inline]
-	pub fn w64() -> Self { BitWidth(64) }
+    /// Creates a `BitWidth` that represents a bit-width of `64` bits.
+    #[inline]
+    pub fn w64() -> Self { BitWidth(64) }
 
-	/// Creates a `BitWidth` that represents a bit-width of `128` bits.
-	#[inline]
-	pub fn w128() -> Self { BitWidth(128) }
+    /// Creates a `BitWidth` that represents a bit-width of `128` bits.
+    #[inline]
+    pub fn w128() -> Self { BitWidth(128) }
 
-	/// Creates a `BitWidth` from the given `usize`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `width` is equal to zero.
-	pub fn new(width: usize) -> Result<Self> {
-		if width == 0 {
-			return Err(Error::invalid_zero_bitwidth())
-		}
-		Ok(BitWidth(width))
-	}
+    /// Creates a `BitWidth` from the given `usize`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `width` is equal to zero.
+    pub fn new(width: usize) -> Result<Self> {
+        if width == 0 {
+            return Err(Error::invalid_zero_bitwidth())
+        }
+        Ok(BitWidth(width))
+    }
 
-	/// Returns `true` if the given `BitPos` is valid for this `BitWidth`.
-	#[inline]
-	pub(crate) fn is_valid_pos<P>(self, pos: P) -> bool
-		where P: Into<BitPos>
-	{
-		pos.into().to_usize() < self.0
-	}
+    /// Returns `true` if the given `BitPos` is valid for this `BitWidth`.
+    #[inline]
+    pub(crate) fn is_valid_pos<P>(self, pos: P) -> bool
+        where P: Into<BitPos>
+    {
+        pos.into().to_usize() < self.0
+    }
 
-	/// Returns `true` if the given `ShiftAmount` is valid for this `BitWidth`.
-	#[inline]
-	pub(crate) fn is_valid_shift_amount<S>(self, shift_amount: S) -> bool
-		where S: Into<ShiftAmount>
-	{
-		shift_amount.into().to_usize() < self.0
-	}
+    /// Returns `true` if the given `ShiftAmount` is valid for this `BitWidth`.
+    #[inline]
+    pub(crate) fn is_valid_shift_amount<S>(self, shift_amount: S) -> bool
+        where S: Into<ShiftAmount>
+    {
+        shift_amount.into().to_usize() < self.0
+    }
 
-	/// Returns the `BitPos` for the sign bit of an `ApInt` with this `BitWidth`.
-	#[inline]
-	pub(crate) fn sign_bit_pos(self) -> BitPos {
-		BitPos::from(self.to_usize() - 1)
-	}
+    /// Returns the `BitPos` for the sign bit of an `ApInt` with this `BitWidth`.
+    #[inline]
+    pub(crate) fn sign_bit_pos(self) -> BitPos {
+        BitPos::from(self.to_usize() - 1)
+    }
 }
 
 impl From<usize> for BitWidth {
-	fn from(width: usize) -> BitWidth {
-		BitWidth::new(width).unwrap()
-	}
+    fn from(width: usize) -> BitWidth {
+        BitWidth::new(width).unwrap()
+    }
 }
 
 //  ===========================================================================
 ///  API
 /// ===========================================================================
 impl BitWidth {
-	/// Converts this `BitWidth` into a `usize`.
-	#[inline]
-	pub fn to_usize(self) -> usize {
-		self.0
-	}
+    /// Converts this `BitWidth` into a `usize`.
+    #[inline]
+    pub fn to_usize(self) -> usize {
+        self.0
+    }
 
-	/// Returns the number of exceeding bits that is implied for `ApInt`
-	/// instances with this `BitWidth`.
-	/// 
-	/// For example for an `ApInt` with a `BitWidth` of `140` bits requires
-	/// exactly `3` digits (each with its `64` bits). The third however,
-	/// only requires `140 - 128 = 12` bits of its `64` bits in total to
-	/// represent the `ApInt` instance. So `excess_bits` returns `12` for
-	/// a `BitWidth` that is equal to `140`.
-	/// 
-	/// *Note:* A better name for this method has yet to be found!
-	pub(crate) fn excess_bits(self) -> Option<usize> {
-		match self.to_usize() % digit::BITS {
-			0 => None,
-			n => Some(n)
-		}
-	}
+    /// Returns the number of exceeding bits that is implied for `ApInt`
+    /// instances with this `BitWidth`.
+    /// 
+    /// For example for an `ApInt` with a `BitWidth` of `140` bits requires
+    /// exactly `3` digits (each with its `64` bits). The third however,
+    /// only requires `140 - 128 = 12` bits of its `64` bits in total to
+    /// represent the `ApInt` instance. So `excess_bits` returns `12` for
+    /// a `BitWidth` that is equal to `140`.
+    /// 
+    /// *Note:* A better name for this method has yet to be found!
+    pub(crate) fn excess_bits(self) -> Option<usize> {
+        match self.to_usize() % digit::BITS {
+            0 => None,
+            n => Some(n)
+        }
+    }
 
-	/// Returns the exceeding `BitWidth` of this `BitWidth`.
-	/// 
-	/// *Note:* This is just a simple wrapper around the `excess_bits` method.
-	///         Read the documentation of `excess_bits` for more information 
-	///         about what is actually returned by this.
-	pub(crate) fn excess_width(self) -> Option<BitWidth> {
-		self.excess_bits().map(BitWidth::from)
-	}
+    /// Returns the exceeding `BitWidth` of this `BitWidth`.
+    /// 
+    /// *Note:* This is just a simple wrapper around the `excess_bits` method.
+    ///         Read the documentation of `excess_bits` for more information 
+    ///         about what is actually returned by this.
+    pub(crate) fn excess_width(self) -> Option<BitWidth> {
+        self.excess_bits().map(BitWidth::from)
+    }
 
-	/// Returns a storage specifier that tells the caller if `ApInt`'s 
-	/// associated with this bitwidth require an external memory (`Ext`) to store 
-	/// their digits or may use inplace memory (`Inl`).
-	/// 
-	/// *Note:* Maybe this method should be removed. A constructor for
-	///         `Storage` fits better for this purpose.
-	#[inline]
-	pub(crate) fn storage(self) -> Storage {
-		Storage::from(self)
-	}
+    /// Returns a storage specifier that tells the caller if `ApInt`'s 
+    /// associated with this bitwidth require an external memory (`Ext`) to store 
+    /// their digits or may use inplace memory (`Inl`).
+    /// 
+    /// *Note:* Maybe this method should be removed. A constructor for
+    ///         `Storage` fits better for this purpose.
+    #[inline]
+    pub(crate) fn storage(self) -> Storage {
+        Storage::from(self)
+    }
 
-	/// Returns the number of digits that are required to represent an
-	/// `ApInt` with this `BitWidth`.
-	/// 
-	/// *Note:* Maybe we should move this method somewhere else?
-	#[inline]
-	pub(crate) fn required_digits(&self) -> usize {
-		((self.to_usize() - 1) / digit::BITS) + 1
-	}
+    /// Returns the number of digits that are required to represent an
+    /// `ApInt` with this `BitWidth`.
+    /// 
+    /// *Note:* Maybe we should move this method somewhere else?
+    #[inline]
+    pub(crate) fn required_digits(&self) -> usize {
+        ((self.to_usize() - 1) / digit::BITS) + 1
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	mod excess_bits {
-		use super::*;
+    mod excess_bits {
+        use super::*;
 
-		#[test]
-		fn powers_of_two() {
-			assert_eq!(BitWidth::w1().excess_bits(), Some(1));
-			assert_eq!(BitWidth::w8().excess_bits(), Some(8));
-			assert_eq!(BitWidth::w16().excess_bits(), Some(16));
-			assert_eq!(BitWidth::w32().excess_bits(), Some(32));
-			assert_eq!(BitWidth::w64().excess_bits(), None);
-			assert_eq!(BitWidth::w128().excess_bits(), None);
-		}
+        #[test]
+        fn powers_of_two() {
+            assert_eq!(BitWidth::w1().excess_bits(), Some(1));
+            assert_eq!(BitWidth::w8().excess_bits(), Some(8));
+            assert_eq!(BitWidth::w16().excess_bits(), Some(16));
+            assert_eq!(BitWidth::w32().excess_bits(), Some(32));
+            assert_eq!(BitWidth::w64().excess_bits(), None);
+            assert_eq!(BitWidth::w128().excess_bits(), None);
+        }
 
-		#[test]
-		fn multiples_of_50() {
-			assert_eq!(BitWidth::new(50).unwrap().excess_bits(), Some(50));
-			assert_eq!(BitWidth::new(100).unwrap().excess_bits(), Some(36));
-			assert_eq!(BitWidth::new(150).unwrap().excess_bits(), Some(22));
-			assert_eq!(BitWidth::new(200).unwrap().excess_bits(), Some(8));
-			assert_eq!(BitWidth::new(250).unwrap().excess_bits(), Some(58));
-			assert_eq!(BitWidth::new(300).unwrap().excess_bits(), Some(44));
-		}
-	}
+        #[test]
+        fn multiples_of_50() {
+            assert_eq!(BitWidth::new(50).unwrap().excess_bits(), Some(50));
+            assert_eq!(BitWidth::new(100).unwrap().excess_bits(), Some(36));
+            assert_eq!(BitWidth::new(150).unwrap().excess_bits(), Some(22));
+            assert_eq!(BitWidth::new(200).unwrap().excess_bits(), Some(8));
+            assert_eq!(BitWidth::new(250).unwrap().excess_bits(), Some(58));
+            assert_eq!(BitWidth::new(300).unwrap().excess_bits(), Some(44));
+        }
+    }
 }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -5,26 +5,26 @@ use apint::{ShiftAmount};
 
 #[inline]
 pub(crate) fn verify_bit_access<T, P>(a: &T, pos: P) -> Result<()>
-	where T: Width,
-	      P: Into<BitPos>
+    where T: Width,
+          P: Into<BitPos>
 {
-	let pos = pos.into();
-	let width = a.width();
-	if !width.is_valid_pos(pos) {
-		return Err(Error::invalid_bit_access(pos, width))
-	}
-	Ok(())
+    let pos = pos.into();
+    let width = a.width();
+    if !width.is_valid_pos(pos) {
+        return Err(Error::invalid_bit_access(pos, width))
+    }
+    Ok(())
 }
 
 #[inline]
 pub(crate) fn verify_shift_amount<W, S>(a: &W, shift_amount: S) -> Result<()>
-	where W: Width,
-	      S: Into<ShiftAmount>
+    where W: Width,
+          S: Into<ShiftAmount>
 {
-	let shift_amount = shift_amount.into();
-	let width = a.width();
-	if !width.is_valid_shift_amount(shift_amount) {
-		return Err(Error::invalid_shift_amount(shift_amount, width))
-	}
-	Ok(())
+    let shift_amount = shift_amount.into();
+    let width = a.width();
+    if !width.is_valid_shift_amount(shift_amount) {
+        return Err(Error::invalid_shift_amount(shift_amount, width))
+    }
+    Ok(())
 }

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -5,19 +5,19 @@ use traits::{Width};
 use checks;
 
 use std::ops::{
-	Not,
-	BitAnd,
-	BitOr,
-	BitXor,
-	BitAndAssign,
-	BitOrAssign,
-	BitXorAssign,
+    Not,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitAndAssign,
+    BitOrAssign,
+    BitXorAssign,
 
-	Add,
-	Sub,
-	Mul,
-	Div,
-	Rem
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem
 };
 
 /// The type for the internal `Digit` representation.
@@ -49,38 +49,38 @@ pub(crate) const ONES: Digit = Digit(REPR_ONES);
 /// Represents the set or unset state of a bit within an `ApInt`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Bit {
-	/// Unset, or `false` or `off` state.
-	Unset = 0,
-	/// Set, or `true` or `on` state.
-	Set = 1
+    /// Unset, or `false` or `off` state.
+    Unset = 0,
+    /// Set, or `true` or `on` state.
+    Set = 1
 }
 
 impl Bit {
-	/// Converts this `Bit` into a `bool`.
-	/// 
-	/// - `Unset` to `false`
-	/// - `Set` to `true`
-	#[inline]
-	pub fn to_bool(self) -> bool {
-		match self {
-			Bit::Unset => false,
-			Bit::Set   => true
-		}
-	}
+    /// Converts this `Bit` into a `bool`.
+    /// 
+    /// - `Unset` to `false`
+    /// - `Set` to `true`
+    #[inline]
+    pub fn to_bool(self) -> bool {
+        match self {
+            Bit::Unset => false,
+            Bit::Set   => true
+        }
+    }
 }
 
 impl From<bool> for Bit {
-	#[inline]
-	fn from(flag: bool) -> Bit {
-		if flag { Bit::Set } else { Bit::Unset }
-	}
+    #[inline]
+    fn from(flag: bool) -> Bit {
+        if flag { Bit::Set } else { Bit::Unset }
+    }
 }
 
 impl From<Bit> for bool {
-	#[inline]
-	fn from(bit: Bit) -> bool {
-		bit.to_bool()
-	}
+    #[inline]
+    fn from(bit: Bit) -> bool {
+        bit.to_bool()
+    }
 }
 
 /// A (big) digit within an `ApInt` or similar representations.
@@ -92,27 +92,27 @@ pub(crate) struct Digit(pub DigitRepr);
 use std::fmt;
 
 impl fmt::Binary for Digit {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.repr().fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.repr().fmt(f)
+    }
 }
 
 impl fmt::Octal for Digit {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.repr().fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.repr().fmt(f)
+    }
 }
 
 impl fmt::LowerHex for Digit {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.repr().fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.repr().fmt(f)
+    }
 }
 
 impl fmt::UpperHex for Digit {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.repr().fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.repr().fmt(f)
+    }
 }
 
 /// A doubled digit.
@@ -125,744 +125,744 @@ impl fmt::UpperHex for Digit {
 pub(crate) struct DoubleDigit(pub DoubleDigitRepr);
 
 impl Add for DoubleDigit {
-	type Output = DoubleDigit;
+    type Output = DoubleDigit;
 
-	fn add(self, rhs: DoubleDigit) -> Self::Output {
-		DoubleDigit(self.repr().wrapping_add(rhs.repr()))
-	}
+    fn add(self, rhs: DoubleDigit) -> Self::Output {
+        DoubleDigit(self.repr().wrapping_add(rhs.repr()))
+    }
 }
 
 impl Sub for DoubleDigit {
-	type Output = DoubleDigit;
+    type Output = DoubleDigit;
 
-	fn sub(self, rhs: DoubleDigit) -> Self::Output {
-		DoubleDigit(self.repr().wrapping_sub(rhs.repr()))
-	}
+    fn sub(self, rhs: DoubleDigit) -> Self::Output {
+        DoubleDigit(self.repr().wrapping_sub(rhs.repr()))
+    }
 }
 
 impl Mul for DoubleDigit {
-	type Output = DoubleDigit;
+    type Output = DoubleDigit;
 
-	fn mul(self, rhs: DoubleDigit) -> Self::Output {
-		DoubleDigit(self.repr().wrapping_mul(rhs.repr()))
-	}
+    fn mul(self, rhs: DoubleDigit) -> Self::Output {
+        DoubleDigit(self.repr().wrapping_mul(rhs.repr()))
+    }
 }
 
 impl Div for DoubleDigit {
-	type Output = DoubleDigit;
+    type Output = DoubleDigit;
 
-	fn div(self, rhs: DoubleDigit) -> Self::Output {
-		DoubleDigit(self.repr().wrapping_div(rhs.repr()))
-	}
+    fn div(self, rhs: DoubleDigit) -> Self::Output {
+        DoubleDigit(self.repr().wrapping_div(rhs.repr()))
+    }
 }
 
 impl Rem for DoubleDigit {
-	type Output = DoubleDigit;
+    type Output = DoubleDigit;
 
-	fn rem(self, rhs: DoubleDigit) -> Self::Output {
-		DoubleDigit(self.repr().wrapping_rem(rhs.repr()))
-	}
+    fn rem(self, rhs: DoubleDigit) -> Self::Output {
+        DoubleDigit(self.repr().wrapping_rem(rhs.repr()))
+    }
 }
 
 impl DoubleDigit {
-	/// Returns the value as its internal representation.
-	#[inline]
-	pub(crate) fn repr(self) -> DoubleDigitRepr {
-		self.0
-	}
+    /// Returns the value as its internal representation.
+    #[inline]
+    pub(crate) fn repr(self) -> DoubleDigitRepr {
+        self.0
+    }
 
-	/// Returns the hi part of this `DoubleDigit` as `Digit`.
-	#[inline]
-	pub(crate) fn hi(self) -> Digit {
-		Digit((self.0 >> BITS) as DigitRepr)
-	}
+    /// Returns the hi part of this `DoubleDigit` as `Digit`.
+    #[inline]
+    pub(crate) fn hi(self) -> Digit {
+        Digit((self.0 >> BITS) as DigitRepr)
+    }
 
-	/// Returns the hi part of this `DoubleDigit` as `Digit`.
-	#[inline]
-	pub(crate) fn lo(self) -> Digit {
-		Digit(self.0 as DigitRepr)
-	}
+    /// Returns the hi part of this `DoubleDigit` as `Digit`.
+    #[inline]
+    pub(crate) fn lo(self) -> Digit {
+        Digit(self.0 as DigitRepr)
+    }
 
-	/// Returns the hi and lo parts of this `DoubleDigit` as `Digit` each.
-	#[inline]
-	pub(crate) fn hi_lo(self) -> (Digit, Digit) {
-		(self.hi(), self.lo())
-	}
+    /// Returns the hi and lo parts of this `DoubleDigit` as `Digit` each.
+    #[inline]
+    pub(crate) fn hi_lo(self) -> (Digit, Digit) {
+        (self.hi(), self.lo())
+    }
 
-	/// Returns a `DoubleDigit` from the given hi and lo raw `Digit` parts.
-	#[inline]
-	pub(crate) fn from_hi_lo(hi: Digit, lo: Digit) -> DoubleDigit {
-		DoubleDigit((DoubleDigitRepr::from(hi.repr()) << BITS) | DoubleDigitRepr::from(lo.repr()))
-	}
+    /// Returns a `DoubleDigit` from the given hi and lo raw `Digit` parts.
+    #[inline]
+    pub(crate) fn from_hi_lo(hi: Digit, lo: Digit) -> DoubleDigit {
+        DoubleDigit((DoubleDigitRepr::from(hi.repr()) << BITS) | DoubleDigitRepr::from(lo.repr()))
+    }
 
-	#[inline]
-	pub(crate) fn wrapping_add(self, other: DoubleDigit) -> Self {
-		DoubleDigit(self.repr().wrapping_add(other.repr()))
-	}
+    #[inline]
+    pub(crate) fn wrapping_add(self, other: DoubleDigit) -> Self {
+        DoubleDigit(self.repr().wrapping_add(other.repr()))
+    }
 
-	#[inline]
-	pub(crate) fn wrapping_mul(self, other: DoubleDigit) -> Self {
-		DoubleDigit(self.repr().wrapping_mul(other.repr()))
-	}
+    #[inline]
+    pub(crate) fn wrapping_mul(self, other: DoubleDigit) -> Self {
+        DoubleDigit(self.repr().wrapping_mul(other.repr()))
+    }
 }
 
 /// # Constructors
 impl Digit {
-	/// Creates a digit that represents the value `0`.
-	/// 
-	/// **Note:** In twos-complement this means that all bits are `0`.
-	#[inline]
-	pub fn zero() -> Digit { ZERO }
+    /// Creates a digit that represents the value `0`.
+    /// 
+    /// **Note:** In twos-complement this means that all bits are `0`.
+    #[inline]
+    pub fn zero() -> Digit { ZERO }
 
-	/// Creates a digit that represents the value `1`.
-	#[inline]
-	pub fn one() -> Digit { ONE	}
+    /// Creates a digit that represents the value `1`.
+    #[inline]
+    pub fn one() -> Digit { ONE	}
 
-	/// Returns `true` if this `Digit` is zero (`0`).
-	#[inline]
-	pub fn is_zero(self) -> bool { self == ZERO }
+    /// Returns `true` if this `Digit` is zero (`0`).
+    #[inline]
+    pub fn is_zero(self) -> bool { self == ZERO }
 
-	/// Returns `true` if this `Digit` is one (`1`).
-	#[inline]
-	pub fn is_one(self) -> bool { self == ONE }
+    /// Returns `true` if this `Digit` is one (`1`).
+    #[inline]
+    pub fn is_one(self) -> bool { self == ONE }
 
-	/// Returns `true` if this `Digit` has all bits set.
-	#[inline]
-	pub fn is_all_set(self) -> bool { self == ONES }
+    /// Returns `true` if this `Digit` has all bits set.
+    #[inline]
+    pub fn is_all_set(self) -> bool { self == ONES }
 
-	/// Creates a digit where all bits are initialized to `1`.
-	#[inline]
-	pub fn all_set() -> Digit { ONES }
+    /// Creates a digit where all bits are initialized to `1`.
+    #[inline]
+    pub fn all_set() -> Digit { ONES }
 }
 
 /// # Utility & helper methods.
 impl Digit {
-	/// Returns the `Digit`'s value as internal representation.
-	#[inline]
-	pub fn repr(self) -> DigitRepr {
-		self.0
-	}
+    /// Returns the `Digit`'s value as internal representation.
+    #[inline]
+    pub fn repr(self) -> DigitRepr {
+        self.0
+    }
 
-	/// Returns a mutable reference to the underlying representation
-	/// of this `Digit`.
-	#[inline]
-	pub fn repr_mut(&mut self) -> &mut DigitRepr {
-		&mut self.0
-	}
+    /// Returns a mutable reference to the underlying representation
+    /// of this `Digit`.
+    #[inline]
+    pub fn repr_mut(&mut self) -> &mut DigitRepr {
+        &mut self.0
+    }
 
-	/// Returns the `DoubleDigit` representation of this `Digit`.
-	#[inline]
-	pub(crate) fn dd(self) -> DoubleDigit {
-		DoubleDigit(DoubleDigitRepr::from(self.repr()))
-	}
+    /// Returns the `DoubleDigit` representation of this `Digit`.
+    #[inline]
+    pub(crate) fn dd(self) -> DoubleDigit {
+        DoubleDigit(DoubleDigitRepr::from(self.repr()))
+    }
 
-	#[inline]
-	pub(crate) fn wrapping_add(self, other: Digit) -> Self {
-		Digit(self.repr().wrapping_add(other.repr()))
-	}
+    #[inline]
+    pub(crate) fn wrapping_add(self, other: Digit) -> Self {
+        Digit(self.repr().wrapping_add(other.repr()))
+    }
 
-	#[inline]
-	pub(crate) fn wrapping_mul(self, other: Digit) -> Self {
-		Digit(self.repr().wrapping_mul(other.repr()))
-	}
+    #[inline]
+    pub(crate) fn wrapping_mul(self, other: Digit) -> Self {
+        Digit(self.repr().wrapping_mul(other.repr()))
+    }
 
-	#[inline]
-	pub(crate) fn wrapping_mul_add(self, mul: Digit, add: Digit) -> Digit {
-		Digit(
-			self.repr()
-				.wrapping_mul(mul.repr())
-				.wrapping_add(add.repr()),
-		)
-	}
+    #[inline]
+    pub(crate) fn wrapping_mul_add(self, mul: Digit, add: Digit) -> Digit {
+        Digit(
+            self.repr()
+                .wrapping_mul(mul.repr())
+                .wrapping_add(add.repr()),
+        )
+    }
 
-	#[inline]
-	pub(crate) fn carrying_add(self, other: Digit) -> (Digit, Digit) {
-		//this is to make sure that the assembly compiles down to the `adc` function
-		match self.repr().overflowing_add(other.repr()) {
-			(x,false) => (Digit(x),Digit::zero()),
-			(x,true) => (Digit(x),Digit::one()),
-		}
-	}
+    #[inline]
+    pub(crate) fn carrying_add(self, other: Digit) -> (Digit, Digit) {
+        //this is to make sure that the assembly compiles down to the `adc` function
+        match self.repr().overflowing_add(other.repr()) {
+            (x,false) => (Digit(x),Digit::zero()),
+            (x,true) => (Digit(x),Digit::one()),
+        }
+    }
 
-	//TODO if and when `carrying_mul` (rust-lang rfc #2417) is stabilized, this function and others in this crate should use `carrying_mul` as the operation
-	#[inline]
-	pub(crate) fn carrying_mul(self, other: Digit) -> (Digit, Digit) {
-		let temp = self.dd().wrapping_mul(other.dd());
-		(temp.lo(), temp.hi())
-	}
+    //TODO if and when `carrying_mul` (rust-lang rfc #2417) is stabilized, this function and others in this crate should use `carrying_mul` as the operation
+    #[inline]
+    pub(crate) fn carrying_mul(self, other: Digit) -> (Digit, Digit) {
+        let temp = self.dd().wrapping_mul(other.dd());
+        (temp.lo(), temp.hi())
+    }
 
-	#[inline]
-	pub(crate) fn carrying_mul_add(self, mul: Digit, add: Digit) -> (Digit, Digit) {
-		let temp = self.dd().wrapping_mul(mul.dd()).wrapping_add(add.dd());
-		(temp.lo(), temp.hi())
-	}
+    #[inline]
+    pub(crate) fn carrying_mul_add(self, mul: Digit, add: Digit) -> (Digit, Digit) {
+        let temp = self.dd().wrapping_mul(mul.dd()).wrapping_add(add.dd());
+        (temp.lo(), temp.hi())
+    }
 }
 
 impl Digit {
-	/// Validates the given `BitWidth` for `Digit` instances and returns
-	/// an appropriate error if the given `BitWidth` is invalid.
-	fn verify_valid_bitwidth<W>(self, width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		let width = width.into();
-		if width.to_usize() > BITS {
-			return Err(Error::invalid_bitwidth(width.to_usize())
-				.with_annotation(format!("Encountered invalid `BitWidth` for operating \
-										  on a `Digit`.")))
-		}
-		Ok(())
-	}
+    /// Validates the given `BitWidth` for `Digit` instances and returns
+    /// an appropriate error if the given `BitWidth` is invalid.
+    fn verify_valid_bitwidth<W>(self, width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        let width = width.into();
+        if width.to_usize() > BITS {
+            return Err(Error::invalid_bitwidth(width.to_usize())
+                .with_annotation(format!("Encountered invalid `BitWidth` for operating \
+                                          on a `Digit`.")))
+        }
+        Ok(())
+    }
 
-	/// Truncates this `Digit` to the given `BitWidth`.
-	/// 
-	/// This operation just zeros out any bits on this `Digit` 
-	/// with bit positions above the given `BitWidth`.
-	/// 
-	/// # Note
-	/// 
-	/// This is equal to calling `Digit::retain_last_n`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `BitWidth` is invalid for `Digit` instances.
-	pub(crate) fn truncate_to<W>(&mut self, to: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		let to = to.into();
-		self.verify_valid_bitwidth(to)?;
-		self.0 &= !(REPR_ONES << to.to_usize());
-		Ok(())
-	}
+    /// Truncates this `Digit` to the given `BitWidth`.
+    /// 
+    /// This operation just zeros out any bits on this `Digit` 
+    /// with bit positions above the given `BitWidth`.
+    /// 
+    /// # Note
+    /// 
+    /// This is equal to calling `Digit::retain_last_n`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `BitWidth` is invalid for `Digit` instances.
+    pub(crate) fn truncate_to<W>(&mut self, to: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        let to = to.into();
+        self.verify_valid_bitwidth(to)?;
+        self.0 &= !(REPR_ONES << to.to_usize());
+        Ok(())
+    }
 
-	/// Sign extends this `Digit` from a given `BitWidth` to `64` bits.
-	/// 
-	/// # Note
-	/// 
-	/// - This can be truncated again to a real target `BitWidth` afterwards if
-	///   the users wishes to.
-	/// 
-	/// - Implementation inspired by
-	///   [Bit Twiddling Hacks](https://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `BitWidth` is invalid for `Digit` instances.
-	pub(crate) fn sign_extend_from<W>(&mut self, from: W) -> Result<()>
-		where W: Into<BitWidth>,
-	{
-		let from = from.into();
-		self.verify_valid_bitwidth(from)?;
+    /// Sign extends this `Digit` from a given `BitWidth` to `64` bits.
+    /// 
+    /// # Note
+    /// 
+    /// - This can be truncated again to a real target `BitWidth` afterwards if
+    ///   the users wishes to.
+    /// 
+    /// - Implementation inspired by
+    ///   [Bit Twiddling Hacks](https://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `BitWidth` is invalid for `Digit` instances.
+    pub(crate) fn sign_extend_from<W>(&mut self, from: W) -> Result<()>
+        where W: Into<BitWidth>,
+    {
+        let from = from.into();
+        self.verify_valid_bitwidth(from)?;
 
-		let b = from.to_usize();    // number of bits representing the number in x
-		let x = self.repr() as i64; // sign extend this b-bit number to r
-		let m: i64 = 1 << (b - 1);       // mask can be pre-computed if b is fixed
-		// x = x & ((1 << b) - 1);  // (Skip this if bits in x above position b are already zero.)
-									// We don't need this step since this condition is an invariant of `Digit`.
-		let r: i64 = (x ^ m).wrapping_sub(m);   // resulting sign-extended number
-		self.0 = r as u64;
-		Ok(())
-	}
+        let b = from.to_usize();    // number of bits representing the number in x
+        let x = self.repr() as i64; // sign extend this b-bit number to r
+        let m: i64 = 1 << (b - 1);       // mask can be pre-computed if b is fixed
+        // x = x & ((1 << b) - 1);  // (Skip this if bits in x above position b are already zero.)
+                                    // We don't need this step since this condition is an invariant of `Digit`.
+        let r: i64 = (x ^ m).wrapping_sub(m);   // resulting sign-extended number
+        self.0 = r as u64;
+        Ok(())
+    }
 }
 
 impl Width for Digit {
-	#[inline]
-	fn width(&self) -> BitWidth {
-		BitWidth::w64()
-	}
+    #[inline]
+    fn width(&self) -> BitWidth {
+        BitWidth::w64()
+    }
 }
 
 impl Width for DoubleDigit {
-	#[inline]
-	fn width(&self) -> BitWidth {
-		BitWidth::w128()
-	}
+    #[inline]
+    fn width(&self) -> BitWidth {
+        BitWidth::w128()
+    }
 }
 
 /// # Bitwise access
 impl Digit {
-	/// Returns the least significant `Bit` of this `Digit`.
-	/// 
-	/// Note: This may be useful to determine if a `Digit`
-	///       represents an even or an uneven number for example.
-	#[inline]
-	pub fn least_significant_bit(self) -> Bit {
-		Bit::from((self.repr() & 0x1) != 0)
-	}
+    /// Returns the least significant `Bit` of this `Digit`.
+    /// 
+    /// Note: This may be useful to determine if a `Digit`
+    ///       represents an even or an uneven number for example.
+    #[inline]
+    pub fn least_significant_bit(self) -> Bit {
+        Bit::from((self.repr() & 0x1) != 0)
+    }
 
-	/// Returns `true` if the `n`th bit is set to `1`, else returns `false`.
-	/// 
-	/// # Errors
-	/// 
-	/// If the given `n` is greater than the digit size.
-	#[inline]
-	pub fn get<P>(self, pos: P) -> Result<Bit>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(&self, pos)?;
-		Ok(Bit::from(((self.repr() >> pos.to_usize()) & 0x01) == 1))
-	}
+    /// Returns `true` if the `n`th bit is set to `1`, else returns `false`.
+    /// 
+    /// # Errors
+    /// 
+    /// If the given `n` is greater than the digit size.
+    #[inline]
+    pub fn get<P>(self, pos: P) -> Result<Bit>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(&self, pos)?;
+        Ok(Bit::from(((self.repr() >> pos.to_usize()) & 0x01) == 1))
+    }
 
-	/// Sets the bit at position `pos` to `1`.
-	/// 
-	/// # Errors
-	/// 
-	/// If the given `n` is greater than the digit size.
-	#[inline]
-	pub fn set<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		Ok(self.0 |= 0x01 << pos.to_usize())
-	}
+    /// Sets the bit at position `pos` to `1`.
+    /// 
+    /// # Errors
+    /// 
+    /// If the given `n` is greater than the digit size.
+    #[inline]
+    pub fn set<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        Ok(self.0 |= 0x01 << pos.to_usize())
+    }
 
-	/// Sets the bit at position `pos` to `0`.
-	/// 
-	/// # Errors
-	/// 
-	/// If the given `n` is greater than the digit size.
-	#[inline]
-	pub fn unset<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		Ok(self.0 &= !(0x01 << pos.to_usize()))
-	}
+    /// Sets the bit at position `pos` to `0`.
+    /// 
+    /// # Errors
+    /// 
+    /// If the given `n` is greater than the digit size.
+    #[inline]
+    pub fn unset<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        Ok(self.0 &= !(0x01 << pos.to_usize()))
+    }
 
-	/// Flips the bit at position `pos`.
-	/// 
-	/// # Errors
-	/// 
-	/// If the given `n` is greater than the digit size.
-	#[inline]
-	pub fn flip<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		let pos = pos.into();
-		checks::verify_bit_access(self, pos)?;
-		Ok(self.0 ^= 0x01 << pos.to_usize())
-	}
+    /// Flips the bit at position `pos`.
+    /// 
+    /// # Errors
+    /// 
+    /// If the given `n` is greater than the digit size.
+    #[inline]
+    pub fn flip<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        let pos = pos.into();
+        checks::verify_bit_access(self, pos)?;
+        Ok(self.0 ^= 0x01 << pos.to_usize())
+    }
 
-	/// Sets all bits in this digit to `1`.
-	#[inline]
-	pub fn set_all(&mut self) {
-		self.0 |= REPR_ONES
-	}
+    /// Sets all bits in this digit to `1`.
+    #[inline]
+    pub fn set_all(&mut self) {
+        self.0 |= REPR_ONES
+    }
 
-	/// Sets all bits in this digit to `0`.
-	#[inline]
-	pub fn unset_all(&mut self) {
-		self.0 &= REPR_ZERO
-	}
+    /// Sets all bits in this digit to `0`.
+    #[inline]
+    pub fn unset_all(&mut self) {
+        self.0 &= REPR_ZERO
+    }
 
-	/// Flips all bits in this digit.
-	#[inline]
-	pub fn flip_all(&mut self) {
-		self.0 ^= REPR_ONES
-	}
+    /// Flips all bits in this digit.
+    #[inline]
+    pub fn flip_all(&mut self) {
+        self.0 ^= REPR_ONES
+    }
 
-	/// Unsets all bits but the last `n` ones.
-	/// 
-	/// # Note
-	/// 
-	/// This is equal to calling `Digit::truncate_to`.
-	/// 
-	/// # Errors
-	/// 
-	/// If the given `n` is greater than the digit size.
-	#[inline]
-	pub fn retain_last_n(&mut self, n: usize) -> Result<()> {
-		checks::verify_bit_access(self, n)?;
-		Ok(self.0 &= !(REPR_ONES << n))
-	}
+    /// Unsets all bits but the last `n` ones.
+    /// 
+    /// # Note
+    /// 
+    /// This is equal to calling `Digit::truncate_to`.
+    /// 
+    /// # Errors
+    /// 
+    /// If the given `n` is greater than the digit size.
+    #[inline]
+    pub fn retain_last_n(&mut self, n: usize) -> Result<()> {
+        checks::verify_bit_access(self, n)?;
+        Ok(self.0 &= !(REPR_ONES << n))
+    }
 }
 
 /// # Bitwise operations
 impl Not for Digit {
-	type Output = Self;
+    type Output = Self;
 
-	fn not(self) -> Self::Output {
-		Digit(!self.repr())
-	}
+    fn not(self) -> Self::Output {
+        Digit(!self.repr())
+    }
 }
 
 impl Digit {
-	pub fn not_inplace(&mut self) {
-		self.0 = !self.repr()
-	}
+    pub fn not_inplace(&mut self) {
+        self.0 = !self.repr()
+    }
 }
 
 impl BitAnd for Digit {
-	type Output = Self;
+    type Output = Self;
 
-	fn bitand(self, rhs: Self) -> Self::Output {
-		Digit(self.repr() & rhs.repr())
-	}
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Digit(self.repr() & rhs.repr())
+    }
 }
 
 impl BitOr for Digit {
-	type Output = Self;
+    type Output = Self;
 
-	fn bitor(self, rhs: Self) -> Self::Output {
-		Digit(self.repr() | rhs.repr())
-	}
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Digit(self.repr() | rhs.repr())
+    }
 }
 
 impl BitXor for Digit {
-	type Output = Self;
+    type Output = Self;
 
-	fn bitxor(self, rhs: Self) -> Self::Output {
-		Digit(self.repr() ^ rhs.repr())
-	}
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Digit(self.repr() ^ rhs.repr())
+    }
 }
 
 // # Bitwise assign operations
 impl BitAndAssign for Digit {
-	fn bitand_assign(&mut self, rhs: Self) {
-		self.0 &= rhs.repr()
-	}
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.repr()
+    }
 }
 
 impl BitOrAssign for Digit {
-	fn bitor_assign(&mut self, rhs: Self) {
-		self.0 |= rhs.repr()
-	}
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.repr()
+    }
 }
 
 impl BitXorAssign for Digit {
-	fn bitxor_assign(&mut self, rhs: Self) {
-		self.0 ^= rhs.repr()
-	}
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.0 ^= rhs.repr()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	mod bit {
-		use super::*;
+    mod bit {
+        use super::*;
 
-		#[test]
-		fn from_bool() {
-			assert_eq!(Bit::from(true) , Bit::Set);
-			assert_eq!(Bit::from(false), Bit::Unset);
-		}
+        #[test]
+        fn from_bool() {
+            assert_eq!(Bit::from(true) , Bit::Set);
+            assert_eq!(Bit::from(false), Bit::Unset);
+        }
 
-		#[test]
-		fn from_bit() {
-			assert_eq!(bool::from(Bit::Set)  , true);
-			assert_eq!(bool::from(Bit::Unset), false);
-		}
-	}
+        #[test]
+        fn from_bit() {
+            assert_eq!(bool::from(Bit::Set)  , true);
+            assert_eq!(bool::from(Bit::Unset), false);
+        }
+    }
 
-	mod double_digit {
-		use super::*;
+    mod double_digit {
+        use super::*;
 
-		static TEST_VALUES: &[DoubleDigitRepr] = &[0, 1, 2, 10, 42, 1337];
+        static TEST_VALUES: &[DoubleDigitRepr] = &[0, 1, 2, 10, 42, 1337];
 
-		#[test]
-		fn ops_add() {
-			fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
-				assert_eq!(
-					DoubleDigit(lhs) + DoubleDigit(rhs),
-					DoubleDigit(lhs.wrapping_add(rhs))
-				)
-			}
-			for &lhs in TEST_VALUES {
-				for &rhs in TEST_VALUES {
-					assert_for(lhs, rhs)
-				}
-			}
-		}
+        #[test]
+        fn ops_add() {
+            fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
+                assert_eq!(
+                    DoubleDigit(lhs) + DoubleDigit(rhs),
+                    DoubleDigit(lhs.wrapping_add(rhs))
+                )
+            }
+            for &lhs in TEST_VALUES {
+                for &rhs in TEST_VALUES {
+                    assert_for(lhs, rhs)
+                }
+            }
+        }
 
-		#[test]
-		fn ops_sub() {
-			fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
-				assert_eq!(
-					DoubleDigit(lhs) - DoubleDigit(rhs),
-					DoubleDigit(lhs.wrapping_sub(rhs))
-				)
-			}
-			for &lhs in TEST_VALUES {
-				for &rhs in TEST_VALUES {
-					assert_for(lhs, rhs)
-				}
-			}
-		}
+        #[test]
+        fn ops_sub() {
+            fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
+                assert_eq!(
+                    DoubleDigit(lhs) - DoubleDigit(rhs),
+                    DoubleDigit(lhs.wrapping_sub(rhs))
+                )
+            }
+            for &lhs in TEST_VALUES {
+                for &rhs in TEST_VALUES {
+                    assert_for(lhs, rhs)
+                }
+            }
+        }
 
-		#[test]
-		fn ops_mul() {
-			fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
-				assert_eq!(
-					DoubleDigit(lhs) * DoubleDigit(rhs),
-					DoubleDigit(lhs.wrapping_mul(rhs))
-				)
-			}
-			for &lhs in TEST_VALUES {
-				for &rhs in TEST_VALUES {
-					assert_for(lhs, rhs)
-				}
-			}
-		}
+        #[test]
+        fn ops_mul() {
+            fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
+                assert_eq!(
+                    DoubleDigit(lhs) * DoubleDigit(rhs),
+                    DoubleDigit(lhs.wrapping_mul(rhs))
+                )
+            }
+            for &lhs in TEST_VALUES {
+                for &rhs in TEST_VALUES {
+                    assert_for(lhs, rhs)
+                }
+            }
+        }
 
-		#[test]
-		fn ops_div() {
-			fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
-				assert_eq!(
-					DoubleDigit(lhs) / DoubleDigit(rhs),
-					DoubleDigit(lhs.wrapping_div(rhs))
-				)
-			}
-			for &lhs in TEST_VALUES {
-				for &rhs in TEST_VALUES {
-					// Avoid division by zero.
-					if rhs != 0 {
-						assert_for(lhs, rhs)
-					}
-				}
-			}
-		}
+        #[test]
+        fn ops_div() {
+            fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
+                assert_eq!(
+                    DoubleDigit(lhs) / DoubleDigit(rhs),
+                    DoubleDigit(lhs.wrapping_div(rhs))
+                )
+            }
+            for &lhs in TEST_VALUES {
+                for &rhs in TEST_VALUES {
+                    // Avoid division by zero.
+                    if rhs != 0 {
+                        assert_for(lhs, rhs)
+                    }
+                }
+            }
+        }
 
-		#[test]
-		fn ops_rem() {
-			fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
-				assert_eq!(
-					DoubleDigit(lhs) % DoubleDigit(rhs),
-					DoubleDigit(lhs.wrapping_rem(rhs))
-				)
-			}
-			for &lhs in TEST_VALUES {
-				for &rhs in TEST_VALUES {
-					// Avoid division by zero.
-					if rhs != 0 {
-						assert_for(lhs, rhs)
-					}
-				}
-			}
-		}
+        #[test]
+        fn ops_rem() {
+            fn assert_for(lhs: DoubleDigitRepr, rhs: DoubleDigitRepr) {
+                assert_eq!(
+                    DoubleDigit(lhs) % DoubleDigit(rhs),
+                    DoubleDigit(lhs.wrapping_rem(rhs))
+                )
+            }
+            for &lhs in TEST_VALUES {
+                for &rhs in TEST_VALUES {
+                    // Avoid division by zero.
+                    if rhs != 0 {
+                        assert_for(lhs, rhs)
+                    }
+                }
+            }
+        }
 
-		#[test]
-		fn width() {
-			for &val in TEST_VALUES {
-				assert_eq!(DoubleDigit(val).width(), BitWidth::w128());
-			}
-		}
+        #[test]
+        fn width() {
+            for &val in TEST_VALUES {
+                assert_eq!(DoubleDigit(val).width(), BitWidth::w128());
+            }
+        }
 
-		#[test]
-		fn repr() {
-			fn assert_for(val: DoubleDigitRepr) {
-				assert_eq!(DoubleDigit(val).repr(), val)
-			}
-			for &val in TEST_VALUES {
-				assert_for(val)
-			}
-		}
+        #[test]
+        fn repr() {
+            fn assert_for(val: DoubleDigitRepr) {
+                assert_eq!(DoubleDigit(val).repr(), val)
+            }
+            for &val in TEST_VALUES {
+                assert_for(val)
+            }
+        }
 
-		#[test]
-		fn hi() {
-			fn assert_for(input: DoubleDigitRepr, expected: DigitRepr) {
-				assert_eq!(DoubleDigit(input).hi(), Digit(expected))
-			}
-			let test_values = &[
-				(0,0),
-				(1,0),
-				(0x0000_0000_0000_0001_0000_0000_0000_0000, 1),
-				(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
-				(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, 0),
-				(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, 0xFFFF_FFFF),
-				(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF),
-				(0x0123_4567_8910_ABCD_EF00_0000_0000_0000, 0x0123_4567_8910_ABCD),
-				(0x0000_0000_0000_00FE_DCBA_0198_7654_3210, 0xFE)
-			];
-			for &(input, expected) in test_values {
-				assert_for(input, expected)
-			}
-		}
+        #[test]
+        fn hi() {
+            fn assert_for(input: DoubleDigitRepr, expected: DigitRepr) {
+                assert_eq!(DoubleDigit(input).hi(), Digit(expected))
+            }
+            let test_values = &[
+                (0,0),
+                (1,0),
+                (0x0000_0000_0000_0001_0000_0000_0000_0000, 1),
+                (0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+                (0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, 0),
+                (0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, 0xFFFF_FFFF),
+                (0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF),
+                (0x0123_4567_8910_ABCD_EF00_0000_0000_0000, 0x0123_4567_8910_ABCD),
+                (0x0000_0000_0000_00FE_DCBA_0198_7654_3210, 0xFE)
+            ];
+            for &(input, expected) in test_values {
+                assert_for(input, expected)
+            }
+        }
 
-		#[test]
-		fn lo() {
-			fn assert_for(input: DoubleDigitRepr, expected: DigitRepr) {
-				assert_eq!(DoubleDigit(input).lo(), Digit(expected))
-			}
-			let test_values = &[
-				(0,0),
-				(1,1),
-				(0x0000_0000_0000_0001_0000_0000_0000_0000, 0),
-				(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
-				(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
-				(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, 0xFFFF_FFFF_0000_0000),
-				(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, 0),
-				(0x0123_4567_8910_ABCD_EF00_0000_0000_0000, 0xEF00_0000_0000_0000),
-				(0x0000_0000_0000_00FE_DCBA_0198_7654_3210, 0xDCBA_0198_7654_3210)
-			];
-			for &(input, expected) in test_values {
-				assert_for(input, expected)
-			}
-		}
+        #[test]
+        fn lo() {
+            fn assert_for(input: DoubleDigitRepr, expected: DigitRepr) {
+                assert_eq!(DoubleDigit(input).lo(), Digit(expected))
+            }
+            let test_values = &[
+                (0,0),
+                (1,1),
+                (0x0000_0000_0000_0001_0000_0000_0000_0000, 0),
+                (0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+                (0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF),
+                (0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, 0xFFFF_FFFF_0000_0000),
+                (0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, 0),
+                (0x0123_4567_8910_ABCD_EF00_0000_0000_0000, 0xEF00_0000_0000_0000),
+                (0x0000_0000_0000_00FE_DCBA_0198_7654_3210, 0xDCBA_0198_7654_3210)
+            ];
+            for &(input, expected) in test_values {
+                assert_for(input, expected)
+            }
+        }
 
-		#[test]
-		fn hi_lo() {
-			fn assert_for(input: DoubleDigitRepr, expected_hi: DigitRepr, expected_lo: DigitRepr) {
-				assert_eq!(DoubleDigit(input).hi_lo(), (Digit(expected_hi), Digit(expected_lo)))
-			}
-			let test_values = &[
-				(0, (0, 0)),
-				(1, (0, 1)),
-				(0x0000_0000_0000_0001_0000_0000_0000_0000, (1, 0)),
-				(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)),
-				(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, (0, 0xFFFF_FFFF_FFFF_FFFF)),
-				(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, (0xFFFF_FFFF, 0xFFFF_FFFF_0000_0000)),
-				(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, (0xFFFF_FFFF_FFFF_FFFF, 0)),
-				(0x0123_4567_8910_ABCD_EF00_0000_0000_0000, (0x0123_4567_8910_ABCD, 0xEF00_0000_0000_0000)),
-				(0x0000_0000_0000_00FE_DCBA_0198_7654_3210, (0x0000_0000_0000_00FE, 0xDCBA_0198_7654_3210))
-			];
-			for &(input, (expected_hi, expected_lo)) in test_values {
-				assert_for(input, expected_hi, expected_lo)
-			}
-		}
+        #[test]
+        fn hi_lo() {
+            fn assert_for(input: DoubleDigitRepr, expected_hi: DigitRepr, expected_lo: DigitRepr) {
+                assert_eq!(DoubleDigit(input).hi_lo(), (Digit(expected_hi), Digit(expected_lo)))
+            }
+            let test_values = &[
+                (0, (0, 0)),
+                (1, (0, 1)),
+                (0x0000_0000_0000_0001_0000_0000_0000_0000, (1, 0)),
+                (0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)),
+                (0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, (0, 0xFFFF_FFFF_FFFF_FFFF)),
+                (0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, (0xFFFF_FFFF, 0xFFFF_FFFF_0000_0000)),
+                (0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, (0xFFFF_FFFF_FFFF_FFFF, 0)),
+                (0x0123_4567_8910_ABCD_EF00_0000_0000_0000, (0x0123_4567_8910_ABCD, 0xEF00_0000_0000_0000)),
+                (0x0000_0000_0000_00FE_DCBA_0198_7654_3210, (0x0000_0000_0000_00FE, 0xDCBA_0198_7654_3210))
+            ];
+            for &(input, (expected_hi, expected_lo)) in test_values {
+                assert_for(input, expected_hi, expected_lo)
+            }
+        }
 
-		#[test]
-		fn from_hi_lo() {
-			fn assert_for(hi: DigitRepr, lo: DigitRepr, expected: DoubleDigitRepr) {
-				assert_eq!(DoubleDigit::from_hi_lo(Digit(hi), Digit(lo)), DoubleDigit(expected))
-			}
-			let test_values = &[
-				(0, (0, 0)),
-				(1, (0, 1)),
-				(0x0000_0000_0000_0001_0000_0000_0000_0000, (1, 0)),
-				(0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)),
-				(0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, (0, 0xFFFF_FFFF_FFFF_FFFF)),
-				(0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, (0xFFFF_FFFF, 0xFFFF_FFFF_0000_0000)),
-				(0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, (0xFFFF_FFFF_FFFF_FFFF, 0)),
-				(0x0123_4567_8910_ABCD_EF00_0000_0000_0000, (0x0123_4567_8910_ABCD, 0xEF00_0000_0000_0000)),
-				(0x0000_0000_0000_00FE_DCBA_0198_7654_3210, (0x0000_0000_0000_00FE, 0xDCBA_0198_7654_3210))
-			];
-			for &(expected, (hi, lo)) in test_values {
-				assert_for(hi, lo, expected)
-			}
-		}
-	}
+        #[test]
+        fn from_hi_lo() {
+            fn assert_for(hi: DigitRepr, lo: DigitRepr, expected: DoubleDigitRepr) {
+                assert_eq!(DoubleDigit::from_hi_lo(Digit(hi), Digit(lo)), DoubleDigit(expected))
+            }
+            let test_values = &[
+                (0, (0, 0)),
+                (1, (0, 1)),
+                (0x0000_0000_0000_0001_0000_0000_0000_0000, (1, 0)),
+                (0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF, (0xFFFF_FFFF_FFFF_FFFF, 0xFFFF_FFFF_FFFF_FFFF)),
+                (0x0000_0000_0000_0000_FFFF_FFFF_FFFF_FFFF, (0, 0xFFFF_FFFF_FFFF_FFFF)),
+                (0x0000_0000_FFFF_FFFF_FFFF_FFFF_0000_0000, (0xFFFF_FFFF, 0xFFFF_FFFF_0000_0000)),
+                (0xFFFF_FFFF_FFFF_FFFF_0000_0000_0000_0000, (0xFFFF_FFFF_FFFF_FFFF, 0)),
+                (0x0123_4567_8910_ABCD_EF00_0000_0000_0000, (0x0123_4567_8910_ABCD, 0xEF00_0000_0000_0000)),
+                (0x0000_0000_0000_00FE_DCBA_0198_7654_3210, (0x0000_0000_0000_00FE, 0xDCBA_0198_7654_3210))
+            ];
+            for &(expected, (hi, lo)) in test_values {
+                assert_for(hi, lo, expected)
+            }
+        }
+    }
 
-	mod digit {
-		use super::*;
+    mod digit {
+        use super::*;
 
-		use std::usize;
+        use std::usize;
 
-		static VALID_TEST_POS_VALUES: &[usize] = &[
-			0, 1, 2, 3, 10, 32, 42, 48, 63
-		];
+        static VALID_TEST_POS_VALUES: &[usize] = &[
+            0, 1, 2, 3, 10, 32, 42, 48, 63
+        ];
 
-		static INVALID_TEST_POS_VALUES: &[usize] = &[
-			64, 65, 100, 1337, usize::MAX
-		];
+        static INVALID_TEST_POS_VALUES: &[usize] = &[
+            64, 65, 100, 1337, usize::MAX
+        ];
 
-		static TEST_DIGIT_REPRS: &[DigitRepr] = &[
-			digit::REPR_ZERO,
-			digit::REPR_ONE,
-			digit::REPR_ONES,
-			0x5555_5555_5555_5555,
-			0xAAAA_AAAA_AAAA_AAAA,
-			0xFFFF_FFFF_0000_0000,
-			0x0000_FFFF_FFFF_0000,
-			0x0000_0000_FFFF_FFFF
-		];
+        static TEST_DIGIT_REPRS: &[DigitRepr] = &[
+            digit::REPR_ZERO,
+            digit::REPR_ONE,
+            digit::REPR_ONES,
+            0x5555_5555_5555_5555,
+            0xAAAA_AAAA_AAAA_AAAA,
+            0xFFFF_FFFF_0000_0000,
+            0x0000_FFFF_FFFF_0000,
+            0x0000_0000_FFFF_FFFF
+        ];
 
-		/// Returns a digit that has every even bit set, starting at index 0.
-		/// 
-		/// E.g.: `0x....010101`
-		fn even_digit() -> Digit {
-			Digit(0x5555_5555_5555_5555)
-		}
+        /// Returns a digit that has every even bit set, starting at index 0.
+        /// 
+        /// E.g.: `0x....010101`
+        fn even_digit() -> Digit {
+            Digit(0x5555_5555_5555_5555)
+        }
 
-		/// Returns a digit that has every odd bit set, starting at index 0.
-		/// 
-		/// E.g.: `0x....101010`
-		fn odd_digit() -> Digit {
-			Digit(0xAAAA_AAAA_AAAA_AAAA)
-		}
+        /// Returns a digit that has every odd bit set, starting at index 0.
+        /// 
+        /// E.g.: `0x....101010`
+        fn odd_digit() -> Digit {
+            Digit(0xAAAA_AAAA_AAAA_AAAA)
+        }
 
-		#[test]
-		fn repr() {
-			for &val in TEST_DIGIT_REPRS {
-				assert_eq!(Digit(val).repr(), val);
-			}
-		}
+        #[test]
+        fn repr() {
+            for &val in TEST_DIGIT_REPRS {
+                assert_eq!(Digit(val).repr(), val);
+            }
+        }
 
-		#[test]
-		fn dd() {
-			for &val in TEST_DIGIT_REPRS {
-				assert_eq!(Digit(val).dd(), DoubleDigit(val as DoubleDigitRepr));
-			}
-		}
+        #[test]
+        fn dd() {
+            for &val in TEST_DIGIT_REPRS {
+                assert_eq!(Digit(val).dd(), DoubleDigit(val as DoubleDigitRepr));
+            }
+        }
 
-		#[test]
-		fn width() {
-			assert_eq!(digit::ONES.width(), BitWidth::w64());
-			assert_eq!(digit::ZERO.width(), BitWidth::w64());
-			assert_eq!(even_digit().width(), BitWidth::w64());
-			assert_eq!(odd_digit().width(), BitWidth::w64());
-		}
+        #[test]
+        fn width() {
+            assert_eq!(digit::ONES.width(), BitWidth::w64());
+            assert_eq!(digit::ZERO.width(), BitWidth::w64());
+            assert_eq!(even_digit().width(), BitWidth::w64());
+            assert_eq!(odd_digit().width(), BitWidth::w64());
+        }
 
-		#[test]
-		fn get_ok() {
-			for &pos in VALID_TEST_POS_VALUES {
-				assert_eq!(digit::ONES.get(pos), Ok(Bit::Set));
-				assert_eq!(digit::ZERO.get(pos), Ok(Bit::Unset));
-				assert_eq!(even_digit().get(pos), Ok(if pos % 2 == 0 { Bit::Set } else { Bit::Unset }));
-				assert_eq!(odd_digit().get(pos), Ok(if pos % 2 == 1 { Bit::Set } else { Bit::Unset }));
-			}
-		}
+        #[test]
+        fn get_ok() {
+            for &pos in VALID_TEST_POS_VALUES {
+                assert_eq!(digit::ONES.get(pos), Ok(Bit::Set));
+                assert_eq!(digit::ZERO.get(pos), Ok(Bit::Unset));
+                assert_eq!(even_digit().get(pos), Ok(if pos % 2 == 0 { Bit::Set } else { Bit::Unset }));
+                assert_eq!(odd_digit().get(pos), Ok(if pos % 2 == 1 { Bit::Set } else { Bit::Unset }));
+            }
+        }
 
-		#[test]
-		fn get_fail() {
-			for &pos in INVALID_TEST_POS_VALUES {
-				let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
-				assert_eq!(digit::ONES.get(pos), expected_err);
-				assert_eq!(digit::ZERO.get(pos), expected_err);
-				assert_eq!(digit::even_digit().get(pos), expected_err);
-				assert_eq!(digit::odd_digit().get(pos), expected_err);
-			}
-		}
+        #[test]
+        fn get_fail() {
+            for &pos in INVALID_TEST_POS_VALUES {
+                let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
+                assert_eq!(digit::ONES.get(pos), expected_err);
+                assert_eq!(digit::ZERO.get(pos), expected_err);
+                assert_eq!(digit::even_digit().get(pos), expected_err);
+                assert_eq!(digit::odd_digit().get(pos), expected_err);
+            }
+        }
 
-		#[test]
-		fn set_ok() {
-			for &val in TEST_DIGIT_REPRS {
-				let mut digit = Digit(val);
-				for &pos in VALID_TEST_POS_VALUES {
-					digit.set(pos).unwrap();
-					assert_eq!(digit.get(pos), Ok(Bit::Set));
-				}
-			}
-		}
+        #[test]
+        fn set_ok() {
+            for &val in TEST_DIGIT_REPRS {
+                let mut digit = Digit(val);
+                for &pos in VALID_TEST_POS_VALUES {
+                    digit.set(pos).unwrap();
+                    assert_eq!(digit.get(pos), Ok(Bit::Set));
+                }
+            }
+        }
 
-		#[test]
-		fn set_fail() {
-			for &pos in INVALID_TEST_POS_VALUES {
-				let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
-				assert_eq!(digit::ONES.set(pos), expected_err);
-				assert_eq!(digit::ZERO.set(pos), expected_err);
-				assert_eq!(digit::even_digit().set(pos), expected_err);
-				assert_eq!(digit::odd_digit().set(pos), expected_err);
-			}
-		}
+        #[test]
+        fn set_fail() {
+            for &pos in INVALID_TEST_POS_VALUES {
+                let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
+                assert_eq!(digit::ONES.set(pos), expected_err);
+                assert_eq!(digit::ZERO.set(pos), expected_err);
+                assert_eq!(digit::even_digit().set(pos), expected_err);
+                assert_eq!(digit::odd_digit().set(pos), expected_err);
+            }
+        }
 
-		// pub fn set(&mut self, n: usize) -> Result<()> {
-		// pub fn unset(&mut self, n: usize) -> Result<()> {
-		// pub fn flip(&mut self, n: usize) -> Result<()> {
-		// pub fn set_all(&mut self) {
-		// pub fn unset_all(&mut self) {
-		// pub fn flip_all(&mut self) {
-		// pub fn set_first_n(&mut self, n: usize) -> Result<()> {
-		// pub fn unset_first_n(&mut self, n: usize) -> Result<()> {
-		// pub fn retain_last_n(&mut self, n: usize) -> Result<()> {
+        // pub fn set(&mut self, n: usize) -> Result<()> {
+        // pub fn unset(&mut self, n: usize) -> Result<()> {
+        // pub fn flip(&mut self, n: usize) -> Result<()> {
+        // pub fn set_all(&mut self) {
+        // pub fn unset_all(&mut self) {
+        // pub fn flip_all(&mut self) {
+        // pub fn set_first_n(&mut self, n: usize) -> Result<()> {
+        // pub fn unset_first_n(&mut self, n: usize) -> Result<()> {
+        // pub fn retain_last_n(&mut self, n: usize) -> Result<()> {
 
-		#[test]
-		fn retain_last_n() {
-			let mut d = ONES;
-			d.retain_last_n(32).unwrap();
-			assert_eq!(d, Digit(0x0000_0000_FFFF_FFFF));
-		}
-	}
+        #[test]
+        fn retain_last_n() {
+            let mut d = ONES;
+            d.retain_last_n(32).unwrap();
+            assert_eq!(d, Digit(0x0000_0000_FFFF_FFFF));
+        }
+    }
 }

--- a/src/digit_seq.rs
+++ b/src/digit_seq.rs
@@ -7,23 +7,23 @@ use std::slice;
 /// This is a very efficient `DigitSeq` since its data is contiguous in memory.
 #[derive(Debug, Clone)]
 pub(crate) struct ContiguousDigitSeq<'a> {
-	digits: slice::Iter<'a, Digit>
+    digits: slice::Iter<'a, Digit>
 }
 
 impl<'a> From<&'a [Digit]> for ContiguousDigitSeq<'a> {
-	#[inline]
-	fn from(slice: &'a [Digit]) -> ContiguousDigitSeq<'a> {
-		ContiguousDigitSeq{digits: slice.iter()}
-	}
+    #[inline]
+    fn from(slice: &'a [Digit]) -> ContiguousDigitSeq<'a> {
+        ContiguousDigitSeq{digits: slice.iter()}
+    }
 }
 
 impl<'a> Iterator for ContiguousDigitSeq<'a> {
-	type Item = Digit;
+    type Item = Digit;
 
-	#[inline]
-	fn next(&mut self) -> Option<Self::Item> {
-		self.digits.next().cloned()
-	}
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.digits.next().cloned()
+    }
 }
 
 /// A sequence of mutable digits.
@@ -31,21 +31,21 @@ impl<'a> Iterator for ContiguousDigitSeq<'a> {
 /// This is a very efficient `DigitSeqMut` since its data is contiguous in memory.
 #[derive(Debug)]
 pub(crate) struct ContiguousDigitSeqMut<'a> {
-	digits: slice::IterMut<'a, Digit>
+    digits: slice::IterMut<'a, Digit>
 }
 
 impl<'a> From<&'a mut [Digit]> for ContiguousDigitSeqMut<'a> {
-	#[inline]
-	fn from(slice: &'a mut [Digit]) -> ContiguousDigitSeqMut<'a> {
-		ContiguousDigitSeqMut{digits: slice.iter_mut()}
-	}
+    #[inline]
+    fn from(slice: &'a mut [Digit]) -> ContiguousDigitSeqMut<'a> {
+        ContiguousDigitSeqMut{digits: slice.iter_mut()}
+    }
 }
 
 impl<'a> Iterator for ContiguousDigitSeqMut<'a> {
-	type Item = &'a mut Digit;
+    type Item = &'a mut Digit;
 
-	#[inline]
-	fn next(&mut self) -> Option<Self::Item> {
-		self.digits.next()
-	}
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.digits.next()
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,89 +13,89 @@ use std::fmt;
 /// This also stores the unique information tied to the error report.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorKind {
-	/// Returned on trying to create a `Radix` from an invalid `u8` representation.
-	InvalidRadix(u8),
+    /// Returned on trying to create a `Radix` from an invalid `u8` representation.
+    InvalidRadix(u8),
 
-	/// Returned whenever trying to parse an invalid string representation for an `ApInt`.
-	InvalidStringRepr{
-		/// The string storing the invalid representation of the int for the given radix.
-		input: String,
-		/// The radix that was used.
-		radix: Radix,
-		/// An optional index and character when encountering an invalid character.
-		pos_char: Option<(usize, char)>
-	},
+    /// Returned whenever trying to parse an invalid string representation for an `ApInt`.
+    InvalidStringRepr{
+        /// The string storing the invalid representation of the int for the given radix.
+        input: String,
+        /// The radix that was used.
+        radix: Radix,
+        /// An optional index and character when encountering an invalid character.
+        pos_char: Option<(usize, char)>
+    },
 
-	/// Returned on trying to access an invalid bit position.
-	InvalidBitAccess{
-		/// The invalid bit position that was tried to access.
-		pos: BitPos,
-		/// The upper bound for valid bit positions in this context.
-		width: BitWidth
-	},
+    /// Returned on trying to access an invalid bit position.
+    InvalidBitAccess{
+        /// The invalid bit position that was tried to access.
+        pos: BitPos,
+        /// The upper bound for valid bit positions in this context.
+        width: BitWidth
+    },
 
-	/// Returned on trying to shift with an invalid shift amount.
-	InvalidShiftAmount{
-		/// The invalid shift amount.
-		shift_amount: ShiftAmount,
-		/// The bit width for which this shift amount of invalid.
-		width: BitWidth
-	},
+    /// Returned on trying to shift with an invalid shift amount.
+    InvalidShiftAmount{
+        /// The invalid shift amount.
+        shift_amount: ShiftAmount,
+        /// The bit width for which this shift amount of invalid.
+        width: BitWidth
+    },
 
-	/// Returns on trying to cast an `ApInt` to a primitive type
-	/// that can not represent the value represented by the `ApInt`.
-	ValueUnrepresentable{
-		/// The `ApInt` that the user wanted to represent as the given `PrimitiveTy`.
-		value: ApInt,
-		/// The `PrimitiveTy` that the user wanted for representing the given `ApInt`.
-		destination_ty: PrimitiveTy
-	},
+    /// Returns on trying to cast an `ApInt` to a primitive type
+    /// that can not represent the value represented by the `ApInt`.
+    ValueUnrepresentable{
+        /// The `ApInt` that the user wanted to represent as the given `PrimitiveTy`.
+        value: ApInt,
+        /// The `PrimitiveTy` that the user wanted for representing the given `ApInt`.
+        destination_ty: PrimitiveTy
+    },
 
-	/// Returned on violation of matching bitwidth constraints of operations.
-	UnmatchingBitwidth(BitWidth, BitWidth),
+    /// Returned on violation of matching bitwidth constraints of operations.
+    UnmatchingBitwidth(BitWidth, BitWidth),
 
-	/// Returned on trying to create a `BitWidth` from an invalid `usize` representation.
-	InvalidBitWidth(usize),
+    /// Returned on trying to create a `BitWidth` from an invalid `usize` representation.
+    InvalidBitWidth(usize),
 
-	/// Returned on truncating an `ApInt` with a bitwidth greater than the current one.
-	TruncationBitWidthTooLarge{
-		/// The target bit width.
-		target: BitWidth,
-		/// The current actual bit width.
-		current: BitWidth
-	},
+    /// Returned on truncating an `ApInt` with a bitwidth greater than the current one.
+    TruncationBitWidthTooLarge{
+        /// The target bit width.
+        target: BitWidth,
+        /// The current actual bit width.
+        current: BitWidth
+    },
 
-	/// Returned on extending an `ApInt` with a bitwidth less than the current one.
-	ExtensionBitWidthTooSmall{
-		/// The target bit width.
-		target: BitWidth,
-		/// The current actual bit width.
-		current: BitWidth
-	},
+    /// Returned on extending an `ApInt` with a bitwidth less than the current one.
+    ExtensionBitWidthTooSmall{
+        /// The target bit width.
+        target: BitWidth,
+        /// The current actual bit width.
+        current: BitWidth
+    },
 
-	/// Returned on division by zero.
-	DivisionByZero {
-		/// The exact division operation.
-		op: DivOp,
-		/// The left-hand side of the division.
-		lhs: ApInt
-	},
+    /// Returned on division by zero.
+    DivisionByZero {
+        /// The exact division operation.
+        op: DivOp,
+        /// The left-hand side of the division.
+        lhs: ApInt
+    },
 
-	/// Returned on constructing an `ApInt` from an empty iterator of `Digit`s.
-	ExpectedNonEmptyDigits,
+    /// Returned on constructing an `ApInt` from an empty iterator of `Digit`s.
+    ExpectedNonEmptyDigits,
 }
 
 /// All division operations that may be affected by division-by-zero errors.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DivOp {
-	/// The signed division operation.
-	SignedDiv,
-	/// The signed remainder operation.
-	SignedRem,
-	/// The unsigned division operation.
-	UnsignedDiv,
-	/// The unsigned remainder operation.
-	UnsignedRem
+    /// The signed division operation.
+    SignedDiv,
+    /// The signed remainder operation.
+    SignedRem,
+    /// The unsigned division operation.
+    UnsignedDiv,
+    /// The unsigned remainder operation.
+    UnsignedRem
 }
 
 /// Represents an error that may occure upon using the `ApInt` library.
@@ -104,221 +104,221 @@ pub enum DivOp {
 /// Besides that an `Error` also stores a message and an optional additional annotation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Error {
-	kind      : ErrorKind,
-	message   : String,
-	annotation: Option<String>
+    kind      : ErrorKind,
+    message   : String,
+    annotation: Option<String>
 }
 
 //  ===========================================================================
 ///  Public getters for `Error`.
 /// ===========================================================================
 impl Error {
-	/// Returns a reference to the kind of this `Error`.
-	#[inline]
-	pub fn kind(&self) -> &ErrorKind {
-		&self.kind
-	}
+    /// Returns a reference to the kind of this `Error`.
+    #[inline]
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
 
-	/// Returns the error message description of this `Error`.
-	#[inline]
-	pub fn message(&self) -> &str {
-		self.message.as_str()
-	}
+    /// Returns the error message description of this `Error`.
+    #[inline]
+    pub fn message(&self) -> &str {
+        self.message.as_str()
+    }
 
-	/// Returns the optional annotation of this `Error`.
-	#[inline]
-	pub fn annotation(&self) -> Option<&str> {
-		match self.annotation {
-			Some(ref ann) => Some(ann.as_str()),
-			None          => None
-		}
-	}
+    /// Returns the optional annotation of this `Error`.
+    #[inline]
+    pub fn annotation(&self) -> Option<&str> {
+        match self.annotation {
+            Some(ref ann) => Some(ann.as_str()),
+            None          => None
+        }
+    }
 }
 
 //  ===========================================================================
 ///  Extending constructors for `Error`.
 /// ===========================================================================
 impl Error {
-	#[inline]
-	pub(crate) fn with_annotation<A>(mut self, annotation: A) -> Error
-		where A: Into<String>
-	{
-		self.annotation = Some(annotation.into());
-		self
-	}
+    #[inline]
+    pub(crate) fn with_annotation<A>(mut self, annotation: A) -> Error
+        where A: Into<String>
+    {
+        self.annotation = Some(annotation.into());
+        self
+    }
 }
 
 //  ===========================================================================
 ///  Default constructors for `Error`.
 /// ===========================================================================
 impl Error {
-	pub(crate) fn invalid_radix(val: u8) -> Error {
-		Error{
-			kind: ErrorKind::InvalidRadix(val),
-			message: format!("Encountered an invalid parsing radix of {:?}.", val),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_radix(val: u8) -> Error {
+        Error{
+            kind: ErrorKind::InvalidRadix(val),
+            message: format!("Encountered an invalid parsing radix of {:?}.", val),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_string_repr<S>(input: S, radix: Radix) -> Error
-		where S: Into<String>
-	{
-		let input = input.into();
-		Error{
-			kind: ErrorKind::InvalidStringRepr{input, radix, pos_char: None},
-			message: format!("Encountered an invalid string representation for the given radix (= {:?}).", radix),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_string_repr<S>(input: S, radix: Radix) -> Error
+        where S: Into<String>
+    {
+        let input = input.into();
+        Error{
+            kind: ErrorKind::InvalidStringRepr{input, radix, pos_char: None},
+            message: format!("Encountered an invalid string representation for the given radix (= {:?}).", radix),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_char_in_string_repr<S>(input: S, radix: Radix, pos: usize, ch: char) -> Error
-		where S: Into<String>
-	{
-		let input = input.into();
-		Error{
-			kind: ErrorKind::InvalidStringRepr{input, radix, pos_char: None},
-			message: format!("Encountered an invalid character (= '{:?}') at position {:?} within the given string \
-				              representation for the given radix (= {:?}).", ch, pos, radix),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_char_in_string_repr<S>(input: S, radix: Radix, pos: usize, ch: char) -> Error
+        where S: Into<String>
+    {
+        let input = input.into();
+        Error{
+            kind: ErrorKind::InvalidStringRepr{input, radix, pos_char: None},
+            message: format!("Encountered an invalid character (= '{:?}') at position {:?} within the given string \
+                              representation for the given radix (= {:?}).", ch, pos, radix),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_bitwidth(val: usize) -> Error {
-		Error{
-			kind: ErrorKind::InvalidBitWidth(val),
-			message: format!("Encountered invalid bitwidth of {:?}.", val),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_bitwidth(val: usize) -> Error {
+        Error{
+            kind: ErrorKind::InvalidBitWidth(val),
+            message: format!("Encountered invalid bitwidth of {:?}.", val),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_zero_bitwidth() -> Error {
-		Error::invalid_bitwidth(0)
-	}
+    pub(crate) fn invalid_zero_bitwidth() -> Error {
+        Error::invalid_bitwidth(0)
+    }
 
-	pub(crate) fn extension_bitwidth_too_small<W1, W2>(target: W1, current: W2) -> Error
-		where W1: Into<BitWidth>,
-		      W2: Into<BitWidth>
-	{
-		let target = target.into();
-		let current = current.into();
-		Error{
-			kind: ErrorKind::ExtensionBitWidthTooSmall{target, current},
-			message: format!("Tried to extend an `ApInt` with a width of {:?} to a smaller target width of {:?}", current, target),
-			annotation: None
-		}
-	}
+    pub(crate) fn extension_bitwidth_too_small<W1, W2>(target: W1, current: W2) -> Error
+        where W1: Into<BitWidth>,
+              W2: Into<BitWidth>
+    {
+        let target = target.into();
+        let current = current.into();
+        Error{
+            kind: ErrorKind::ExtensionBitWidthTooSmall{target, current},
+            message: format!("Tried to extend an `ApInt` with a width of {:?} to a smaller target width of {:?}", current, target),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn truncation_bitwidth_too_large<W1, W2>(target: W1, current: W2) -> Error
-		where W1: Into<BitWidth>,
-		      W2: Into<BitWidth>
-	{
-		let target = target.into();
-		let current = current.into();
-		Error{
-			kind: ErrorKind::TruncationBitWidthTooLarge{target, current},
-			message: format!("Tried to truncate an `ApInt` with a width of {:?} to a larger target width of {:?}", current, target),
-			annotation: None
-		}
-	}
+    pub(crate) fn truncation_bitwidth_too_large<W1, W2>(target: W1, current: W2) -> Error
+        where W1: Into<BitWidth>,
+              W2: Into<BitWidth>
+    {
+        let target = target.into();
+        let current = current.into();
+        Error{
+            kind: ErrorKind::TruncationBitWidthTooLarge{target, current},
+            message: format!("Tried to truncate an `ApInt` with a width of {:?} to a larger target width of {:?}", current, target),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn unmatching_bitwidths<W1, W2>(lhs: W1, rhs: W2) -> Error
-		where W1: Into<BitWidth>,
-		      W2: Into<BitWidth>
-	{
-		let lhs = lhs.into();
-		let rhs = rhs.into();
-		Error{
-			kind: ErrorKind::UnmatchingBitwidth(lhs, rhs),
-			message: format!("Encountered invalid operation on entities with non-matching bit-widths of {:?} and {:?}.", lhs, rhs),
-			annotation: None
-		}
-	}
+    pub(crate) fn unmatching_bitwidths<W1, W2>(lhs: W1, rhs: W2) -> Error
+        where W1: Into<BitWidth>,
+              W2: Into<BitWidth>
+    {
+        let lhs = lhs.into();
+        let rhs = rhs.into();
+        Error{
+            kind: ErrorKind::UnmatchingBitwidth(lhs, rhs),
+            message: format!("Encountered invalid operation on entities with non-matching bit-widths of {:?} and {:?}.", lhs, rhs),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_shift_amount<S, W>(shift_amount: S, width: W) -> Error
-		where S: Into<ShiftAmount>,
-		      W: Into<BitWidth>
-	{
-		let shift_amount = shift_amount.into();
-		let width = width.into();
-		Error{
-			kind: ErrorKind::InvalidShiftAmount{shift_amount, width},
-			message: format!("Encountered invalid shift amount of {:?} on bit-width with {:?} bits.", shift_amount, width),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_shift_amount<S, W>(shift_amount: S, width: W) -> Error
+        where S: Into<ShiftAmount>,
+              W: Into<BitWidth>
+    {
+        let shift_amount = shift_amount.into();
+        let width = width.into();
+        Error{
+            kind: ErrorKind::InvalidShiftAmount{shift_amount, width},
+            message: format!("Encountered invalid shift amount of {:?} on bit-width with {:?} bits.", shift_amount, width),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn invalid_bit_access<P, W>(pos: P, width: W) -> Error
-		where P: Into<BitPos>,
-		      W: Into<BitWidth>
-	{
-		let pos = pos.into();
-		let width = width.into();
-		Error{
-			kind: ErrorKind::InvalidBitAccess{pos, width},
-			message: format!("Encountered invalid bit access at position {:?} with a total bit-width of {:?}.", pos, width),
-			annotation: None
-		}
-	}
+    pub(crate) fn invalid_bit_access<P, W>(pos: P, width: W) -> Error
+        where P: Into<BitPos>,
+              W: Into<BitWidth>
+    {
+        let pos = pos.into();
+        let width = width.into();
+        Error{
+            kind: ErrorKind::InvalidBitAccess{pos, width},
+            message: format!("Encountered invalid bit access at position {:?} with a total bit-width of {:?}.", pos, width),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn expected_non_empty_digits() -> Error {
-		Error{
-			kind: ErrorKind::ExpectedNonEmptyDigits,
-			message: "Encountered an empty iterator upon construction of an `ApInt` from a digit iterator.".to_owned(),
-			annotation: None
-		}
-	}
+    pub(crate) fn expected_non_empty_digits() -> Error {
+        Error{
+            kind: ErrorKind::ExpectedNonEmptyDigits,
+            message: "Encountered an empty iterator upon construction of an `ApInt` from a digit iterator.".to_owned(),
+            annotation: None
+        }
+    }
 
-	pub(crate) fn encountered_unrepresentable_value(
-		value: ApInt,
-		destination_ty: PrimitiveTy
-	)
-		-> Error
-	{
-		let message = format!(
-			"Encountered a value ({:?}) that is unrepresentable \
-			 by the destination type {:?}.", value, destination_ty);
-		Error{
-			kind: ErrorKind::ValueUnrepresentable{value, destination_ty},
-			message,
-			annotation: None
-		}
-	}
+    pub(crate) fn encountered_unrepresentable_value(
+        value: ApInt,
+        destination_ty: PrimitiveTy
+    )
+        -> Error
+    {
+        let message = format!(
+            "Encountered a value ({:?}) that is unrepresentable \
+             by the destination type {:?}.", value, destination_ty);
+        Error{
+            kind: ErrorKind::ValueUnrepresentable{value, destination_ty},
+            message,
+            annotation: None
+        }
+    }
 
-	pub(crate) fn division_by_zero(op: DivOp, lhs: ApInt) -> Error {
-		let message = format!(
-			"Encountered a division-by-zero for operation (= {:?}) with the left hand-side value: (= {:?})",
-			op, lhs
-		);
-		Error{
-			kind: ErrorKind::DivisionByZero{op, lhs},
-			message,
-			annotation: None
-		}
-	}
+    pub(crate) fn division_by_zero(op: DivOp, lhs: ApInt) -> Error {
+        let message = format!(
+            "Encountered a division-by-zero for operation (= {:?}) with the left hand-side value: (= {:?})",
+            op, lhs
+        );
+        Error{
+            kind: ErrorKind::DivisionByZero{op, lhs},
+            message,
+            annotation: None
+        }
+    }
 }
 
 impl<T> Into<Result<T>> for Error {
-	/// Converts an `Error` into a `Result<T, Error>`.
-	/// 
-	/// This might be useful to prevent some parentheses spams
-	/// because it replaces `Err(my_error)` with `my_error.into()`.
-	/// 
-	/// On the other hand it might be an abuse of the trait ...
-	fn into(self) -> Result<T> {
-		Err(self)
-	}
+    /// Converts an `Error` into a `Result<T, Error>`.
+    /// 
+    /// This might be useful to prevent some parentheses spams
+    /// because it replaces `Err(my_error)` with `my_error.into()`.
+    /// 
+    /// On the other hand it might be an abuse of the trait ...
+    fn into(self) -> Result<T> {
+        Err(self)
+    }
 }
 
 impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		<Self as fmt::Debug>::fmt(self, f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
 }
 
 impl error::Error for Error {
-	fn description(&self) -> &str {
-		self.message.as_str()
-	}
+    fn description(&self) -> &str {
+        self.message.as_str()
+    }
 }
 
 /// The `Result` type used in `ApInt`.

--- a/src/int.rs
+++ b/src/int.rs
@@ -13,28 +13,28 @@ use rand;
 
 use std::cmp::Ordering;
 use std::ops::{
-	Not,
-	BitAnd,
-	BitOr,
-	BitXor,
-	BitAndAssign,
-	BitOrAssign,
-	BitXorAssign,
-	Neg,
-	Add,
-	Sub,
-	Mul,
-	Div,
-	Rem,
-	AddAssign,
-	SubAssign,
-	MulAssign,
-	DivAssign,
-	RemAssign,
-	Shl,
-	ShlAssign,
-	Shr,
-	ShrAssign
+    Not,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitAndAssign,
+    BitOrAssign,
+    BitXorAssign,
+    Neg,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+    AddAssign,
+    SubAssign,
+    MulAssign,
+    DivAssign,
+    RemAssign,
+    Shl,
+    ShlAssign,
+    Shr,
+    ShrAssign
 };
 
 /// Signed machine integer with arbitrary bitwidths and modulo arithmetics.
@@ -45,152 +45,152 @@ use std::ops::{
 /// `UInt` offers a more elegant and higher-level abstraction interface to the lower-level `ApInt`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Int {
-	value: ApInt,
+    value: ApInt,
 }
 
 impl From<ApInt> for Int {
-	fn from(value: ApInt) -> Int {
-		Int { value }
-	}
+    fn from(value: ApInt) -> Int {
+        Int { value }
+    }
 }
 
 impl Int {
-	/// Transforms this `Int` into an equivalent `ApInt` instance.
-	pub fn into_apint(self) -> ApInt {
-		self.value
-	}
+    /// Transforms this `Int` into an equivalent `ApInt` instance.
+    pub fn into_apint(self) -> ApInt {
+        self.value
+    }
 
-	/// Transforms this `Int` into an equivalent `UInt` instance.
-	pub fn into_unsigned(self) -> UInt {
-		UInt::from(self.value)
-	}
+    /// Transforms this `Int` into an equivalent `UInt` instance.
+    pub fn into_unsigned(self) -> UInt {
+        UInt::from(self.value)
+    }
 }
 
 /// # Constructors
 impl Int {
-	/// Creates a new `Int` from the given `Bit` value with a bit width of `1`.
-	///
-	/// This function is generic over types that are convertible to `Bit` such as `bool`.
-	pub fn from_bit<B>(bit: B) -> Int
-	where
-		B: Into<Bit>,
-	{
-		Int::from(ApInt::from_bit(bit))
-	}
+    /// Creates a new `Int` from the given `Bit` value with a bit width of `1`.
+    ///
+    /// This function is generic over types that are convertible to `Bit` such as `bool`.
+    pub fn from_bit<B>(bit: B) -> Int
+    where
+        B: Into<Bit>,
+    {
+        Int::from(ApInt::from_bit(bit))
+    }
 
-	/// Creates a new `Int` from a given `i8` value with a bit-width of 8.
-	#[inline]
-	pub fn from_i8(val: i8) -> Int {
-		Int::from(ApInt::from_i8(val))
-	}
+    /// Creates a new `Int` from a given `i8` value with a bit-width of 8.
+    #[inline]
+    pub fn from_i8(val: i8) -> Int {
+        Int::from(ApInt::from_i8(val))
+    }
 
-	/// Creates a new `Int` from a given `i16` value with a bit-width of 16.
-	#[inline]
-	pub fn from_i16(val: i16) -> Int {
-		Int::from(ApInt::from_i16(val))
-	}
+    /// Creates a new `Int` from a given `i16` value with a bit-width of 16.
+    #[inline]
+    pub fn from_i16(val: i16) -> Int {
+        Int::from(ApInt::from_i16(val))
+    }
 
-	/// Creates a new `Int` from a given `i32` value with a bit-width of 32.
-	#[inline]
-	pub fn from_i32(val: i32) -> Int {
-		Int::from(ApInt::from_i32(val))
-	}
+    /// Creates a new `Int` from a given `i32` value with a bit-width of 32.
+    #[inline]
+    pub fn from_i32(val: i32) -> Int {
+        Int::from(ApInt::from_i32(val))
+    }
 
-	/// Creates a new `Int` from a given `i64` value with a bit-width of 64.
-	#[inline]
-	pub fn from_i64(val: i64) -> Int {
-		Int::from(ApInt::from_i64(val))
-	}
+    /// Creates a new `Int` from a given `i64` value with a bit-width of 64.
+    #[inline]
+    pub fn from_i64(val: i64) -> Int {
+        Int::from(ApInt::from_i64(val))
+    }
 
-	/// Creates a new `Int` from a given `i64` value with a bit-width of 64.
-	pub fn from_i128(val: i128) -> Int {
-		Int::from(ApInt::from_i128(val))
-	}
+    /// Creates a new `Int` from a given `i64` value with a bit-width of 64.
+    pub fn from_i128(val: i128) -> Int {
+        Int::from(ApInt::from_i128(val))
+    }
 
-	/// Creates a new `Int` with the given bit width that represents zero.
-	pub fn zero(width: BitWidth) -> Int {
-		Int::from(ApInt::zero(width))
-	}
+    /// Creates a new `Int` with the given bit width that represents zero.
+    pub fn zero(width: BitWidth) -> Int {
+        Int::from(ApInt::zero(width))
+    }
 
-	/// Creates a new `Int` with the given bit width that represents one.
-	pub fn one(width: BitWidth) -> Int {
-		Int::from(ApInt::one(width))
-	}
+    /// Creates a new `Int` with the given bit width that represents one.
+    pub fn one(width: BitWidth) -> Int {
+        Int::from(ApInt::one(width))
+    }
 
-	/// Creates a new `Int` with the given bit width that has all bits unset.
-	///
-	/// **Note:** This is equal to calling `Int::zero` with the given `width`.
-	pub fn all_unset(width: BitWidth) -> Int {
-		Int::zero(width)
-	}
+    /// Creates a new `Int` with the given bit width that has all bits unset.
+    ///
+    /// **Note:** This is equal to calling `Int::zero` with the given `width`.
+    pub fn all_unset(width: BitWidth) -> Int {
+        Int::zero(width)
+    }
 
-	/// Creates a new `Int` with the given bit width that has all bits set.
-	///
-	/// # Note
-	///
-	/// - This is equal to minus one on any twos-complement machine.
-	pub fn all_set(width: BitWidth) -> Int {
-		Int::from(ApInt::all_set(width))
-	}
+    /// Creates a new `Int` with the given bit width that has all bits set.
+    ///
+    /// # Note
+    ///
+    /// - This is equal to minus one on any twos-complement machine.
+    pub fn all_set(width: BitWidth) -> Int {
+        Int::from(ApInt::all_set(width))
+    }
 
-	/// Returns the smallest `Int` that can be represented by the given `BitWidth`.
-	pub fn min_value(width: BitWidth) -> Int {
-		Int::from(ApInt::signed_min_value(width))
-	}
+    /// Returns the smallest `Int` that can be represented by the given `BitWidth`.
+    pub fn min_value(width: BitWidth) -> Int {
+        Int::from(ApInt::signed_min_value(width))
+    }
 
-	/// Returns the largest `Int` that can be represented by the given `BitWidth`.
-	pub fn max_value(width: BitWidth) -> Int {
-		Int::from(ApInt::signed_max_value(width))
-	}
+    /// Returns the largest `Int` that can be represented by the given `BitWidth`.
+    pub fn max_value(width: BitWidth) -> Int {
+        Int::from(ApInt::signed_max_value(width))
+    }
 }
 
 impl<B> From<B> for Int
-	where B: Into<Bit>
+    where B: Into<Bit>
 {
-	#[inline]
-	fn from(bit: B) -> Int {
-		Int::from_bit(bit)
-	}
+    #[inline]
+    fn from(bit: B) -> Int {
+        Int::from_bit(bit)
+    }
 }
 
 impl From<i8> for Int {
-	fn from(val: i8) -> Int {
-		Int::from_i8(val)
-	}
+    fn from(val: i8) -> Int {
+        Int::from_i8(val)
+    }
 }
 
 impl From<i16> for Int {
-	fn from(val: i16) -> Int {
-		Int::from_i16(val)
-	}
+    fn from(val: i16) -> Int {
+        Int::from_i16(val)
+    }
 }
 
 impl From<i32> for Int {
-	fn from(val: i32) -> Int {
-		Int::from_i32(val)
-	}
+    fn from(val: i32) -> Int {
+        Int::from_i32(val)
+    }
 }
 
 impl From<i64> for Int {
-	fn from(val: i64) -> Int {
-		Int::from_i64(val)
-	}
+    fn from(val: i64) -> Int {
+        Int::from_i64(val)
+    }
 }
 
 impl From<i128> for Int {
-	fn from(val: i128) -> Int {
-		Int::from_i128(val)
-	}
+    fn from(val: i128) -> Int {
+        Int::from_i128(val)
+    }
 }
 
 macro_rules! impl_from_array_for_Int {
-	($n:expr) => {
-		impl From<[i64; $n]> for Int {
-			fn from(val: [i64; $n]) -> Int {
-				Int::from(ApInt::from(val))
-			}
-		}
-	}
+    ($n:expr) => {
+        impl From<[i64; $n]> for Int {
+            fn from(val: [i64; $n]) -> Int {
+                Int::from(ApInt::from(val))
+            }
+        }
+    }
 }
 
 impl_from_array_for_Int!(2); // 128 bits
@@ -205,823 +205,821 @@ impl_from_array_for_Int!(32); // 2048 bits
 
 /// # Utilities
 impl Int {
-	/// Returns `true` if this `Int` represents the value zero (`0`).
-	///
-	/// # Note
-	///
-	/// - Zero (`0`) is also called the additive neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `Int` for the same reason.
-	pub fn is_zero(&self) -> bool {
-		self.value.is_zero()
-	}
+    /// Returns `true` if this `Int` represents the value zero (`0`).
+    ///
+    /// # Note
+    ///
+    /// - Zero (`0`) is also called the additive neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `Int` for the same reason.
+    pub fn is_zero(&self) -> bool {
+        self.value.is_zero()
+    }
 
-	/// Returns `true` if this `Int` represents the value one (`1`).
-	///
-	/// # Note
-	///
-	/// - One (`1`) is also called the multiplicative neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `Int` for the same reason.
-	pub fn is_one(&self) -> bool {
-		self.value.is_one()
-	}
+    /// Returns `true` if this `Int` represents the value one (`1`).
+    ///
+    /// # Note
+    ///
+    /// - One (`1`) is also called the multiplicative neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `Int` for the same reason.
+    pub fn is_one(&self) -> bool {
+        self.value.is_one()
+    }
 
-	/// Returns `true` if this `Int` represents an even number.
-	pub fn is_even(&self) -> bool {
-		self.value.is_even()
-	}
+    /// Returns `true` if this `Int` represents an even number.
+    pub fn is_even(&self) -> bool {
+        self.value.is_even()
+    }
 
-	/// Returns `true` if this `Int` represents an odd number.
-	pub fn is_odd(&self) -> bool {
-		self.value.is_odd()
-	}
+    /// Returns `true` if this `Int` represents an odd number.
+    pub fn is_odd(&self) -> bool {
+        self.value.is_odd()
+    }
 
-	/// Returns `true` if the value of this `Int` is positive.
-	pub fn is_positive(&self) -> bool {
-		self.sign_bit() == Bit::Unset
-	}
+    /// Returns `true` if the value of this `Int` is positive.
+    pub fn is_positive(&self) -> bool {
+        self.sign_bit() == Bit::Unset
+    }
 
-	/// Returns `true` if the value of this `Int` is negative.
-	pub fn is_negative(&self) -> bool {
-		!self.is_positive()
-	}
+    /// Returns `true` if the value of this `Int` is negative.
+    pub fn is_negative(&self) -> bool {
+        !self.is_positive()
+    }
 
-	/// Returns a number representing sign of this `ApInt`.
-	/// 
-	/// - `0` if the number is zero
-	/// - `1` if the number is positive
-	/// - `-1` if the number is negative
-	pub fn signum(&self) -> i8 {
-		if self.is_zero() {
-			return 0
-		}
-		if self.is_negative() {
-			return -1
-		}
-		1
-	}
+    /// Returns a number representing sign of this `ApInt`.
+    /// 
+    /// - `0` if the number is zero
+    /// - `1` if the number is positive
+    /// - `-1` if the number is negative
+    pub fn signum(&self) -> i8 {
+        if self.is_zero() {
+            return 0
+        }
+        if self.is_negative() {
+            return -1
+        }
+        1
+    }
 
-	/// Returns an absolute value representation of this `Int`.
-	/// 
-	/// # Note
-	/// 
-	/// - Consumes `self`.
-	/// - Does nothing for positive `Int` instances.
-	pub fn into_abs(self) -> Int {
-		forward_mut_impl(self, Int::wrapping_abs)
-	}
+    /// Returns an absolute value representation of this `Int`.
+    /// 
+    /// # Note
+    /// 
+    /// - Consumes `self`.
+    /// - Does nothing for positive `Int` instances.
+    pub fn into_abs(self) -> Int {
+        forward_mut_impl(self, Int::wrapping_abs)
+    }
 
-	/// Converts this `Int` into its absolute value representation.
-	/// 
-	/// - Does nothing for positive `Int` instances.
-	pub fn wrapping_abs(&mut self) {
-		if self.is_negative() {
-			self.wrapping_neg()
-		}
-	}
-
+    /// Converts this `Int` into its absolute value representation.
+    /// 
+    /// - Does nothing for positive `Int` instances.
+    pub fn wrapping_abs(&mut self) {
+        if self.is_negative() {
+            self.wrapping_neg()
+        }
+    }
 }
 
 /// # Comparisons
 impl Int {
+    /// Less-than (`lt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self < rhs`.
+    /// - Interprets both `Int` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn checked_lt(&self, rhs: &Int) -> Result<bool> {
+        self.value.checked_slt(&rhs.value)
+    }
 
-	/// Less-than (`lt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self < rhs`.
-	/// - Interprets both `Int` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_lt(&self, rhs: &Int) -> Result<bool> {
-		self.value.checked_slt(&rhs.value)
-	}
+    /// Less-equals (`le`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self <= rhs`.
+    /// - Interprets both `Int` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_le(&self, rhs: &Int) -> Result<bool> {
+        self.value.checked_sle(&rhs.value)
+    }
 
-	/// Less-equals (`le`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self <= rhs`.
-	/// - Interprets both `Int` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_le(&self, rhs: &Int) -> Result<bool> {
-		self.value.checked_sle(&rhs.value)
-	}
+    /// Greater-than (`gt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self > rhs`.
+    /// - Interprets both `Int` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_gt(&self, rhs: &Int) -> Result<bool> {
+        self.value.checked_sgt(&rhs.value)
+    }
 
-	/// Greater-than (`gt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self > rhs`.
-	/// - Interprets both `Int` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_gt(&self, rhs: &Int) -> Result<bool> {
-		self.value.checked_sgt(&rhs.value)
-	}
-
-	/// Greater-equals (`ge`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self >= rhs`.
-	/// - Interprets both `Int` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_ge(&self, rhs: &Int) -> Result<bool> {
-		self.value.checked_sge(&rhs.value)
-	}
+    /// Greater-equals (`ge`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self >= rhs`.
+    /// - Interprets both `Int` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_ge(&self, rhs: &Int) -> Result<bool> {
+        self.value.checked_sge(&rhs.value)
+    }
 }
 
 /// If `self` and `rhs` have unmatching bit widths, `None` will be returned for `partial_cmp`
 /// and `false` will be returned for the rest of the `PartialOrd` methods.
 impl PartialOrd for Int {
-	fn partial_cmp(&self, rhs: &Int) -> Option<Ordering> {
-		if self.value.width() != rhs.value.width() {
-			return None;
-		}
-		if self.checked_lt(rhs).unwrap() {
-			return Some(Ordering::Less);
-		}
-		if self.value == rhs.value {
-			return Some(Ordering::Equal);
-		}
-		Some(Ordering::Greater)
-	}
+    fn partial_cmp(&self, rhs: &Int) -> Option<Ordering> {
+        if self.value.width() != rhs.value.width() {
+            return None;
+        }
+        if self.checked_lt(rhs).unwrap() {
+            return Some(Ordering::Less);
+        }
+        if self.value == rhs.value {
+            return Some(Ordering::Equal);
+        }
+        Some(Ordering::Greater)
+    }
 
-	fn lt(&self, rhs: &Int) -> bool {
-		self.checked_lt(rhs).unwrap_or(false)
-	}
+    fn lt(&self, rhs: &Int) -> bool {
+        self.checked_lt(rhs).unwrap_or(false)
+    }
 
-	fn le(&self, rhs: &Int) -> bool {
-		self.checked_le(rhs).unwrap_or(false)
-	}
+    fn le(&self, rhs: &Int) -> bool {
+        self.checked_le(rhs).unwrap_or(false)
+    }
 
-	fn gt(&self, rhs: &Int) -> bool {
-		self.checked_gt(rhs).unwrap_or(false)
-	}
+    fn gt(&self, rhs: &Int) -> bool {
+        self.checked_gt(rhs).unwrap_or(false)
+    }
 
-	fn ge(&self, rhs: &Int) -> bool {
-		self.checked_ge(rhs).unwrap_or(false)
-	}
+    fn ge(&self, rhs: &Int) -> bool {
+        self.checked_ge(rhs).unwrap_or(false)
+    }
 }
 
 /// # To Primitive (Resize)
 impl Int {
-	/// Resizes this `Int` to a `bool` primitive type.
-	///
-	/// Bits in this `Int` that are not within the bounds
-	/// of the `bool` are being ignored.
-	///
-	/// # Note
-	///
-	/// - Basically this returns `true` if the least significant
-	///   bit of this `Int` is `1` and `false` otherwise.
-	pub fn resize_to_bool(&self) -> bool {
-		self.value.resize_to_bool()
-	}
+    /// Resizes this `Int` to a `bool` primitive type.
+    ///
+    /// Bits in this `Int` that are not within the bounds
+    /// of the `bool` are being ignored.
+    ///
+    /// # Note
+    ///
+    /// - Basically this returns `true` if the least significant
+    ///   bit of this `Int` is `1` and `false` otherwise.
+    pub fn resize_to_bool(&self) -> bool {
+        self.value.resize_to_bool()
+    }
 
-	/// Resizes this `Int` to a `i8` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `8` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i8(&self) -> i8 {
-		self.value.resize_to_i8()
-	}
+    /// Resizes this `Int` to a `i8` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `8` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i8(&self) -> i8 {
+        self.value.resize_to_i8()
+    }
 
-	/// Resizes this `Int` to a `i16` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `16` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i16(&self) -> i16 {
-		self.value.resize_to_i16()
-	}
+    /// Resizes this `Int` to a `i16` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `16` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i16(&self) -> i16 {
+        self.value.resize_to_i16()
+    }
 
-	/// Resizes this `Int` to a `i32` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `32` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i32(&self) -> i32 {
-		self.value.resize_to_i32()
-	}
+    /// Resizes this `Int` to a `i32` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `32` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i32(&self) -> i32 {
+        self.value.resize_to_i32()
+    }
 
-	/// Resizes this `Int` to a `i64` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `64` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i64(&self) -> i64 {
-		self.value.resize_to_i64()
-	}
+    /// Resizes this `Int` to a `i64` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `64` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i64(&self) -> i64 {
+        self.value.resize_to_i64()
+    }
 
-	/// Resizes this `Int` to a `i128` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `128` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_i128(&self) -> i128 {
-		self.value.resize_to_i128()
-	}
+    /// Resizes this `Int` to a `i128` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `128` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_i128(&self) -> i128 {
+        self.value.resize_to_i128()
+    }
 }
 
 /// # To Primitive (Try-Cast)
 impl Int {
-	/// Tries to represent the value of this `Int` as a `bool`.
-	///
-	/// # Note
-	///
-	/// This returns `true` if the value represented by this `Int`
-	/// is `1`, returns `false` if the value represented by this
-	/// `Int` is `0` and returns an error otherwise.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `bool`.
-	pub fn try_to_bool(&self) -> Result<bool> {
-		self.value.try_to_bool()
-	}
+    /// Tries to represent the value of this `Int` as a `bool`.
+    ///
+    /// # Note
+    ///
+    /// This returns `true` if the value represented by this `Int`
+    /// is `1`, returns `false` if the value represented by this
+    /// `Int` is `0` and returns an error otherwise.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `bool`.
+    pub fn try_to_bool(&self) -> Result<bool> {
+        self.value.try_to_bool()
+    }
 
-	/// Tries to represent the value of this `Int` as a `i8`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `Int` does not exceed the maximum value of `i8`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `u8`.
-	pub fn try_to_i8(&self) -> Result<i8> {
-		self.value.try_to_i8()
-	}
+    /// Tries to represent the value of this `Int` as a `i8`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `Int` does not exceed the maximum value of `i8`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `u8`.
+    pub fn try_to_i8(&self) -> Result<i8> {
+        self.value.try_to_i8()
+    }
 
-	/// Tries to represent the value of this `Int` as a `i16`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `Int` does not exceed the maximum value of `i16`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `i16`.
-	pub fn try_to_i16(&self) -> Result<i16> {
-		self.value.try_to_i16()
-	}
+    /// Tries to represent the value of this `Int` as a `i16`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `Int` does not exceed the maximum value of `i16`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `i16`.
+    pub fn try_to_i16(&self) -> Result<i16> {
+        self.value.try_to_i16()
+    }
 
-	/// Tries to represent the value of this `Int` as a `i32`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `Int` does not exceed the maximum value of `i32`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `i32`.
-	pub fn try_to_i32(&self) -> Result<i32> {
-		self.value.try_to_i32()
-	}
+    /// Tries to represent the value of this `Int` as a `i32`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `Int` does not exceed the maximum value of `i32`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `i32`.
+    pub fn try_to_i32(&self) -> Result<i32> {
+        self.value.try_to_i32()
+    }
 
-	/// Tries to represent the value of this `Int` as a `i64`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `Int` does not exceed the maximum value of `i64`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `i64`.
-	pub fn try_to_i64(&self) -> Result<i64> {
-		self.value.try_to_i64()
-	}
+    /// Tries to represent the value of this `Int` as a `i64`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `Int` does not exceed the maximum value of `i64`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `i64`.
+    pub fn try_to_i64(&self) -> Result<i64> {
+        self.value.try_to_i64()
+    }
 
-	/// Tries to represent the value of this `Int` as a `i128`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `Int` does not exceed the maximum value of `i128`.
-	///
-	/// # Complexity
-	///
-	/// - 𝒪(n) where n is the number of digits of this `Int`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `Int` can not be
-	///   represented by a `i128`.
-	pub fn try_to_i128(&self) -> Result<i128> {
-		self.value.try_to_i128()
-	}
+    /// Tries to represent the value of this `Int` as a `i128`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `Int` does not exceed the maximum value of `i128`.
+    ///
+    /// # Complexity
+    ///
+    /// - 𝒪(n) where n is the number of digits of this `Int`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `Int` can not be
+    ///   represented by a `i128`.
+    pub fn try_to_i128(&self) -> Result<i128> {
+        self.value.try_to_i128()
+    }
 }
 
 /// # Shifts
 impl Int {
-   	/// Shift this `Int` left by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `Int`.
-	pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		self.value.wrapping_shl_assign(shift_amount)
-	}
+    /// Shift this `Int` left by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `Int`.
+    pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        self.value.wrapping_shl_assign(shift_amount)
+    }
 
-	/// Shift this `Int` left by the given `shift_amount` bits and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `Int`.
-	pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<Int>
-		where S: Into<ShiftAmount>
-	{
-		self.value.into_wrapping_shl(shift_amount).map(Int::from)
-	}
+    /// Shift this `Int` left by the given `shift_amount` bits and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `Int`.
+    pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<Int>
+        where S: Into<ShiftAmount>
+    {
+        self.value.into_wrapping_shl(shift_amount).map(Int::from)
+    }
 
-	/// Right-shifts this `Int` by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `Int`.
-	pub fn wrapping_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		self.value.wrapping_ashr_assign(shift_amount)
-	}
+    /// Right-shifts this `Int` by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `Int`.
+    pub fn wrapping_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        self.value.wrapping_ashr_assign(shift_amount)
+    }
 
-	/// Right-shifts this `Int` by the given `shift_amount` bits
-	/// and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `Int`.
-	pub fn into_wrapping_shr<S>(self, shift_amount: S) -> Result<Int>
-		where S: Into<ShiftAmount>
-	{
-		self.value.into_wrapping_ashr(shift_amount).map(Int::from)
-	}
+    /// Right-shifts this `Int` by the given `shift_amount` bits
+    /// and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `Int`.
+    pub fn into_wrapping_shr<S>(self, shift_amount: S) -> Result<Int>
+        where S: Into<ShiftAmount>
+    {
+        self.value.into_wrapping_ashr(shift_amount).map(Int::from)
+    }
 }
 
 impl<S> Shl<S> for Int
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	type Output = Int;
+    type Output = Int;
 
-	fn shl(self, shift_amount: S) -> Self::Output {
-		self.into_wrapping_shl(shift_amount).unwrap()
-	}
+    fn shl(self, shift_amount: S) -> Self::Output {
+        self.into_wrapping_shl(shift_amount).unwrap()
+    }
 }
 
 impl<S> Shr<S> for Int
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	type Output = Int;
+    type Output = Int;
 
-	fn shr(self, shift_amount: S) -> Self::Output {
-		self.into_wrapping_shr(shift_amount).unwrap()
-	}
+    fn shr(self, shift_amount: S) -> Self::Output {
+        self.into_wrapping_shr(shift_amount).unwrap()
+    }
 }
 
 impl<S> ShlAssign<S> for Int
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	fn shl_assign(&mut self, shift_amount: S) {
-		self.wrapping_shl_assign(shift_amount).unwrap()
-	}
+    fn shl_assign(&mut self, shift_amount: S) {
+        self.wrapping_shl_assign(shift_amount).unwrap()
+    }
 }
 
 impl<S> ShrAssign<S> for Int
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	fn shr_assign(&mut self, shift_amount: S) {
-		self.wrapping_shr_assign(shift_amount).unwrap()
-	}
+    fn shr_assign(&mut self, shift_amount: S) {
+        self.wrapping_shr_assign(shift_amount).unwrap()
+    }
 }
 
 /// # Random Utilities using `rand` crate.
 #[cfg(feature = "rand_support")]
 impl Int {
-	/// Creates a new `Int` with the given `BitWidth` and random `Digit`s.
-	pub fn random_with_width(width: BitWidth) -> Int {
-		Int::from(ApInt::random_with_width(width))
-	}
+    /// Creates a new `Int` with the given `BitWidth` and random `Digit`s.
+    pub fn random_with_width(width: BitWidth) -> Int {
+        Int::from(ApInt::random_with_width(width))
+    }
 
-	/// Creates a new `Int` with the given `BitWidth` and random `Digit`s
-	/// using the given random number generator.
-	/// 
-	/// **Note:** This is useful for cryptographic or testing purposes.
-	pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> Int
-		where R: rand::Rng
-	{
-		Int::from(ApInt::random_with_width_using(width, rng))
-	}
+    /// Creates a new `Int` with the given `BitWidth` and random `Digit`s
+    /// using the given random number generator.
+    /// 
+    /// **Note:** This is useful for cryptographic or testing purposes.
+    pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> Int
+        where R: rand::Rng
+    {
+        Int::from(ApInt::random_with_width_using(width, rng))
+    }
 
-	/// Randomizes the digits of this `Int` inplace.
-	/// 
-	/// This won't change its `BitWidth`.
-	pub fn randomize(&mut self) {
-		self.value.randomize()
-	}
+    /// Randomizes the digits of this `Int` inplace.
+    /// 
+    /// This won't change its `BitWidth`.
+    pub fn randomize(&mut self) {
+        self.value.randomize()
+    }
 
-	/// Randomizes the digits of this `Int` inplace using the given
-	/// random number generator.
-	/// 
-	/// This won't change its `BitWidth`.
-	pub fn randomize_using<R>(&mut self, rng: &mut R)
-		where R: rand::Rng
-	{
-		self.value.randomize_using(rng)
-	}
+    /// Randomizes the digits of this `Int` inplace using the given
+    /// random number generator.
+    /// 
+    /// This won't change its `BitWidth`.
+    pub fn randomize_using<R>(&mut self, rng: &mut R)
+        where R: rand::Rng
+    {
+        self.value.randomize_using(rng)
+    }
 }
 
 impl Int {
-	/// Assigns `rhs` to this `Int`.
-	///
-	/// This mutates digits and may affect the bitwidth of `self`
-	/// which **might result in an expensive operations**.
-	///
-	/// After this operation `rhs` and `self` are equal to each other.
-	pub fn assign(&mut self, rhs: &Int) {
-		self.value.assign(&rhs.value)
-	}
+    /// Assigns `rhs` to this `Int`.
+    ///
+    /// This mutates digits and may affect the bitwidth of `self`
+    /// which **might result in an expensive operations**.
+    ///
+    /// After this operation `rhs` and `self` are equal to each other.
+    pub fn assign(&mut self, rhs: &Int) {
+        self.value.assign(&rhs.value)
+    }
 
-	/// Strictly assigns `rhs` to this `Int`.
-	/// 
-	/// After this operation `rhs` and `self` are equal to each other.
-	/// 
-	/// **Note:** Strict assigns protect against mutating the bit width
-	/// of `self` and thus return an error instead of executing a probably
-	/// expensive `assign` operation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `rhs` and `self` have unmatching bit widths.
-	pub fn strict_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.strict_assign(&rhs.value)
-	}
+    /// Strictly assigns `rhs` to this `Int`.
+    /// 
+    /// After this operation `rhs` and `self` are equal to each other.
+    /// 
+    /// **Note:** Strict assigns protect against mutating the bit width
+    /// of `self` and thus return an error instead of executing a probably
+    /// expensive `assign` operation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `rhs` and `self` have unmatching bit widths.
+    pub fn strict_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.strict_assign(&rhs.value)
+    }
 }
 
 /// # Casting: Truncation & Extension
 impl Int {
-	/// Tries to truncate this `Int` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`truncate`](struct.Int.html#method.truncate).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn into_truncate<W>(self, target_width: W) -> Result<Int>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, Int::truncate)
-	}
+    /// Tries to truncate this `Int` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`truncate`](struct.Int.html#method.truncate).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn into_truncate<W>(self, target_width: W) -> Result<Int>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, Int::truncate)
+    }
 
-	/// Tries to truncate this `Int` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		self.value.truncate(target_width)
-	}
+    /// Tries to truncate this `Int` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        self.value.truncate(target_width)
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Tries to zero-extend this `Int` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`extend`](struct.Int.html#method.extend).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn into_extend<W>(self, target_width: W) -> Result<Int>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, Int::extend)
-	}
+    /// Tries to zero-extend this `Int` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`extend`](struct.Int.html#method.extend).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn into_extend<W>(self, target_width: W) -> Result<Int>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, Int::extend)
+    }
 
-	/// Tries to extend this `Int` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn extend<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		self.value.sign_extend(target_width)
-	}
+    /// Tries to extend this `Int` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn extend<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        self.value.sign_extend(target_width)
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Resizes this `Int` to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`resize`](struct.Int.html#method.resize).
-	pub fn into_resize<W>(self, target_width: W) -> Int
-		where W: Into<BitWidth>
-	{
-		forward_bin_mut_impl(self, target_width, Int::resize)
-	}
+    /// Resizes this `Int` to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`resize`](struct.Int.html#method.resize).
+    pub fn into_resize<W>(self, target_width: W) -> Int
+        where W: Into<BitWidth>
+    {
+        forward_bin_mut_impl(self, target_width, Int::resize)
+    }
 
-	/// Resizes the given `Int` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// This operation will forward to
-	/// 
-	/// - [`truncate`](struct.Int.html#method.truncate)
-	///   if `target_width` is less than or equal to the width of
-	///   the given `Int`
-	/// - [`extend`](struct.Int.html#method.extend)
-	///   otherwise
-	pub fn resize<W>(&mut self, target_width: W)
-		where W: Into<BitWidth>
-	{
-		self.value.sign_resize(target_width)
-	}
+    /// Resizes the given `Int` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// This operation will forward to
+    /// 
+    /// - [`truncate`](struct.Int.html#method.truncate)
+    ///   if `target_width` is less than or equal to the width of
+    ///   the given `Int`
+    /// - [`extend`](struct.Int.html#method.extend)
+    ///   otherwise
+    pub fn resize<W>(&mut self, target_width: W)
+        where W: Into<BitWidth>
+    {
+        self.value.sign_resize(target_width)
+    }
 }
 
 /// # Bitwise Operations
 impl Int {
-	/// Flips all bits of `self` and returns the result.
-	pub fn into_bitnot(self) -> Self {
-		forward_mut_impl(self, Int::bitnot)
-	}
+    /// Flips all bits of `self` and returns the result.
+    pub fn into_bitnot(self) -> Self {
+        forward_mut_impl(self, Int::bitnot)
+    }
 
-	/// Flip all bits of this `Int` inplace.
-	pub fn bitnot(&mut self) {
-		self.value.bitnot()
-	}
+    /// Flip all bits of this `Int` inplace.
+    pub fn bitnot(&mut self) {
+        self.value.bitnot()
+    }
 
-	/// Tries to bit-and assign this `Int` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitand(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::bitand_assign)
-	}
+    /// Tries to bit-and assign this `Int` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitand(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::bitand_assign)
+    }
 
-	/// Bit-and assigns all bits of this `Int` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitand_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.bitand_assign(&rhs.value)
-	}
+    /// Bit-and assigns all bits of this `Int` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitand_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.bitand_assign(&rhs.value)
+    }
 
-	/// Tries to bit-and assign this `Int` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitor(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::bitor_assign)
-	}
+    /// Tries to bit-and assign this `Int` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitor(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::bitor_assign)
+    }
 
-	/// Bit-or assigns all bits of this `Int` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitor_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.bitor_assign(&rhs.value)
-	}
+    /// Bit-or assigns all bits of this `Int` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitor_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.bitor_assign(&rhs.value)
+    }
 
-	/// Tries to bit-xor assign this `Int` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitxor(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::bitxor_assign)
-	}
+    /// Tries to bit-xor assign this `Int` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitxor(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::bitxor_assign)
+    }
 
-	/// Bit-xor assigns all bits of this `Int` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitxor_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.bitxor_assign(&rhs.value)
-	}
+    /// Bit-xor assigns all bits of this `Int` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitxor_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.bitxor_assign(&rhs.value)
+    }
 }
 
 /// # Bitwise Access
 impl Int {
-	/// Returns the bit at the given bit position `pos`.
-	/// 
-	/// This returns
-	/// 
-	/// - `Bit::Set` if the bit at `pos` is `1`
-	/// - `Bit::Unset` otherwise
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `Int`.
-	pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
-		where P: Into<BitPos>
-	{
-		self.value.get_bit_at(pos)
-	}
+    /// Returns the bit at the given bit position `pos`.
+    /// 
+    /// This returns
+    /// 
+    /// - `Bit::Set` if the bit at `pos` is `1`
+    /// - `Bit::Unset` otherwise
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `Int`.
+    pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
+        where P: Into<BitPos>
+    {
+        self.value.get_bit_at(pos)
+    }
 
-	/// Sets the bit at the given bit position `pos` to one (`1`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `Int`.
-	pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.set_bit_at(pos)
-	}
+    /// Sets the bit at the given bit position `pos` to one (`1`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `Int`.
+    pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.set_bit_at(pos)
+    }
 
-	/// Sets the bit at the given bit position `pos` to zero (`0`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `Int`.
-	pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.unset_bit_at(pos)
-	}
+    /// Sets the bit at the given bit position `pos` to zero (`0`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `Int`.
+    pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.unset_bit_at(pos)
+    }
 
-	/// Flips the bit at the given bit position `pos`.
-	/// 
-	/// # Note
-	/// 
-	/// - If the bit at the given position was `0` it will be `1`
-	///   after this operation and vice versa.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `Int`.
-	pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.flip_bit_at(pos)
-	}
+    /// Flips the bit at the given bit position `pos`.
+    /// 
+    /// # Note
+    /// 
+    /// - If the bit at the given position was `0` it will be `1`
+    ///   after this operation and vice versa.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `Int`.
+    pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.flip_bit_at(pos)
+    }
 
-	/// Sets all bits of this `Int` to one (`1`).
-	pub fn set_all(&mut self) {
-		self.value.set_all()
-	}
+    /// Sets all bits of this `Int` to one (`1`).
+    pub fn set_all(&mut self) {
+        self.value.set_all()
+    }
 
-	/// Returns `true` if all bits in this `Int` are set.
-	pub fn is_all_set(&self) -> bool {
-		self.value.is_all_set()
-	}
+    /// Returns `true` if all bits in this `Int` are set.
+    pub fn is_all_set(&self) -> bool {
+        self.value.is_all_set()
+    }
 
-	/// Sets all bits of this `Int` to zero (`0`).
-	pub fn unset_all(&mut self) {
-		self.value.unset_all()
-	}
+    /// Sets all bits of this `Int` to zero (`0`).
+    pub fn unset_all(&mut self) {
+        self.value.unset_all()
+    }
 
-	/// Returns `true` if all bits in this `Int` are unset.
-	pub fn is_all_unset(&self) -> bool {
-		self.value.is_all_unset()
-	}
+    /// Returns `true` if all bits in this `Int` are unset.
+    pub fn is_all_unset(&self) -> bool {
+        self.value.is_all_unset()
+    }
 
-	/// Flips all bits of this `Int`.
-	pub fn flip_all(&mut self) {
-		self.value.flip_all()
-	}
+    /// Flips all bits of this `Int`.
+    pub fn flip_all(&mut self) {
+        self.value.flip_all()
+    }
 
-	/// Returns the sign bit of this `Int`.
-	/// 
-	/// **Note:** This is equal to the most significant bit of this `Int`.
-	pub fn sign_bit(&self) -> Bit {
-		self.value.sign_bit()
-	}
+    /// Returns the sign bit of this `Int`.
+    /// 
+    /// **Note:** This is equal to the most significant bit of this `Int`.
+    pub fn sign_bit(&self) -> Bit {
+        self.value.sign_bit()
+    }
 
-	/// Sets the sign bit of this `Int` to one (`1`).
-	pub fn set_sign_bit(&mut self) {
-		self.value.set_sign_bit()
-	}
+    /// Sets the sign bit of this `Int` to one (`1`).
+    pub fn set_sign_bit(&mut self) {
+        self.value.set_sign_bit()
+    }
 
-	/// Sets the sign bit of this `Int` to zero (`0`).
-	pub fn unset_sign_bit(&mut self) {
-		self.value.unset_sign_bit()
-	}
+    /// Sets the sign bit of this `Int` to zero (`0`).
+    pub fn unset_sign_bit(&mut self) {
+        self.value.unset_sign_bit()
+    }
 
-	/// Flips the sign bit of this `Int`.
-	/// 
-	/// # Note
-	/// 
-	/// - If the sign bit was `0` it will be `1` after this operation and vice versa.
-	/// - Depending on the interpretation of the `Int` this
-	///   operation changes its signedness.
-	pub fn flip_sign_bit(&mut self) {
-		self.value.flip_sign_bit()
-	}
+    /// Flips the sign bit of this `Int`.
+    /// 
+    /// # Note
+    /// 
+    /// - If the sign bit was `0` it will be `1` after this operation and vice versa.
+    /// - Depending on the interpretation of the `Int` this
+    ///   operation changes its signedness.
+    pub fn flip_sign_bit(&mut self) {
+        self.value.flip_sign_bit()
+    }
 }
 
 /// # Bitwise utility methods.
 impl Int {
-	/// Returns the number of ones in the binary representation of this `Int`.
-	pub fn count_ones(&self) -> usize {
-		self.value.count_ones()
-	}
+    /// Returns the number of ones in the binary representation of this `Int`.
+    pub fn count_ones(&self) -> usize {
+        self.value.count_ones()
+    }
 
-	/// Returns the number of zeros in the binary representation of this `Int`.
-	pub fn count_zeros(&self) -> usize {
-		self.value.count_zeros()
-	}
+    /// Returns the number of zeros in the binary representation of this `Int`.
+    pub fn count_zeros(&self) -> usize {
+        self.value.count_zeros()
+    }
 
-	/// Returns the number of leading zeros in the binary representation of this `Int`.
-	pub fn leading_zeros(&self) -> usize {
-		self.value.leading_zeros()
-	}
+    /// Returns the number of leading zeros in the binary representation of this `Int`.
+    pub fn leading_zeros(&self) -> usize {
+        self.value.leading_zeros()
+    }
 
-	/// Returns the number of trailing zeros in the binary representation of this `Int`.
-	pub fn trailing_zeros(&self) -> usize {
-		self.value.trailing_zeros()
-	}
+    /// Returns the number of trailing zeros in the binary representation of this `Int`.
+    pub fn trailing_zeros(&self) -> usize {
+        self.value.trailing_zeros()
+    }
 }
 
 //  ===========================================================================
@@ -1029,11 +1027,11 @@ impl Int {
 //  ===========================================================================
 
 impl Not for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn not(self) -> Self::Output {
-		forward_mut_impl(self, Int::bitnot)
-	}
+    fn not(self) -> Self::Output {
+        forward_mut_impl(self, Int::bitnot)
+    }
 }
 
 //  ===========================================================================
@@ -1041,27 +1039,27 @@ impl Not for Int {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitand(self, rhs: &'a Int) -> Self::Output {
-		self.into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a Int) -> Self::Output {
+        self.into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitand(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a Int> for &'b mut Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitand(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -1069,27 +1067,27 @@ impl<'a, 'b> BitAnd<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitor(self, rhs: &'a Int) -> Self::Output {
-		self.into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a Int) -> Self::Output {
+        self.into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitor(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a Int> for &'b mut Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitor(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -1097,27 +1095,27 @@ impl<'a, 'b> BitOr<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitxor(self, rhs: &'a Int) -> Self::Output {
-		self.into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a Int) -> Self::Output {
+        self.into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitxor(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a Int> for &'b mut Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn bitxor(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -1125,176 +1123,176 @@ impl<'a, 'b> BitXor<&'a Int> for &'b mut Int {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a Int> for Int {
-	fn bitand_assign(&mut self, rhs: &'a Int) {
-		self.bitand_assign(rhs).unwrap();
-	}
+    fn bitand_assign(&mut self, rhs: &'a Int) {
+        self.bitand_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitOrAssign<&'a Int> for Int {
-	fn bitor_assign(&mut self, rhs: &'a Int) {
-		self.bitor_assign(rhs).unwrap();
-	}
+    fn bitor_assign(&mut self, rhs: &'a Int) {
+        self.bitor_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitXorAssign<&'a Int> for Int {
-	fn bitxor_assign(&mut self, rhs: &'a Int) {
-		self.bitxor_assign(rhs).unwrap();
-	}
+    fn bitxor_assign(&mut self, rhs: &'a Int) {
+        self.bitxor_assign(rhs).unwrap();
+    }
 }
 
 /// # Arithmetic Operations
 impl Int {
-	/// Negates this `Int` inplace and returns the result.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	pub fn into_wrapping_neg(self) -> Int {
-		forward_mut_impl(self, Int::wrapping_neg)
-	}
+    /// Negates this `Int` inplace and returns the result.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    pub fn into_wrapping_neg(self) -> Int {
+        forward_mut_impl(self, Int::wrapping_neg)
+    }
 
-	/// Negates this `Int` inplace.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	pub fn wrapping_neg(&mut self) {
-		self.value.wrapping_neg()
-	}
+    /// Negates this `Int` inplace.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    pub fn wrapping_neg(&mut self) {
+        self.value.wrapping_neg()
+    }
 
-	/// Adds `rhs` to `self` and returns the result.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_add(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::wrapping_add_assign)
-	}
+    /// Adds `rhs` to `self` and returns the result.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_add(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::wrapping_add_assign)
+    }
 
-	/// Add-assigns `rhs` to `self` inplace.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_add_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.wrapping_add_assign(&rhs.value)
-	}
+    /// Add-assigns `rhs` to `self` inplace.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_add_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.wrapping_add_assign(&rhs.value)
+    }
 
-	/// Subtracts `rhs` from `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_sub(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::wrapping_sub_assign)
-	}
+    /// Subtracts `rhs` from `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_sub(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::wrapping_sub_assign)
+    }
 
-	/// Subtract-assigns `rhs` from `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_sub_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.wrapping_sub_assign(&rhs.value)
-	}
+    /// Subtract-assigns `rhs` from `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_sub_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.wrapping_sub_assign(&rhs.value)
+    }
 
-	/// Subtracts `rhs` from `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_mul(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::wrapping_mul_assign)
-	}
+    /// Subtracts `rhs` from `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_mul(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::wrapping_mul_assign)
+    }
 
-	/// Multiply-assigns `rhs` to `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_mul_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.wrapping_mul_assign(&rhs.value)
-	}
+    /// Multiply-assigns `rhs` to `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_mul_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.wrapping_mul_assign(&rhs.value)
+    }
 
-	/// Divides `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_div(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::wrapping_div_assign)
-	}
+    /// Divides `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_div(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::wrapping_div_assign)
+    }
 
-	/// Assignes `self` to the division of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_div_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.wrapping_sdiv_assign(&rhs.value)
-	}
+    /// Assignes `self` to the division of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_div_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.wrapping_sdiv_assign(&rhs.value)
+    }
 
-	/// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_rem(self, rhs: &Int) -> Result<Int> {
-		try_forward_bin_mut_impl(self, rhs, Int::wrapping_rem_assign)
-	}
+    /// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_rem(self, rhs: &Int) -> Result<Int> {
+        try_forward_bin_mut_impl(self, rhs, Int::wrapping_rem_assign)
+    }
 
-	/// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_rem_assign(&mut self, rhs: &Int) -> Result<()> {
-		self.value.wrapping_srem_assign(&rhs.value)
-	}
+    /// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_rem_assign(&mut self, rhs: &Int) -> Result<()> {
+        self.value.wrapping_srem_assign(&rhs.value)
+    }
 }
 
 // ============================================================================
@@ -1302,28 +1300,28 @@ impl Int {
 // ============================================================================
 
 impl Neg for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn neg(self) -> Self::Output {
-		self.into_wrapping_neg()
-	}
+    fn neg(self) -> Self::Output {
+        self.into_wrapping_neg()
+    }
 }
 
 impl<'a> Neg for &'a Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn neg(self) -> Self::Output {
-		self.clone().into_wrapping_neg()
-	}
+    fn neg(self) -> Self::Output {
+        self.clone().into_wrapping_neg()
+    }
 }
 
 impl<'a> Neg for &'a mut Int {
-	type Output = &'a mut Int;
+    type Output = &'a mut Int;
 
-	fn neg(self) -> Self::Output {
-		self.wrapping_neg();
-		self
-	}
+    fn neg(self) -> Self::Output {
+        self.wrapping_neg();
+        self
+    }
 }
 
 // ============================================================================
@@ -1331,25 +1329,25 @@ impl<'a> Neg for &'a mut Int {
 // ============================================================================
 
 impl<'a> Add<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn add(self, rhs: &'a Int) -> Self::Output {
-		self.into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a Int) -> Self::Output {
+        self.into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Add<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn add(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a> AddAssign<&'a Int> for Int {
-	fn add_assign(&mut self, rhs: &'a Int) {
-		self.wrapping_add_assign(rhs).unwrap()
-	}
+    fn add_assign(&mut self, rhs: &'a Int) {
+        self.wrapping_add_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -1357,25 +1355,25 @@ impl<'a> AddAssign<&'a Int> for Int {
 // ============================================================================
 
 impl<'a> Sub<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn sub(self, rhs: &'a Int) -> Self::Output {
-		self.into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a Int) -> Self::Output {
+        self.into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Sub<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn sub(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a> SubAssign<&'a Int> for Int {
-	fn sub_assign(&mut self, rhs: &'a Int) {
-		self.wrapping_sub_assign(rhs).unwrap()
-	}
+    fn sub_assign(&mut self, rhs: &'a Int) {
+        self.wrapping_sub_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -1383,25 +1381,25 @@ impl<'a> SubAssign<&'a Int> for Int {
 // ============================================================================
 
 impl<'a> Mul<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn mul(self, rhs: &'a Int) -> Self::Output {
-		self.into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a Int) -> Self::Output {
+        self.into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Mul<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn mul(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a> MulAssign<&'a Int> for Int {
-	fn mul_assign(&mut self, rhs: &'a Int) {
-		self.wrapping_mul_assign(rhs).unwrap();
-	}
+    fn mul_assign(&mut self, rhs: &'a Int) {
+        self.wrapping_mul_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1409,25 +1407,25 @@ impl<'a> MulAssign<&'a Int> for Int {
 // ============================================================================
 
 impl<'a> Div<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn div(self, rhs: &'a Int) -> Self::Output {
-		self.into_wrapping_div(rhs).unwrap()
-	}
+    fn div(self, rhs: &'a Int) -> Self::Output {
+        self.into_wrapping_div(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Div<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn div(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_wrapping_div(rhs).unwrap()
-	}
+    fn div(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_wrapping_div(rhs).unwrap()
+    }
 }
 
 impl<'a> DivAssign<&'a Int> for Int {
-	fn div_assign(&mut self, rhs: &'a Int) {
-		self.wrapping_div_assign(rhs).unwrap();
-	}
+    fn div_assign(&mut self, rhs: &'a Int) {
+        self.wrapping_div_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1435,25 +1433,25 @@ impl<'a> DivAssign<&'a Int> for Int {
 // ============================================================================
 
 impl<'a> Rem<&'a Int> for Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn rem(self, rhs: &'a Int) -> Self::Output {
-		self.into_wrapping_rem(rhs).unwrap()
-	}
+    fn rem(self, rhs: &'a Int) -> Self::Output {
+        self.into_wrapping_rem(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Rem<&'a Int> for &'b Int {
-	type Output = Int;
+    type Output = Int;
 
-	fn rem(self, rhs: &'a Int) -> Self::Output {
-		self.clone().into_wrapping_rem(rhs).unwrap()
-	}
+    fn rem(self, rhs: &'a Int) -> Self::Output {
+        self.clone().into_wrapping_rem(rhs).unwrap()
+    }
 }
 
 impl<'a> RemAssign<&'a Int> for Int {
-	fn rem_assign(&mut self, rhs: &'a Int) {
-		self.wrapping_rem_assign(rhs).unwrap();
-	}
+    fn rem_assign(&mut self, rhs: &'a Int) {
+        self.wrapping_rem_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1463,25 +1461,25 @@ impl<'a> RemAssign<&'a Int> for Int {
 use std::fmt;
 
 impl fmt::Binary for Int {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::Octal for Int {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::LowerHex for Int {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::UpperHex for Int {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -14,9 +14,9 @@ use digit;
 ///   carry of this addition after the carry-add computation.
 #[inline]
 pub(crate) fn carry_add(a: Digit, b: Digit, carry: &mut Digit) -> Digit {
-	let (hi, lo) = (a.dd() + b.dd() + carry.dd()).hi_lo();
-	*carry = hi;
-	lo
+    let (hi, lo) = (a.dd() + b.dd() + carry.dd()).hi_lo();
+    *carry = hi;
+    lo
 }
 
 /// Returns the result of a borrow-sub between `a` and `b` with
@@ -33,7 +33,7 @@ pub(crate) fn carry_add(a: Digit, b: Digit, carry: &mut Digit) -> Digit {
 ///   after the borrow-sub computation.
 #[inline]
 pub(crate) fn borrow_sub(a: Digit, b: Digit, borrow: &mut Digit) -> Digit {
-	let (hi, lo) = (digit::BASE + a.dd() - b.dd() - borrow.dd()).hi_lo();
+    let (hi, lo) = (digit::BASE + a.dd() - b.dd() - borrow.dd()).hi_lo();
 
     // This is the actual computation:
     //
@@ -41,8 +41,8 @@ pub(crate) fn borrow_sub(a: Digit, b: Digit, borrow: &mut Digit) -> Digit {
     // The hi part then is the borrow for the next pair of Digits
     // whereas the lo part is the actual wrapped result.
     // 
-	//     hi * (base) + lo        ==    1 * (base) + ai - bi - borrow
-	// =>  a_i - b_i - borrow < 0   <==>   hi == 0
+    //     hi * (base) + lo        ==    1 * (base) + ai - bi - borrow
+    // =>  a_i - b_i - borrow < 0   <==>   hi == 0
 
     *borrow = if hi == Digit::zero() { Digit::one() } else { Digit::zero() };
     lo

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -19,108 +19,108 @@ use errors::{Error, Result};
 pub struct Radix(u8);
 
 impl Radix {
-	/// The minimum supported radix is the binary that has only `0` and `1` in its alphabet.
-	const MIN: u8 =  2;
-	/// The maximum supported radix is the 36-ary that has an alphabet containing `0..9` and `a..z`.
-	const MAX: u8 = 36;
+    /// The minimum supported radix is the binary that has only `0` and `1` in its alphabet.
+    const MIN: u8 =  2;
+    /// The maximum supported radix is the 36-ary that has an alphabet containing `0..9` and `a..z`.
+    const MAX: u8 = 36;
 
-	/// Create a new `Radix` from the given `u8`.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given value is not within the valid radix range of `2..36`.
-	#[inline]
-	pub fn new(radix: u8) -> Result<Radix> {
-		if !(Radix::MIN <= radix && radix <= Radix::MAX) {
-			return Err(Error::invalid_radix(radix))
-		}
-		Ok(Radix(radix))
-	}
+    /// Create a new `Radix` from the given `u8`.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given value is not within the valid radix range of `2..36`.
+    #[inline]
+    pub fn new(radix: u8) -> Result<Radix> {
+        if !(Radix::MIN <= radix && radix <= Radix::MAX) {
+            return Err(Error::invalid_radix(radix))
+        }
+        Ok(Radix(radix))
+    }
 
-	/// Returns the `u8` representation of this `Radix`.
-	#[inline]
-	pub fn to_u8(self) -> u8 {
-		self.0
-	}
+    /// Returns the `u8` representation of this `Radix`.
+    #[inline]
+    pub fn to_u8(self) -> u8 {
+        self.0
+    }
 
-	/// Returns `true` if the given byte is a valid ascii representation for this `Radix`
-	/// and `false` otherwise.
-	#[inline]
-	pub(crate) fn is_valid_byte(self, byte: u8) -> bool {
-		byte < self.to_u8()
-	}
+    /// Returns `true` if the given byte is a valid ascii representation for this `Radix`
+    /// and `false` otherwise.
+    #[inline]
+    pub(crate) fn is_valid_byte(self, byte: u8) -> bool {
+        byte < self.to_u8()
+    }
 
-	/// Returns `true` if the number represenatation of this `Radix` is a power of two
-	/// and `false` otherwise.
-	#[inline]
-	pub(crate) fn is_power_of_two(self) -> bool {
-		self.to_u8().is_power_of_two()
-	}
+    /// Returns `true` if the number represenatation of this `Radix` is a power of two
+    /// and `false` otherwise.
+    #[inline]
+    pub(crate) fn is_power_of_two(self) -> bool {
+        self.to_u8().is_power_of_two()
+    }
 
-	/// Returns the number of bits required to store a single digit with this `Radix`.
-	/// 
-	/// This is equivalent to the logarithm of base 2 for this `Radix`.
-	/// 
-	/// # Example
-	/// 
-	/// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
-	/// stored in `1` bit each.
-	/// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
-	/// requires `4` bits to be stored.
-	/// 
-	/// Note: This is only valid for `Radix` instances that represent a radix
-	///       that are a power of two.
-	#[inline]
-	pub(crate) fn bits_per_digit(self) -> usize {
-		assert!(self.is_power_of_two());
-		fn find_last_bit_set(val: u8) -> usize {
-			::std::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
-		}
-		find_last_bit_set(self.to_u8()) - 1
-	}
+    /// Returns the number of bits required to store a single digit with this `Radix`.
+    /// 
+    /// This is equivalent to the logarithm of base 2 for this `Radix`.
+    /// 
+    /// # Example
+    /// 
+    /// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
+    /// stored in `1` bit each.
+    /// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
+    /// requires `4` bits to be stored.
+    /// 
+    /// Note: This is only valid for `Radix` instances that represent a radix
+    ///       that are a power of two.
+    #[inline]
+    pub(crate) fn bits_per_digit(self) -> usize {
+        assert!(self.is_power_of_two());
+        fn find_last_bit_set(val: u8) -> usize {
+            ::std::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
+        }
+        find_last_bit_set(self.to_u8()) - 1
+    }
 
-	/// Returns the exact number of bits required to store a single digit
-	/// with this `Radix` if possible; else `None` is returned.
-	/// 
-	/// # Example
-	/// 
-	/// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
-	/// stored in `1` bit each.
-	/// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
-	/// requires `4` bits to be stored.
-	/// For a decimal `Radix` (`= 10`) digits `None` is returned.
-	/// 
-	/// Note: This always returns `None` for `Radix` instances that are a
-	///       power of two.
-	#[inline]
-	pub(crate) fn exact_bits_per_digit(self) -> Option<usize> {
-		if self.is_power_of_two() {
-			Some(self.bits_per_digit())
-		}
-		else {
-			None
-		}
-	}
+    /// Returns the exact number of bits required to store a single digit
+    /// with this `Radix` if possible; else `None` is returned.
+    /// 
+    /// # Example
+    /// 
+    /// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
+    /// stored in `1` bit each.
+    /// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
+    /// requires `4` bits to be stored.
+    /// For a decimal `Radix` (`= 10`) digits `None` is returned.
+    /// 
+    /// Note: This always returns `None` for `Radix` instances that are a
+    ///       power of two.
+    #[inline]
+    pub(crate) fn exact_bits_per_digit(self) -> Option<usize> {
+        if self.is_power_of_two() {
+            Some(self.bits_per_digit())
+        }
+        else {
+            None
+        }
+    }
 
-	/// Returns the greatest power of the radix <= digit::BASE.
-	/// 
-	/// Note: This operation is only valid for `Radix` instances that are not a power-of-two.
-	#[inline]
-	pub(crate) fn get_radix_base(self) -> (Digit, usize) {
-	    assert!(!self.is_power_of_two());
+    /// Returns the greatest power of the radix <= digit::BASE.
+    /// 
+    /// Note: This operation is only valid for `Radix` instances that are not a power-of-two.
+    #[inline]
+    pub(crate) fn get_radix_base(self) -> (Digit, usize) {
+        assert!(!self.is_power_of_two());
 
-	    // To generate this table:
-	    // ```
-	    //    for radix in 2u64..37 {
-	    //        let mut power = digit::BITS / find_last_bit_set(radix.to_u8() as u64);
-	    //        let mut base  = (radix.to_u8() as u32).pow(power as u32);
-	    //        while let Some(b) = base.checked_mul(radix) {
-	    //            base   = b;
-	    //            power += 1;
-	    //        }
-	    //        println!("({:20}, {:2}), // {:2}", base, power, radix);
-	    //    }
-	    // ```
+        // To generate this table:
+        // ```
+        //    for radix in 2u64..37 {
+        //        let mut power = digit::BITS / find_last_bit_set(radix.to_u8() as u64);
+        //        let mut base  = (radix.to_u8() as u32).pow(power as u32);
+        //        while let Some(b) = base.checked_mul(radix) {
+        //            base   = b;
+        //            power += 1;
+        //        }
+        //        println!("({:20}, {:2}), // {:2}", base, power, radix);
+        //    }
+        // ```
         const BASES: [(DigitRepr, usize); 37] = [
             (                       0,  0), //  0 (invalid Radix!)
             (                       0,  0), //  1 (invalid Radix!)
@@ -163,12 +163,12 @@ impl Radix {
 
         let (base, power) = BASES[self.to_u8() as usize];
         (Digit(base as DigitRepr), power)
-	}
+    }
 }
 
 impl From<u8> for Radix {
-	#[inline]
-	fn from(radix: u8) -> Radix {
-		Radix::new(radix).unwrap()
-	}
+    #[inline]
+    fn from(radix: u8) -> Radix {
+        Radix::new(radix).unwrap()
+    }
 }

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -13,8 +13,8 @@ use errors::{Error, Result};
 /// # Examples
 /// 
 /// - The binary 2-radix supports only `0` and `1` as input.
-/// - The decimal 10-radix supports `0`,`1`,...`9` as input characters.
-/// - The hex-dec 16-radix supports inputs characters within `0`,..,`9` and `a`,..,`f`.
+/// - The decimal 10-radix supports `0`..=`9` as input characters.
+/// - The hex-dec 16-radix supports inputs characters within `0`..=`9` and `a`..=`f`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Radix(u8);
 
@@ -65,7 +65,7 @@ impl Radix {
     /// 
     /// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
     /// stored in `1` bit each.
-    /// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
+    /// For a hexdec `Radix` (`= 16`) digits are `0`..=`9`,`A`..=`F` and a digit 
     /// requires `4` bits to be stored.
     /// 
     /// Note: This is only valid for `Radix` instances that represent a radix
@@ -86,7 +86,7 @@ impl Radix {
     /// 
     /// For binary `Radix` (`= 2`) there are only digits `0` and `1` which can be
     /// stored in `1` bit each.
-    /// For a hexdec `Radix` (`= 16`) digits are `0`...`9`,`A`...`F` and a digit 
+    /// For a hexdec `Radix` (`= 16`) digits are `0`..=`9`,`A`..=`F` and a digit 
     /// requires `4` bits to be stored.
     /// For a decimal `Radix` (`= 10`) digits `None` is returned.
     /// 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,27 +5,27 @@ use bitwidth::BitWidth;
 pub(crate) enum Storage { Inl, Ext }
 
 impl<W> From<W> for Storage
-	where W: Into<BitWidth>
+    where W: Into<BitWidth>
 {
-	#[inline]
-	fn from(width: W) -> Storage {
-		let width = width.into();
-		if Storage::is_inline(width) {
-			Storage::Inl
-		}
-		else {
-			Storage::Ext
-		}
-	}
+    #[inline]
+    fn from(width: W) -> Storage {
+        let width = width.into();
+        if Storage::is_inline(width) {
+            Storage::Inl
+        }
+        else {
+            Storage::Ext
+        }
+    }
 }
 
 impl Storage {
-	/// Returns `true` if the given `BitWidth` is small enough to be stored inline.
-	/// 
-	/// Note: Inline storage in the context of `ApInt` means that it is space-optimized
-	///       similar to the well-known small-string optimization.
-	#[inline]
-	fn is_inline(width: BitWidth) -> bool {
-		width.to_usize() <= digit::BITS
-	}
+    /// Returns `true` if the given `BitWidth` is small enough to be stored inline.
+    /// 
+    /// Note: Inline storage in the context of `ApInt` means that it is space-optimized
+    ///       similar to the well-known small-string optimization.
+    #[inline]
+    fn is_inline(width: BitWidth) -> bool {
+        width.to_usize() <= digit::BITS
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,6 +2,6 @@ use bitwidth::{BitWidth};
 
 /// Types that have an associated bit width may implement `Width`.
 pub trait Width {
-	/// Returns the bit width of `self`.
-	fn width(&self) -> BitWidth;
+    /// Returns the bit width of `self`.
+    fn width(&self) -> BitWidth;
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -13,23 +13,23 @@ use rand;
 
 use std::cmp::Ordering;
 use std::ops::{
-	Not,
-	BitAnd,
-	BitOr,
-	BitXor,
-	BitAndAssign,
-	BitOrAssign,
-	BitXorAssign,
-	Add,
-	Sub,
-	Mul,
-	Div,
-	Rem,
-	AddAssign,
-	SubAssign,
-	MulAssign,
-	DivAssign,
-	RemAssign
+    Not,
+    BitAnd,
+    BitOr,
+    BitXor,
+    BitAndAssign,
+    BitOrAssign,
+    BitXorAssign,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+    AddAssign,
+    SubAssign,
+    MulAssign,
+    DivAssign,
+    RemAssign
 };
 
 /// Unsigned machine integer with arbitrary bitwidths and modulo arithmetics.
@@ -40,152 +40,152 @@ use std::ops::{
 /// `Int` offers a more elegant and higher-level abstraction interface to the lower-level `ApInt`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UInt {
-	value: ApInt,
+    value: ApInt,
 }
 
 impl From<ApInt> for UInt {
-	fn from(value: ApInt) -> UInt {
-		UInt { value }
-	}
+    fn from(value: ApInt) -> UInt {
+        UInt { value }
+    }
 }
 
 impl UInt {
-	/// Transforms this `UInt` into an equivalent `ApInt` instance.
-	pub fn into_apint(self) -> ApInt {
-		self.value
-	}
+    /// Transforms this `UInt` into an equivalent `ApInt` instance.
+    pub fn into_apint(self) -> ApInt {
+        self.value
+    }
 
-	/// Transforms this `UInt` into an equivalent `Int` instance.
-	pub fn into_signed(self) -> Int {
-		Int::from(self.value)
-	}
+    /// Transforms this `UInt` into an equivalent `Int` instance.
+    pub fn into_signed(self) -> Int {
+        Int::from(self.value)
+    }
 }
 
 /// # Constructors
 impl UInt {
-	/// Creates a new `UInt` from the given `Bit` value with a bit width of `1`.
-	///
-	/// This function is generic over types that are convertible to `Bit` such as `bool`.
-	pub fn from_bit<B>(bit: B) -> UInt
-	where
-		B: Into<Bit>,
-	{
-		UInt::from(ApInt::from_bit(bit))
-	}
+    /// Creates a new `UInt` from the given `Bit` value with a bit width of `1`.
+    ///
+    /// This function is generic over types that are convertible to `Bit` such as `bool`.
+    pub fn from_bit<B>(bit: B) -> UInt
+    where
+        B: Into<Bit>,
+    {
+        UInt::from(ApInt::from_bit(bit))
+    }
 
-	/// Creates a new `UInt` from a given `u8` value with a bit-width of 8.
-	#[inline]
-	pub fn from_u8(val: u8) -> UInt {
-		UInt::from(ApInt::from_u8(val))
-	}
+    /// Creates a new `UInt` from a given `u8` value with a bit-width of 8.
+    #[inline]
+    pub fn from_u8(val: u8) -> UInt {
+        UInt::from(ApInt::from_u8(val))
+    }
 
-	/// Creates a new `UInt` from a given `u16` value with a bit-width of 16.
-	#[inline]
-	pub fn from_u16(val: u16) -> UInt {
-		UInt::from(ApInt::from_u16(val))
-	}
+    /// Creates a new `UInt` from a given `u16` value with a bit-width of 16.
+    #[inline]
+    pub fn from_u16(val: u16) -> UInt {
+        UInt::from(ApInt::from_u16(val))
+    }
 
-	/// Creates a new `UInt` from a given `u32` value with a bit-width of 32.
-	#[inline]
-	pub fn from_u32(val: u32) -> UInt {
-		UInt::from(ApInt::from_u32(val))
-	}
+    /// Creates a new `UInt` from a given `u32` value with a bit-width of 32.
+    #[inline]
+    pub fn from_u32(val: u32) -> UInt {
+        UInt::from(ApInt::from_u32(val))
+    }
 
-	/// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
-	#[inline]
-	pub fn from_u64(val: u64) -> UInt {
-		UInt::from(ApInt::from_u64(val))
-	}
+    /// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
+    #[inline]
+    pub fn from_u64(val: u64) -> UInt {
+        UInt::from(ApInt::from_u64(val))
+    }
 
-	/// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
-	pub fn from_u128(val: u128) -> UInt {
-		UInt::from(ApInt::from_u128(val))
-	}
+    /// Creates a new `UInt` from a given `u64` value with a bit-width of 64.
+    pub fn from_u128(val: u128) -> UInt {
+        UInt::from(ApInt::from_u128(val))
+    }
 
-	/// Creates a new `UInt` with the given bit width that represents zero.
-	pub fn zero(width: BitWidth) -> UInt {
-		UInt::from(ApInt::zero(width))
-	}
+    /// Creates a new `UInt` with the given bit width that represents zero.
+    pub fn zero(width: BitWidth) -> UInt {
+        UInt::from(ApInt::zero(width))
+    }
 
-	/// Creates a new `UInt` with the given bit width that represents one.
-	pub fn one(width: BitWidth) -> UInt {
-		UInt::from(ApInt::one(width))
-	}
+    /// Creates a new `UInt` with the given bit width that represents one.
+    pub fn one(width: BitWidth) -> UInt {
+        UInt::from(ApInt::one(width))
+    }
 
-	/// Creates a new `UInt` with the given bit width that has all bits unset.
-	///
-	/// **Note:** This is equal to calling `UInt::zero` with the given `width`.
-	pub fn all_unset(width: BitWidth) -> UInt {
-		UInt::zero(width)
-	}
+    /// Creates a new `UInt` with the given bit width that has all bits unset.
+    ///
+    /// **Note:** This is equal to calling `UInt::zero` with the given `width`.
+    pub fn all_unset(width: BitWidth) -> UInt {
+        UInt::zero(width)
+    }
 
-	/// Creates a new `UInt` with the given bit width that has all bits set.
-	///
-	/// # Note
-	///
-	/// - This is equal to minus one on any twos-complement machine.
-	pub fn all_set(width: BitWidth) -> UInt {
-		UInt::from(ApInt::all_set(width))
-	}
+    /// Creates a new `UInt` with the given bit width that has all bits set.
+    ///
+    /// # Note
+    ///
+    /// - This is equal to minus one on any twos-complement machine.
+    pub fn all_set(width: BitWidth) -> UInt {
+        UInt::from(ApInt::all_set(width))
+    }
 
-	/// Returns the smallest `UInt` that can be represented by the given `BitWidth`.
-	pub fn min_value(width: BitWidth) -> UInt {
-		UInt::from(ApInt::unsigned_min_value(width))
-	}
+    /// Returns the smallest `UInt` that can be represented by the given `BitWidth`.
+    pub fn min_value(width: BitWidth) -> UInt {
+        UInt::from(ApInt::unsigned_min_value(width))
+    }
 
-	/// Returns the largest `UInt` that can be represented by the given `BitWidth`.
-	pub fn max_value(width: BitWidth) -> UInt {
-		UInt::from(ApInt::unsigned_max_value(width))
-	}
+    /// Returns the largest `UInt` that can be represented by the given `BitWidth`.
+    pub fn max_value(width: BitWidth) -> UInt {
+        UInt::from(ApInt::unsigned_max_value(width))
+    }
 }
 
 impl<B> From<B> for UInt
-	where B: Into<Bit>
+    where B: Into<Bit>
 {
-	#[inline]
-	fn from(bit: B) -> UInt {
-		UInt::from_bit(bit)
-	}
+    #[inline]
+    fn from(bit: B) -> UInt {
+        UInt::from_bit(bit)
+    }
 }
 
 impl From<u8> for UInt {
-	fn from(val: u8) -> UInt {
-		UInt::from_u8(val)
-	}
+    fn from(val: u8) -> UInt {
+        UInt::from_u8(val)
+    }
 }
 
 impl From<u16> for UInt {
-	fn from(val: u16) -> UInt {
-		UInt::from_u16(val)
-	}
+    fn from(val: u16) -> UInt {
+        UInt::from_u16(val)
+    }
 }
 
 impl From<u32> for UInt {
-	fn from(val: u32) -> UInt {
-		UInt::from_u32(val)
-	}
+    fn from(val: u32) -> UInt {
+        UInt::from_u32(val)
+    }
 }
 
 impl From<u64> for UInt {
-	fn from(val: u64) -> UInt {
-		UInt::from_u64(val)
-	}
+    fn from(val: u64) -> UInt {
+        UInt::from_u64(val)
+    }
 }
 
 impl From<u128> for UInt {
-	fn from(val: u128) -> UInt {
-		UInt::from_u128(val)
-	}
+    fn from(val: u128) -> UInt {
+        UInt::from_u128(val)
+    }
 }
 
 macro_rules! impl_from_array_for_uint {
-	($n:expr) => {
-		impl From<[u64; $n]> for UInt {
-			fn from(val: [u64; $n]) -> UInt {
-				UInt::from(ApInt::from(val))
-			}
-		}
-	}
+    ($n:expr) => {
+        impl From<[u64; $n]> for UInt {
+            fn from(val: [u64; $n]) -> UInt {
+                UInt::from(ApInt::from(val))
+            }
+        }
+    }
 }
 
 impl_from_array_for_uint!(2); // 128 bits
@@ -200,751 +200,751 @@ impl_from_array_for_uint!(32); // 2048 bits
 
 /// # Utilities
 impl UInt {
-	/// Returns `true` if this `UInt` represents the value zero (`0`).
-	///
-	/// # Note
-	///
-	/// - Zero (`0`) is also called the additive neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `UInt` for the same reason.
-	pub fn is_zero(&self) -> bool {
-		self.value.is_zero()
-	}
+    /// Returns `true` if this `UInt` represents the value zero (`0`).
+    ///
+    /// # Note
+    ///
+    /// - Zero (`0`) is also called the additive neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `UInt` for the same reason.
+    pub fn is_zero(&self) -> bool {
+        self.value.is_zero()
+    }
 
-	/// Returns `true` if this `UInt` represents the value one (`1`).
-	///
-	/// # Note
-	///
-	/// - One (`1`) is also called the multiplicative neutral element.
-	/// - This operation is more efficient than comparing two instances
-	///   of `UInt` for the same reason.
-	pub fn is_one(&self) -> bool {
-		self.value.is_one()
-	}
+    /// Returns `true` if this `UInt` represents the value one (`1`).
+    ///
+    /// # Note
+    ///
+    /// - One (`1`) is also called the multiplicative neutral element.
+    /// - This operation is more efficient than comparing two instances
+    ///   of `UInt` for the same reason.
+    pub fn is_one(&self) -> bool {
+        self.value.is_one()
+    }
 
-	/// Returns `true` if this `UInt` represents an even number.
-	pub fn is_even(&self) -> bool {
-		self.value.is_even()
-	}
+    /// Returns `true` if this `UInt` represents an even number.
+    pub fn is_even(&self) -> bool {
+        self.value.is_even()
+    }
 
-	/// Returns `true` if this `UInt` represents an odd number.
-	pub fn is_odd(&self) -> bool {
-		self.value.is_odd()
-	}
+    /// Returns `true` if this `UInt` represents an odd number.
+    pub fn is_odd(&self) -> bool {
+        self.value.is_odd()
+    }
 }
 
 impl UInt {
 
-	/// Less-than (`lt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self < rhs`.
-	/// - Interprets both `UInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn checked_lt(&self, rhs: &UInt) -> Result<bool> {
-		self.value.checked_ult(&rhs.value)
-	}
+    /// Less-than (`lt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self < rhs`.
+    /// - Interprets both `UInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn checked_lt(&self, rhs: &UInt) -> Result<bool> {
+        self.value.checked_ult(&rhs.value)
+    }
 
-	/// Less-equals (`le`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self <= rhs`.
-	/// - Interprets both `UInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_le(&self, rhs: &UInt) -> Result<bool> {
-		self.value.checked_ule(&rhs.value)
-	}
+    /// Less-equals (`le`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self <= rhs`.
+    /// - Interprets both `UInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_le(&self, rhs: &UInt) -> Result<bool> {
+        self.value.checked_ule(&rhs.value)
+    }
 
-	/// Greater-than (`gt`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self > rhs`.
-	/// - Interprets both `UInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_gt(&self, rhs: &UInt) -> Result<bool> {
-		self.value.checked_ugt(&rhs.value)
-	}
+    /// Greater-than (`gt`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self > rhs`.
+    /// - Interprets both `UInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_gt(&self, rhs: &UInt) -> Result<bool> {
+        self.value.checked_ugt(&rhs.value)
+    }
 
-	/// Greater-equals (`ge`) comparison between `self` and `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - `checked_` for this function means that it checks the bit widths
-	/// - Returns `Ok(true)` if `self >= rhs`.
-	/// - Interprets both `UInt` instances as **unsigned** values.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	#[inline]
-	pub fn checked_ge(&self, rhs: &UInt) -> Result<bool> {
-		self.value.checked_uge(&rhs.value)
-	}
+    /// Greater-equals (`ge`) comparison between `self` and `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - `checked_` for this function means that it checks the bit widths
+    /// - Returns `Ok(true)` if `self >= rhs`.
+    /// - Interprets both `UInt` instances as **unsigned** values.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    #[inline]
+    pub fn checked_ge(&self, rhs: &UInt) -> Result<bool> {
+        self.value.checked_uge(&rhs.value)
+    }
 }
 
 /// If `self` and `rhs` have unmatching bit widths, `None` will be returned for `partial_cmp`
 /// and `false` will be returned for the rest of the `PartialOrd` methods.
 impl PartialOrd for UInt {
-	fn partial_cmp(&self, rhs: &UInt) -> Option<Ordering> {
-		if self.value.width() != rhs.value.width() {
-			return None;
-		}
-		if self.checked_lt(rhs).unwrap() {
-			return Some(Ordering::Less);
-		}
-		if self.value == rhs.value {
-			return Some(Ordering::Equal);
-		}
-		Some(Ordering::Greater)
-	}
+    fn partial_cmp(&self, rhs: &UInt) -> Option<Ordering> {
+        if self.value.width() != rhs.value.width() {
+            return None;
+        }
+        if self.checked_lt(rhs).unwrap() {
+            return Some(Ordering::Less);
+        }
+        if self.value == rhs.value {
+            return Some(Ordering::Equal);
+        }
+        Some(Ordering::Greater)
+    }
 
-	fn lt(&self, rhs: &UInt) -> bool {
-		self.checked_lt(rhs).unwrap_or(false)
-	}
+    fn lt(&self, rhs: &UInt) -> bool {
+        self.checked_lt(rhs).unwrap_or(false)
+    }
 
-	fn le(&self, rhs: &UInt) -> bool {
-		self.checked_le(rhs).unwrap_or(false)
-	}
+    fn le(&self, rhs: &UInt) -> bool {
+        self.checked_le(rhs).unwrap_or(false)
+    }
 
-	fn gt(&self, rhs: &UInt) -> bool {
-		self.checked_gt(rhs).unwrap_or(false)
-	}
+    fn gt(&self, rhs: &UInt) -> bool {
+        self.checked_gt(rhs).unwrap_or(false)
+    }
 
-	fn ge(&self, rhs: &UInt) -> bool {
-		self.checked_ge(rhs).unwrap_or(false)
-	}
+    fn ge(&self, rhs: &UInt) -> bool {
+        self.checked_ge(rhs).unwrap_or(false)
+    }
 }
 
 /// # To Primitive (Resize)
 impl UInt {
-	/// Resizes this `UInt` to a `bool` primitive type.
-	///
-	/// Bits in this `UInt` that are not within the bounds
-	/// of the `bool` are being ignored.
-	///
-	/// # Note
-	///
-	/// - Basically this returns `true` if the least significant
-	///   bit of this `UInt` is `1` and `false` otherwise.
-	pub fn resize_to_bool(&self) -> bool {
-		self.value.resize_to_bool()
-	}
+    /// Resizes this `UInt` to a `bool` primitive type.
+    ///
+    /// Bits in this `UInt` that are not within the bounds
+    /// of the `bool` are being ignored.
+    ///
+    /// # Note
+    ///
+    /// - Basically this returns `true` if the least significant
+    ///   bit of this `UInt` is `1` and `false` otherwise.
+    pub fn resize_to_bool(&self) -> bool {
+        self.value.resize_to_bool()
+    }
 
-	/// Resizes this `UInt` to a `u8` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `8` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u8(&self) -> u8 {
-		self.value.resize_to_u8()
-	}
+    /// Resizes this `UInt` to a `u8` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `8` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u8(&self) -> u8 {
+        self.value.resize_to_u8()
+    }
 
-	/// Resizes this `UInt` to a `u16` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `16` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u16(&self) -> u16 {
-		self.value.resize_to_u16()
-	}
+    /// Resizes this `UInt` to a `u16` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `16` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u16(&self) -> u16 {
+        self.value.resize_to_u16()
+    }
 
-	/// Resizes this `UInt` to a `u32` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `32` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u32(&self) -> u32 {
-		self.value.resize_to_u32()
-	}
+    /// Resizes this `UInt` to a `u32` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `32` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u32(&self) -> u32 {
+        self.value.resize_to_u32()
+    }
 
-	/// Resizes this `UInt` to a `u64` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `64` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u64(&self) -> u64 {
-		self.value.resize_to_u64()
-	}
+    /// Resizes this `UInt` to a `u64` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `64` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u64(&self) -> u64 {
+        self.value.resize_to_u64()
+    }
 
-	/// Resizes this `UInt` to a `u128` primitive type.
-	///
-	/// # Note
-	///
-	/// - All bits but the least significant `128` bits are
-	///   being ignored by this operation to construct the
-	///   result.
-	pub fn resize_to_u128(&self) -> u128 {
-		self.value.resize_to_u128()
-	}
+    /// Resizes this `UInt` to a `u128` primitive type.
+    ///
+    /// # Note
+    ///
+    /// - All bits but the least significant `128` bits are
+    ///   being ignored by this operation to construct the
+    ///   result.
+    pub fn resize_to_u128(&self) -> u128 {
+        self.value.resize_to_u128()
+    }
 }
 
 /// # To Primitive (Try-Cast)
 impl UInt {
-	/// Tries to represent the value of this `UInt` as a `bool`.
-	///
-	/// # Note
-	///
-	/// This returns `true` if the value represented by this `UInt`
-	/// is `1`, returns `false` if the value represented by this
-	/// `UInt` is `0` and returns an error otherwise.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `bool`.
-	pub fn try_to_bool(&self) -> Result<bool> {
-		self.value.try_to_bool()
-	}
+    /// Tries to represent the value of this `UInt` as a `bool`.
+    ///
+    /// # Note
+    ///
+    /// This returns `true` if the value represented by this `UInt`
+    /// is `1`, returns `false` if the value represented by this
+    /// `UInt` is `0` and returns an error otherwise.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `bool`.
+    pub fn try_to_bool(&self) -> Result<bool> {
+        self.value.try_to_bool()
+    }
 
-	/// Tries to represent the value of this `UInt` as a `u8`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `UInt` does not exceed the maximum value of `u8`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `u8`.
-	pub fn try_to_u8(&self) -> Result<u8> {
-		self.value.try_to_u8()
-	}
+    /// Tries to represent the value of this `UInt` as a `u8`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `UInt` does not exceed the maximum value of `u8`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `u8`.
+    pub fn try_to_u8(&self) -> Result<u8> {
+        self.value.try_to_u8()
+    }
 
-	/// Tries to represent the value of this `UInt` as a `u16`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `UInt` does not exceed the maximum value of `u16`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `u16`.
-	pub fn try_to_u16(&self) -> Result<u16> {
-		self.value.try_to_u16()
-	}
+    /// Tries to represent the value of this `UInt` as a `u16`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `UInt` does not exceed the maximum value of `u16`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `u16`.
+    pub fn try_to_u16(&self) -> Result<u16> {
+        self.value.try_to_u16()
+    }
 
-	/// Tries to represent the value of this `UInt` as a `u32`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `UInt` does not exceed the maximum value of `u32`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `u32`.
-	pub fn try_to_u32(&self) -> Result<u32> {
-		self.value.try_to_u32()
-	}
+    /// Tries to represent the value of this `UInt` as a `u32`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `UInt` does not exceed the maximum value of `u32`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `u32`.
+    pub fn try_to_u32(&self) -> Result<u32> {
+        self.value.try_to_u32()
+    }
 
-	/// Tries to represent the value of this `UInt` as a `u64`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `UInt` does not exceed the maximum value of `u64`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `u64`.
-	pub fn try_to_u64(&self) -> Result<u64> {
-		self.value.try_to_u64()
-	}
+    /// Tries to represent the value of this `UInt` as a `u64`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `UInt` does not exceed the maximum value of `u64`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `u64`.
+    pub fn try_to_u64(&self) -> Result<u64> {
+        self.value.try_to_u64()
+    }
 
-	/// Tries to represent the value of this `UInt` as a `u128`.
-	///
-	/// # Note
-	///
-	/// - This conversion is possible as long as the value represented
-	///   by this `UInt` does not exceed the maximum value of `u128`.
-	///
-	/// # Complexity
-	///
-	/// - 𝒪(n) where n is the number of digits of this `UInt`.
-	///
-	/// # Errors
-	///
-	/// - If the value represented by this `UInt` can not be
-	///   represented by a `u128`.
-	pub fn try_to_u128(&self) -> Result<u128> {
-		self.value.try_to_u128()
-	}
+    /// Tries to represent the value of this `UInt` as a `u128`.
+    ///
+    /// # Note
+    ///
+    /// - This conversion is possible as long as the value represented
+    ///   by this `UInt` does not exceed the maximum value of `u128`.
+    ///
+    /// # Complexity
+    ///
+    /// - 𝒪(n) where n is the number of digits of this `UInt`.
+    ///
+    /// # Errors
+    ///
+    /// - If the value represented by this `UInt` can not be
+    ///   represented by a `u128`.
+    pub fn try_to_u128(&self) -> Result<u128> {
+        self.value.try_to_u128()
+    }
 }
 
 /// # Shifts
 impl UInt {
-   	/// Shift this `UInt` left by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		self.value.wrapping_shl_assign(shift_amount)
-	}
+       /// Shift this `UInt` left by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
+    pub fn wrapping_shl_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        self.value.wrapping_shl_assign(shift_amount)
+    }
 
-	/// Shift this `UInt` left by the given `shift_amount` bits and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<UInt>
-		where S: Into<ShiftAmount>
-	{
-		self.value.into_wrapping_shl(shift_amount).map(UInt::from)
-	}
+    /// Shift this `UInt` left by the given `shift_amount` bits and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
+    pub fn into_wrapping_shl<S>(self, shift_amount: S) -> Result<UInt>
+        where S: Into<ShiftAmount>
+    {
+        self.value.into_wrapping_shl(shift_amount).map(UInt::from)
+    }
 
-	/// Right-shifts this `UInt` by the given `shift_amount` bits.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn wrapping_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
-		where S: Into<ShiftAmount>
-	{
-		self.value.wrapping_lshr_assign(shift_amount)
-	}
+    /// Right-shifts this `UInt` by the given `shift_amount` bits.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
+    pub fn wrapping_shr_assign<S>(&mut self, shift_amount: S) -> Result<()>
+        where S: Into<ShiftAmount>
+    {
+        self.value.wrapping_lshr_assign(shift_amount)
+    }
 
-	/// Right-shifts this `UInt` by the given `shift_amount` bits
-	/// and returns the result.
-	/// 
-	/// This operation is inplace and will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
-	pub fn into_wrapping_shr<S>(self, shift_amount: S) -> Result<UInt>
-		where S: Into<ShiftAmount>
-	{
-		self.value.into_wrapping_lshr(shift_amount).map(UInt::from)
-	}
+    /// Right-shifts this `UInt` by the given `shift_amount` bits
+    /// and returns the result.
+    /// 
+    /// This operation is inplace and will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the given `shift_amount` is invalid for the bit width of this `UInt`.
+    pub fn into_wrapping_shr<S>(self, shift_amount: S) -> Result<UInt>
+        where S: Into<ShiftAmount>
+    {
+        self.value.into_wrapping_lshr(shift_amount).map(UInt::from)
+    }
 }
 
 use std::ops::{Shl, ShlAssign, Shr, ShrAssign};
 
 impl<S> Shl<S> for UInt
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn shl(self, shift_amount: S) -> Self::Output {
-		self.into_wrapping_shl(shift_amount).unwrap()
-	}
+    fn shl(self, shift_amount: S) -> Self::Output {
+        self.into_wrapping_shl(shift_amount).unwrap()
+    }
 }
 
 impl<S> Shr<S> for UInt
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn shr(self, shift_amount: S) -> Self::Output {
-		self.into_wrapping_shr(shift_amount).unwrap()
-	}
+    fn shr(self, shift_amount: S) -> Self::Output {
+        self.into_wrapping_shr(shift_amount).unwrap()
+    }
 }
 
 impl<S> ShlAssign<S> for UInt
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	fn shl_assign(&mut self, shift_amount: S) {
-		self.wrapping_shl_assign(shift_amount).unwrap()
-	}
+    fn shl_assign(&mut self, shift_amount: S) {
+        self.wrapping_shl_assign(shift_amount).unwrap()
+    }
 }
 
 impl<S> ShrAssign<S> for UInt
-	where S: Into<ShiftAmount>
+    where S: Into<ShiftAmount>
 {
-	fn shr_assign(&mut self, shift_amount: S) {
-		self.wrapping_shr_assign(shift_amount).unwrap()
-	}
+    fn shr_assign(&mut self, shift_amount: S) {
+        self.wrapping_shr_assign(shift_amount).unwrap()
+    }
 }
 
 /// # Random Utilities using `rand` crate.
 #[cfg(feature = "rand_support")]
 impl UInt {
-	/// Creates a new `UInt` with the given `BitWidth` and random `Digit`s.
-	pub fn random_with_width(width: BitWidth) -> UInt {
-		UInt::from(ApInt::random_with_width(width))
-	}
+    /// Creates a new `UInt` with the given `BitWidth` and random `Digit`s.
+    pub fn random_with_width(width: BitWidth) -> UInt {
+        UInt::from(ApInt::random_with_width(width))
+    }
 
-	/// Creates a new `UInt` with the given `BitWidth` and random `Digit`s
-	/// using the given random number generator.
-	/// 
-	/// **Note:** This is useful for cryptographic or testing purposes.
-	pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> UInt
-		where R: rand::Rng
-	{
-		UInt::from(ApInt::random_with_width_using(width, rng))
-	}
+    /// Creates a new `UInt` with the given `BitWidth` and random `Digit`s
+    /// using the given random number generator.
+    /// 
+    /// **Note:** This is useful for cryptographic or testing purposes.
+    pub fn random_with_width_using<R>(width: BitWidth, rng: &mut R) -> UInt
+        where R: rand::Rng
+    {
+        UInt::from(ApInt::random_with_width_using(width, rng))
+    }
 
-	/// Randomizes the digits of this `UInt` inplace.
-	/// 
-	/// This won't change its `BitWidth`.
-	pub fn randomize(&mut self) {
-		self.value.randomize()
-	}
+    /// Randomizes the digits of this `UInt` inplace.
+    /// 
+    /// This won't change its `BitWidth`.
+    pub fn randomize(&mut self) {
+        self.value.randomize()
+    }
 
-	/// Randomizes the digits of this `UInt` inplace using the given
-	/// random number generator.
-	/// 
-	/// This won't change its `BitWidth`.
-	pub fn randomize_using<R>(&mut self, rng: &mut R)
-		where R: rand::Rng
-	{
-		self.value.randomize_using(rng)
-	}
+    /// Randomizes the digits of this `UInt` inplace using the given
+    /// random number generator.
+    /// 
+    /// This won't change its `BitWidth`.
+    pub fn randomize_using<R>(&mut self, rng: &mut R)
+        where R: rand::Rng
+    {
+        self.value.randomize_using(rng)
+    }
 }
 
 impl UInt {
-	/// Assigns `rhs` to this `UInt`.
-	///
-	/// This mutates digits and may affect the bitwidth of `self`
-	/// which **might result in an expensive operations**.
-	///
-	/// After this operation `rhs` and `self` are equal to each other.
-	pub fn assign(&mut self, rhs: &UInt) {
-		self.value.assign(&rhs.value)
-	}
+    /// Assigns `rhs` to this `UInt`.
+    ///
+    /// This mutates digits and may affect the bitwidth of `self`
+    /// which **might result in an expensive operations**.
+    ///
+    /// After this operation `rhs` and `self` are equal to each other.
+    pub fn assign(&mut self, rhs: &UInt) {
+        self.value.assign(&rhs.value)
+    }
 
-	/// Strictly assigns `rhs` to this `UInt`.
-	/// 
-	/// After this operation `rhs` and `self` are equal to each other.
-	/// 
-	/// **Note:** Strict assigns protect against mutating the bit width
-	/// of `self` and thus return an error instead of executing a probably
-	/// expensive `assign` operation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `rhs` and `self` have unmatching bit widths.
-	pub fn strict_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.strict_assign(&rhs.value)
-	}
+    /// Strictly assigns `rhs` to this `UInt`.
+    /// 
+    /// After this operation `rhs` and `self` are equal to each other.
+    /// 
+    /// **Note:** Strict assigns protect against mutating the bit width
+    /// of `self` and thus return an error instead of executing a probably
+    /// expensive `assign` operation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `rhs` and `self` have unmatching bit widths.
+    pub fn strict_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.strict_assign(&rhs.value)
+    }
 }
 
 /// # Casting: Truncation & Extension
 impl UInt {
-	/// Tries to truncate this `UInt` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`truncate`](struct.UInt.html#method.truncate).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn into_truncate<W>(self, target_width: W) -> Result<UInt>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, UInt::truncate)
-	}
+    /// Tries to truncate this `UInt` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`truncate`](struct.UInt.html#method.truncate).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn into_truncate<W>(self, target_width: W) -> Result<UInt>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, UInt::truncate)
+    }
 
-	/// Tries to truncate this `UInt` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is greater than the current width.
-	pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		self.value.truncate(target_width)
-	}
+    /// Tries to truncate this `UInt` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is greater than the current width.
+    pub fn truncate<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        self.value.truncate(target_width)
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Tries to zero-extend this `UInt` inplace to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`extend`](struct.UInt.html#method.extend).
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn into_extend<W>(self, target_width: W) -> Result<UInt>
-		where W: Into<BitWidth>
-	{
-		try_forward_bin_mut_impl(self, target_width, UInt::extend)
-	}
+    /// Tries to zero-extend this `UInt` inplace to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`extend`](struct.UInt.html#method.extend).
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn into_extend<W>(self, target_width: W) -> Result<UInt>
+        where W: Into<BitWidth>
+    {
+        try_forward_bin_mut_impl(self, target_width, UInt::extend)
+    }
 
-	/// Tries to extend this `UInt` inplace to the given `target_width`.
-	/// 
-	/// # Note
-	/// 
-	/// - This is a no-op if `self.width()` and `target_width` are equal.
-	/// - This operation is inplace as long as `self.width()` and `target_width`
-	///   require the same amount of digits for their representation.
-	/// 
-	/// # Errors
-	/// 
-	/// - If the `target_width` is less than the current width.
-	pub fn extend<W>(&mut self, target_width: W) -> Result<()>
-		where W: Into<BitWidth>
-	{
-		self.value.zero_extend(target_width)
-	}
+    /// Tries to extend this `UInt` inplace to the given `target_width`.
+    /// 
+    /// # Note
+    /// 
+    /// - This is a no-op if `self.width()` and `target_width` are equal.
+    /// - This operation is inplace as long as `self.width()` and `target_width`
+    ///   require the same amount of digits for their representation.
+    /// 
+    /// # Errors
+    /// 
+    /// - If the `target_width` is less than the current width.
+    pub fn extend<W>(&mut self, target_width: W) -> Result<()>
+        where W: Into<BitWidth>
+    {
+        self.value.zero_extend(target_width)
+    }
 
-	// ========================================================================
+    // ========================================================================
 
-	/// Resizes this `UInt` to the given `target_width`
-	/// and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This is useful for method chaining.
-	/// - For more details look into
-	///   [`resize`](struct.UInt.html#method.resize).
-	pub fn into_resize<W>(self, target_width: W) -> UInt
-		where W: Into<BitWidth>
-	{
-		forward_bin_mut_impl(self, target_width, UInt::resize)
-	}
+    /// Resizes this `UInt` to the given `target_width`
+    /// and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This is useful for method chaining.
+    /// - For more details look into
+    ///   [`resize`](struct.UInt.html#method.resize).
+    pub fn into_resize<W>(self, target_width: W) -> UInt
+        where W: Into<BitWidth>
+    {
+        forward_bin_mut_impl(self, target_width, UInt::resize)
+    }
 
-	/// Resizes the given `UInt` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// This operation will forward to
-	/// 
-	/// - [`truncate`](struct.UInt.html#method.truncate)
-	///   if `target_width` is less than or equal to the width of
-	///   the given `UInt`
-	/// - [`extend`](struct.UInt.html#method.extend)
-	///   otherwise
-	pub fn resize<W>(&mut self, target_width: W)
-		where W: Into<BitWidth>
-	{
-		self.value.zero_resize(target_width)
-	}
+    /// Resizes the given `UInt` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// This operation will forward to
+    /// 
+    /// - [`truncate`](struct.UInt.html#method.truncate)
+    ///   if `target_width` is less than or equal to the width of
+    ///   the given `UInt`
+    /// - [`extend`](struct.UInt.html#method.extend)
+    ///   otherwise
+    pub fn resize<W>(&mut self, target_width: W)
+        where W: Into<BitWidth>
+    {
+        self.value.zero_resize(target_width)
+    }
 }
 
 /// # Bitwise Operations
 impl UInt {
-	/// Flips all bits of `self` and returns the result.
-	pub fn into_bitnot(self) -> Self {
-		forward_mut_impl(self, UInt::bitnot)
-	}
+    /// Flips all bits of `self` and returns the result.
+    pub fn into_bitnot(self) -> Self {
+        forward_mut_impl(self, UInt::bitnot)
+    }
 
-	/// Flip all bits of this `UInt` inplace.
-	pub fn bitnot(&mut self) {
-		self.value.bitnot()
-	}
+    /// Flip all bits of this `UInt` inplace.
+    pub fn bitnot(&mut self) {
+        self.value.bitnot()
+    }
 
-	/// Tries to bit-and assign this `UInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitand(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::bitand_assign)
-	}
+    /// Tries to bit-and assign this `UInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitand(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::bitand_assign)
+    }
 
-	/// Bit-and assigns all bits of this `UInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitand_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.bitand_assign(&rhs.value)
-	}
+    /// Bit-and assigns all bits of this `UInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitand_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.bitand_assign(&rhs.value)
+    }
 
-	/// Tries to bit-and assign this `UInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitor(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::bitor_assign)
-	}
+    /// Tries to bit-and assign this `UInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitor(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::bitor_assign)
+    }
 
-	/// Bit-or assigns all bits of this `UInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitor_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.bitor_assign(&rhs.value)
-	}
+    /// Bit-or assigns all bits of this `UInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitor_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.bitor_assign(&rhs.value)
+    }
 
-	/// Tries to bit-xor assign this `UInt` inplace to `rhs`
-	/// and returns the result.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn into_bitxor(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::bitxor_assign)
-	}
+    /// Tries to bit-xor assign this `UInt` inplace to `rhs`
+    /// and returns the result.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn into_bitxor(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::bitxor_assign)
+    }
 
-	/// Bit-xor assigns all bits of this `UInt` with the bits of `rhs`.
-	/// 
-	/// **Note:** This operation is inplace of `self` and won't allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// If `self` and `rhs` have unmatching bit widths.
-	pub fn bitxor_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.bitxor_assign(&rhs.value)
-	}
+    /// Bit-xor assigns all bits of this `UInt` with the bits of `rhs`.
+    /// 
+    /// **Note:** This operation is inplace of `self` and won't allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// If `self` and `rhs` have unmatching bit widths.
+    pub fn bitxor_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.bitxor_assign(&rhs.value)
+    }
 }
 
 /// # Bitwise Access
 impl UInt {
-	/// Returns the bit at the given bit position `pos`.
-	/// 
-	/// This returns
-	/// 
-	/// - `Bit::Set` if the bit at `pos` is `1`
-	/// - `Bit::Unset` otherwise
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `UInt`.
-	pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
-		where P: Into<BitPos>
-	{
-		self.value.get_bit_at(pos)
-	}
+    /// Returns the bit at the given bit position `pos`.
+    /// 
+    /// This returns
+    /// 
+    /// - `Bit::Set` if the bit at `pos` is `1`
+    /// - `Bit::Unset` otherwise
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `UInt`.
+    pub fn get_bit_at<P>(&self, pos: P) -> Result<Bit>
+        where P: Into<BitPos>
+    {
+        self.value.get_bit_at(pos)
+    }
 
-	/// Sets the bit at the given bit position `pos` to one (`1`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `UInt`.
-	pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.set_bit_at(pos)
-	}
+    /// Sets the bit at the given bit position `pos` to one (`1`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `UInt`.
+    pub fn set_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.set_bit_at(pos)
+    }
 
-	/// Sets the bit at the given bit position `pos` to zero (`0`).
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `UInt`.
-	pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.unset_bit_at(pos)
-	}
+    /// Sets the bit at the given bit position `pos` to zero (`0`).
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `UInt`.
+    pub fn unset_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.unset_bit_at(pos)
+    }
 
-	/// Flips the bit at the given bit position `pos`.
-	/// 
-	/// # Note
-	/// 
-	/// - If the bit at the given position was `0` it will be `1`
-	///   after this operation and vice versa.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `pos` is not a valid bit position for the width of this `UInt`.
-	pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
-		where P: Into<BitPos>
-	{
-		self.value.flip_bit_at(pos)
-	}
+    /// Flips the bit at the given bit position `pos`.
+    /// 
+    /// # Note
+    /// 
+    /// - If the bit at the given position was `0` it will be `1`
+    ///   after this operation and vice versa.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `pos` is not a valid bit position for the width of this `UInt`.
+    pub fn flip_bit_at<P>(&mut self, pos: P) -> Result<()>
+        where P: Into<BitPos>
+    {
+        self.value.flip_bit_at(pos)
+    }
 
-	/// Sets all bits of this `UInt` to one (`1`).
-	pub fn set_all(&mut self) {
-		self.value.set_all()
-	}
+    /// Sets all bits of this `UInt` to one (`1`).
+    pub fn set_all(&mut self) {
+        self.value.set_all()
+    }
 
-	/// Returns `true` if all bits in this `UInt` are set.
-	pub fn is_all_set(&self) -> bool {
-		self.value.is_all_set()
-	}
+    /// Returns `true` if all bits in this `UInt` are set.
+    pub fn is_all_set(&self) -> bool {
+        self.value.is_all_set()
+    }
 
-	/// Sets all bits of this `UInt` to zero (`0`).
-	pub fn unset_all(&mut self) {
-		self.value.unset_all()
-	}
+    /// Sets all bits of this `UInt` to zero (`0`).
+    pub fn unset_all(&mut self) {
+        self.value.unset_all()
+    }
 
-	/// Returns `true` if all bits in this `UInt` are unset.
-	pub fn is_all_unset(&self) -> bool {
-		self.value.is_all_unset()
-	}
+    /// Returns `true` if all bits in this `UInt` are unset.
+    pub fn is_all_unset(&self) -> bool {
+        self.value.is_all_unset()
+    }
 
-	/// Flips all bits of this `UInt`.
-	pub fn flip_all(&mut self) {
-		self.value.flip_all()
-	}
+    /// Flips all bits of this `UInt`.
+    pub fn flip_all(&mut self) {
+        self.value.flip_all()
+    }
 }
 
 /// # Bitwise utility methods.
 impl UInt {
-	/// Returns the number of ones in the binary representation of this `UInt`.
-	pub fn count_ones(&self) -> usize {
-		self.value.count_ones()
-	}
+    /// Returns the number of ones in the binary representation of this `UInt`.
+    pub fn count_ones(&self) -> usize {
+        self.value.count_ones()
+    }
 
-	/// Returns the number of zeros in the binary representation of this `UInt`.
-	pub fn count_zeros(&self) -> usize {
-		self.value.count_zeros()
-	}
+    /// Returns the number of zeros in the binary representation of this `UInt`.
+    pub fn count_zeros(&self) -> usize {
+        self.value.count_zeros()
+    }
 
-	/// Returns the number of leading zeros in the binary representation of this `UInt`.
-	pub fn leading_zeros(&self) -> usize {
-		self.value.leading_zeros()
-	}
+    /// Returns the number of leading zeros in the binary representation of this `UInt`.
+    pub fn leading_zeros(&self) -> usize {
+        self.value.leading_zeros()
+    }
 
-	/// Returns the number of trailing zeros in the binary representation of this `UInt`.
-	pub fn trailing_zeros(&self) -> usize {
-		self.value.trailing_zeros()
-	}
+    /// Returns the number of trailing zeros in the binary representation of this `UInt`.
+    pub fn trailing_zeros(&self) -> usize {
+        self.value.trailing_zeros()
+    }
 }
 
 //  ===========================================================================
@@ -952,11 +952,11 @@ impl UInt {
 //  ===========================================================================
 
 impl Not for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn not(self) -> Self::Output {
-		forward_mut_impl(self, UInt::bitnot)
-	}
+    fn not(self) -> Self::Output {
+        forward_mut_impl(self, UInt::bitnot)
+    }
 }
 
 //  ===========================================================================
@@ -964,27 +964,27 @@ impl Not for UInt {
 //  ===========================================================================
 
 impl<'a> BitAnd<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitand(self, rhs: &'a UInt) -> Self::Output {
-		self.into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a UInt) -> Self::Output {
+        self.into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitand(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitAnd<&'a UInt> for &'b mut UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitand(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitand(rhs).unwrap()
-	}
+    fn bitand(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitand(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -992,27 +992,27 @@ impl<'a, 'b> BitAnd<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitOr<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitor(self, rhs: &'a UInt) -> Self::Output {
-		self.into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a UInt) -> Self::Output {
+        self.into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitor(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitOr<&'a UInt> for &'b mut UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitor(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitor(rhs).unwrap()
-	}
+    fn bitor(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -1020,27 +1020,27 @@ impl<'a, 'b> BitOr<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitXor<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-		self.into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+        self.into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn bitxor(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_bitxor(rhs).unwrap()
-	}
+    fn bitxor(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_bitxor(rhs).unwrap()
+    }
 }
 
 //  ===========================================================================
@@ -1048,162 +1048,162 @@ impl<'a, 'b> BitXor<&'a UInt> for &'b mut UInt {
 //  ===========================================================================
 
 impl<'a> BitAndAssign<&'a UInt> for UInt {
-	fn bitand_assign(&mut self, rhs: &'a UInt) {
-		self.bitand_assign(rhs).unwrap();
-	}
+    fn bitand_assign(&mut self, rhs: &'a UInt) {
+        self.bitand_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitOrAssign<&'a UInt> for UInt {
-	fn bitor_assign(&mut self, rhs: &'a UInt) {
-		self.bitor_assign(rhs).unwrap();
-	}
+    fn bitor_assign(&mut self, rhs: &'a UInt) {
+        self.bitor_assign(rhs).unwrap();
+    }
 }
 
 impl<'a> BitXorAssign<&'a UInt> for UInt {
-	fn bitxor_assign(&mut self, rhs: &'a UInt) {
-		self.bitxor_assign(rhs).unwrap();
-	}
+    fn bitxor_assign(&mut self, rhs: &'a UInt) {
+        self.bitxor_assign(rhs).unwrap();
+    }
 }
 
 /// # Arithmetic Operations
 impl UInt {
-	/// Adds `rhs` to `self` and returns the result.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_add(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_add_assign)
-	}
+    /// Adds `rhs` to `self` and returns the result.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_add(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::wrapping_add_assign)
+    }
 
-	/// Add-assigns `rhs` to `self` inplace.
-	/// 
-	/// **Note:** This will **not** allocate memory.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_add_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.wrapping_add_assign(&rhs.value)
-	}
+    /// Add-assigns `rhs` to `self` inplace.
+    /// 
+    /// **Note:** This will **not** allocate memory.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_add_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.wrapping_add_assign(&rhs.value)
+    }
 
-	/// Subtracts `rhs` from `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_sub(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_sub_assign)
-	}
+    /// Subtracts `rhs` from `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_sub(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::wrapping_sub_assign)
+    }
 
-	/// Subtract-assigns `rhs` from `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_sub_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.wrapping_sub_assign(&rhs.value)
-	}
+    /// Subtract-assigns `rhs` from `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned subtraction of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_sub_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.wrapping_sub_assign(&rhs.value)
+    }
 
-	/// Subtracts `rhs` from `self` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_mul(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_mul_assign)
-	}
+    /// Subtracts `rhs` from `self` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_mul(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::wrapping_mul_assign)
+    }
 
-	/// Multiply-assigns `rhs` to `self` inplace.
-	/// 
-	/// # Note
-	/// 
-	/// In the low-level bit-wise representation there is no difference between signed
-	/// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_mul_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.wrapping_mul_assign(&rhs.value)
-	}
+    /// Multiply-assigns `rhs` to `self` inplace.
+    /// 
+    /// # Note
+    /// 
+    /// In the low-level bit-wise representation there is no difference between signed
+    /// and unsigned multiplication of fixed bit-width integers. (Cite: LLVM)
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_mul_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.wrapping_mul_assign(&rhs.value)
+    }
 
-	/// Divides `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_div(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_div_assign)
-	}
+    /// Divides `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_div(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::wrapping_div_assign)
+    }
 
-	/// Assignes `self` to the division of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_div_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.wrapping_udiv_assign(&rhs.value)
-	}
+    /// Assignes `self` to the division of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_div_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.wrapping_udiv_assign(&rhs.value)
+    }
 
-	/// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn into_wrapping_rem(self, rhs: &UInt) -> Result<UInt> {
-		try_forward_bin_mut_impl(self, rhs, UInt::wrapping_rem_assign)
-	}
+    /// Calculates the **unsigned** remainder of `self` by `rhs` and returns the result.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn into_wrapping_rem(self, rhs: &UInt) -> Result<UInt> {
+        try_forward_bin_mut_impl(self, rhs, UInt::wrapping_rem_assign)
+    }
 
-	/// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
-	/// 
-	/// # Note
-	/// 
-	/// - This operation will **not** allocate memory and computes inplace of `self`.
-	/// - In the low-level machine abstraction signed division and unsigned division
-	///   are two different operations.
-	/// 
-	/// # Errors
-	/// 
-	/// - If `self` and `rhs` have unmatching bit widths.
-	pub fn wrapping_rem_assign(&mut self, rhs: &UInt) -> Result<()> {
-		self.value.wrapping_urem_assign(&rhs.value)
-	}
+    /// Assignes `self` to the **unsigned** remainder of `self` by `rhs`.
+    /// 
+    /// # Note
+    /// 
+    /// - This operation will **not** allocate memory and computes inplace of `self`.
+    /// - In the low-level machine abstraction signed division and unsigned division
+    ///   are two different operations.
+    /// 
+    /// # Errors
+    /// 
+    /// - If `self` and `rhs` have unmatching bit widths.
+    pub fn wrapping_rem_assign(&mut self, rhs: &UInt) -> Result<()> {
+        self.value.wrapping_urem_assign(&rhs.value)
+    }
 }
 
 // ============================================================================
@@ -1211,25 +1211,25 @@ impl UInt {
 // ============================================================================
 
 impl<'a> Add<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn add(self, rhs: &'a UInt) -> Self::Output {
-		self.into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a UInt) -> Self::Output {
+        self.into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Add<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn add(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_wrapping_add(rhs).unwrap()
-	}
+    fn add(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_wrapping_add(rhs).unwrap()
+    }
 }
 
 impl<'a> AddAssign<&'a UInt> for UInt {
-	fn add_assign(&mut self, rhs: &'a UInt) {
-		self.wrapping_add_assign(rhs).unwrap()
-	}
+    fn add_assign(&mut self, rhs: &'a UInt) {
+        self.wrapping_add_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -1237,25 +1237,25 @@ impl<'a> AddAssign<&'a UInt> for UInt {
 // ============================================================================
 
 impl<'a> Sub<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn sub(self, rhs: &'a UInt) -> Self::Output {
-		self.into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a UInt) -> Self::Output {
+        self.into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Sub<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn sub(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_wrapping_sub(rhs).unwrap()
-	}
+    fn sub(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_wrapping_sub(rhs).unwrap()
+    }
 }
 
 impl<'a> SubAssign<&'a UInt> for UInt {
-	fn sub_assign(&mut self, rhs: &'a UInt) {
-		self.wrapping_sub_assign(rhs).unwrap()
-	}
+    fn sub_assign(&mut self, rhs: &'a UInt) {
+        self.wrapping_sub_assign(rhs).unwrap()
+    }
 }
 
 // ============================================================================
@@ -1263,25 +1263,25 @@ impl<'a> SubAssign<&'a UInt> for UInt {
 // ============================================================================
 
 impl<'a> Mul<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn mul(self, rhs: &'a UInt) -> Self::Output {
-		self.into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a UInt) -> Self::Output {
+        self.into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Mul<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn mul(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_wrapping_mul(rhs).unwrap()
-	}
+    fn mul(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_wrapping_mul(rhs).unwrap()
+    }
 }
 
 impl<'a> MulAssign<&'a UInt> for UInt {
-	fn mul_assign(&mut self, rhs: &'a UInt) {
-		self.wrapping_mul_assign(rhs).unwrap();
-	}
+    fn mul_assign(&mut self, rhs: &'a UInt) {
+        self.wrapping_mul_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1289,25 +1289,25 @@ impl<'a> MulAssign<&'a UInt> for UInt {
 // ============================================================================
 
 impl<'a> Div<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn div(self, rhs: &'a UInt) -> Self::Output {
-		self.into_wrapping_div(rhs).unwrap()
-	}
+    fn div(self, rhs: &'a UInt) -> Self::Output {
+        self.into_wrapping_div(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Div<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn div(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_wrapping_div(rhs).unwrap()
-	}
+    fn div(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_wrapping_div(rhs).unwrap()
+    }
 }
 
 impl<'a> DivAssign<&'a UInt> for UInt {
-	fn div_assign(&mut self, rhs: &'a UInt) {
-		self.wrapping_div_assign(rhs).unwrap();
-	}
+    fn div_assign(&mut self, rhs: &'a UInt) {
+        self.wrapping_div_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1315,25 +1315,25 @@ impl<'a> DivAssign<&'a UInt> for UInt {
 // ============================================================================
 
 impl<'a> Rem<&'a UInt> for UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn rem(self, rhs: &'a UInt) -> Self::Output {
-		self.into_wrapping_rem(rhs).unwrap()
-	}
+    fn rem(self, rhs: &'a UInt) -> Self::Output {
+        self.into_wrapping_rem(rhs).unwrap()
+    }
 }
 
 impl<'a, 'b> Rem<&'a UInt> for &'b UInt {
-	type Output = UInt;
+    type Output = UInt;
 
-	fn rem(self, rhs: &'a UInt) -> Self::Output {
-		self.clone().into_wrapping_rem(rhs).unwrap()
-	}
+    fn rem(self, rhs: &'a UInt) -> Self::Output {
+        self.clone().into_wrapping_rem(rhs).unwrap()
+    }
 }
 
 impl<'a> RemAssign<&'a UInt> for UInt {
-	fn rem_assign(&mut self, rhs: &'a UInt) {
-		self.wrapping_rem_assign(rhs).unwrap();
-	}
+    fn rem_assign(&mut self, rhs: &'a UInt) {
+        self.wrapping_rem_assign(rhs).unwrap();
+    }
 }
 
 // ============================================================================
@@ -1343,25 +1343,25 @@ impl<'a> RemAssign<&'a UInt> for UInt {
 use std::fmt;
 
 impl fmt::Binary for UInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::Octal for UInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::LowerHex for UInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl fmt::UpperHex for UInt {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		self.value.fmt(f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }


### PR DESCRIPTION
This changes no functionality, and only converts the tab indentation to spaces and `...` to `..=`.