### PR TITLE
Make whole crate no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["data-structures"]
 smallvec = { version = "0.6.5", default-features = false }
 specialized-div-rem = { version = "0.0.2", optional = true }
 rand = { version = "0.5.5", default-features = false, optional = true }
+specialized-div-rem = { version = "0.0.5", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
 libm = { version = "0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = { version = "0.6.5", default-features = false }
 specialized-div-rem = { version = "0.0.2", optional = true }
 rand = { version = "0.5.5", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+libm = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,22 @@ description = """Arbitrary precision integers library."""
 categories = ["data-structures"]
 
 [dependencies]
-smallvec = { version = "0.6.5" }
+smallvec = { version = "0.6.5", default-features = false }
 specialized-div-rem = { version = "0.0.2", optional = true }
-rand = { version = "0.5.5", optional = true }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+rand = { version = "0.5.5", default-features = false, optional = true }
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = "1.0.75"
 itertools = "0.7.8"
 
 [features]
-default = ["rand_support", "serde_support", "specialized-div-rem"]
+default = ["rand_support", "serde_support", "specialized-div-rem", "std"]
+std = [
+    "smallvec/std",
+    "rand/std",
+    "serde/std",
+]
 rand_support = ["rand"]
 serde_support = ["serde"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ description = """Arbitrary precision integers library."""
 categories = ["data-structures"]
 
 [dependencies]
-smallvec = { version = "0.6.5", default-features = false }
-specialized-div-rem = { version = "0.0.2", optional = true }
+smallvec = { version = "0.6", default-features = false }
 rand = { version = "0.5.5", default-features = false, optional = true }
 specialized-div-rem = { version = "0.0.5", optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
@@ -23,7 +22,7 @@ serde = { version = "1.0", default-features = false, optional = true, features =
 libm = { version = "0.1", default-features = false }
 
 [dev-dependencies]
-serde_test = "1.0.75"
+serde_test = "1.0"
 itertools = "0.8"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libm = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.75"
-itertools = "0.7.8"
+itertools = "0.8"
 
 [features]
 default = ["rand_support", "serde_support", "specialized-div-rem", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ specialized-div-rem = { version = "0.0.5", optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
-libm = { version = "0.1", default-features = false }
+libm = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
@@ -27,7 +27,13 @@ itertools = "0.8"
 rand_xorshift = "0.2"
 
 [features]
-default = ["rand_support", "serde_support", "specialized-div-rem", "std"]
+default = [
+    "rand_support",
+    "serde_support",
+    "specialized-div-rem",
+    "std",
+    "libm_0",
+]
 std = [
     "smallvec/std",
     "rand/std",
@@ -39,6 +45,8 @@ rand_support = [
     "rand/getrandom",
 ]
 serde_support = ["serde"]
+# Usage of libm is required for `no_std` builds.
+libm_0 = ["libm"]
 
 [badges]
 travis-ci = { repository = "Robbepop/apint" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ categories = ["data-structures"]
 smallvec = { version = "0.6", default-features = false }
 specialized-div-rem = { version = "0.0.5", optional = true }
 rand = { version = "0.7", default-features = false, optional = true }
-rand_xorshift = { version = "0.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
 libm = { version = "0.1", default-features = false }
@@ -25,21 +24,19 @@ libm = { version = "0.1", default-features = false }
 [dev-dependencies]
 serde_test = "1.0"
 itertools = "0.8"
+rand_xorshift = "0.2"
 
 [features]
 default = ["rand_support", "serde_support", "specialized-div-rem", "std"]
 std = [
     "smallvec/std",
     "rand/std",
-    # "rand_xorshift/std",
     "serde/std",
 ]
 rand_support = [
     "rand",
     "rand/small_rng",
     "rand/getrandom",
-    "rand_xorshift",
-    # "rand_xorshift/getrandom",
 ]
 serde_support = ["serde"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ categories = ["data-structures"]
 [dependencies]
 smallvec = { version = "0.6", default-features = false }
 specialized-div-rem = { version = "0.0.5", optional = true }
-rand = { version = "0.6", default-features = false, optional = true }
-rand_xorshift = { version = "0.1", default-features = false, optional = true }
+rand = { version = "0.7", default-features = false, optional = true }
+rand_xorshift = { version = "0.2", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
 libm = { version = "0.1", default-features = false }
@@ -31,9 +31,16 @@ default = ["rand_support", "serde_support", "specialized-div-rem", "std"]
 std = [
     "smallvec/std",
     "rand/std",
+    # "rand_xorshift/std",
     "serde/std",
 ]
-rand_support = ["rand", "rand_xorshift"]
+rand_support = [
+    "rand",
+    "rand/small_rng",
+    "rand/getrandom",
+    "rand_xorshift",
+    # "rand_xorshift/getrandom",
+]
 serde_support = ["serde"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ smallvec = { version = "0.6.5", default-features = false }
 specialized-div-rem = { version = "0.0.2", optional = true }
 rand = { version = "0.5.5", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
-libm = { version = "0.1", default-features = false, optional = true }
+libm = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ smallvec = { version = "0.6.5", default-features = false }
 specialized-div-rem = { version = "0.0.2", optional = true }
 rand = { version = "0.5.5", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+# Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
 libm = { version = "0.1", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ categories = ["data-structures"]
 
 [dependencies]
 smallvec = { version = "0.6", default-features = false }
-rand = { version = "0.5.5", default-features = false, optional = true }
 specialized-div-rem = { version = "0.0.5", optional = true }
+rand = { version = "0.6", default-features = false, optional = true }
+rand_xorshift = { version = "0.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # Currently needed because of: https://github.com/rust-lang/rfcs/issues/2505
 libm = { version = "0.1", default-features = false }
@@ -32,7 +33,7 @@ std = [
     "rand/std",
     "serde/std",
 ]
-rand_support = ["rand"]
+rand_support = ["rand", "rand_xorshift"]
 serde_support = ["serde"]
 
 [badges]

--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -20,14 +20,17 @@ use crate::{
         Error,
         Result,
     },
+    mem::{
+        vec,
+        vec::Vec,
+    },
     traits::Width,
     utils::{
         forward_mut_impl,
         try_forward_bin_mut_impl,
     },
 };
-
-use std::ops::{
+use core::ops::{
     Add,
     AddAssign,
     Mul,
@@ -1708,7 +1711,7 @@ impl ApInt {
 ///  **Note:** These ops will panic if their corresponding functions return an
 ///  error. They may also allocate memory.
 ///
-///  `ApInt` implements some `std::ops` traits for improved usability.
+///  `ApInt` implements some `core::ops` traits for improved usability.
 ///  Only traits for operations that do not depend on the signedness
 ///  interpretation of the specific `ApInt` instance are actually implemented.
 ///  Operations like `div` and `rem` are not expected to have an
@@ -1812,7 +1815,7 @@ mod tests {
 
     mod inc {
         use super::*;
-        use std::u64;
+        use core::u64;
 
         #[test]
         fn test() {
@@ -1882,7 +1885,7 @@ mod tests {
     mod mul {
         use super::*;
         use crate::bitwidth::BitWidth;
-        use std::{
+        use core::{
             u64,
             u8,
         };
@@ -2034,7 +2037,7 @@ mod tests {
     mod div_rem {
         use super::*;
         use crate::bitwidth::BitWidth;
-        use std::u64;
+        use core::u64;
 
         // TODO: add division by zero testing after error refactoring is finished
         // use errors::ErrorKind;
@@ -2446,8 +2449,8 @@ mod tests {
     mod megafuzz {
         use super::*;
         use crate::bitwidth::BitWidth;
+        use core::u64;
         use rand::random;
-        use std::u64;
 
         #[test]
         fn pull_request_35_regression() {

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -18,7 +18,7 @@ use crate::{
     },
 };
 
-use std::ops::{
+use core::ops::{
     BitAnd,
     BitAndAssign,
     BitOr,

--- a/src/apint/casting.rs
+++ b/src/apint/casting.rs
@@ -1,14 +1,12 @@
 use crate::{
     apint::ApInt,
+    bitwidth::BitWidth,
+    digit::Bit,
     errors::{
         Error,
         Result,
     },
-};
-
-use crate::{
-    bitwidth::BitWidth,
-    digit::Bit,
+    mem::format,
     storage::Storage,
     traits::Width,
     utils::{
@@ -22,7 +20,7 @@ impl Clone for ApInt {
         match self.storage() {
             Storage::Inl => ApInt::new_inl(self.len, unsafe { self.data.inl }),
             Storage::Ext => {
-                use std::mem;
+                use core::mem;
                 let req_digits = self.len_digits();
                 let mut buffer = self.as_digit_slice().to_vec().into_boxed_slice();
                 assert_eq!(buffer.len(), req_digits);
@@ -72,7 +70,7 @@ impl ApInt {
                     // need to expensively clone its buffer and feed it to `self`.
                     let cloned = rhs.clone();
                     self.data.ext = unsafe { cloned.data.ext };
-                    use std::mem;
+                    use core::mem;
                     mem::forget(cloned);
                 }
             }
@@ -284,7 +282,7 @@ impl ApInt {
             // for the target width. Also we need to `memcpy` the digits of the
             // extended `ApInt` to the newly allocated buffer.
             use crate::digit;
-            use std::iter;
+            use core::iter;
             assert!(target_req_digits > actual_req_digits);
             let additional_digits = target_req_digits - actual_req_digits;
             let extended_clone = ApInt::from_iter(
@@ -383,7 +381,7 @@ impl ApInt {
             // for the target width. Also we need to `memcpy` the digits of the
             // extended `ApInt` to the newly allocated buffer.
             use crate::digit;
-            use std::iter;
+            use core::iter;
             assert!(target_req_digits > actual_req_digits);
             let additional_digits = target_req_digits - actual_req_digits;
 
@@ -741,7 +739,7 @@ mod tests {
 
         #[test]
         fn regression_issue15() {
-            use std::{
+            use core::{
                 i128,
                 i64,
             };

--- a/src/apint/constructors.rs
+++ b/src/apint/constructors.rs
@@ -13,12 +13,13 @@ use crate::{
         Error,
         Result,
     },
+    mem::vec::Vec,
     storage::Storage,
 };
 
 use smallvec::SmallVec;
 
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 
 impl ApInt {
     /// Deallocates memory that may be allocated by this `ApInt`.
@@ -188,7 +189,7 @@ impl ApInt {
                 Ok(ApInt::new_inl(BitWidth::w64(), first_and_only))
             }
             n => {
-                use std::mem;
+                use core::mem;
                 let bitwidth = BitWidth::new(n * digit::BITS)
                     .expect("We have already asserted that the number of items the given Iterator \
                              iterates over is greater than `1` and thus non-zero and thus a valid `BitWidth`.");
@@ -223,7 +224,7 @@ impl ApInt {
     where
         D: Into<Digit>,
     {
-        use std::iter;
+        use core::iter;
         let digit = digit.into();
         let req_digits = target_width.required_digits();
         ApInt::from_iter(iter::repeat(digit).take(req_digits))
@@ -375,7 +376,7 @@ macro_rules! impl_from_array_for_apint {
         impl From<[i64; $n]> for ApInt {
             fn from(val: [i64; $n]) -> ApInt {
                 <Self as From<[u64; $n]>>::from(unsafe {
-                    ::std::mem::transmute::<[i64; $n], [u64; $n]>(val)
+                    ::core::mem::transmute::<[i64; $n], [u64; $n]>(val)
                 })
             }
         }
@@ -412,7 +413,7 @@ impl_from_array_for_apint!(32); // 2048 bits
 mod tests {
     use super::*;
 
-    use std::ops::Range;
+    use core::ops::Range;
 
     fn powers() -> impl Iterator<Item = u128> {
         (0..128).map(|p| 1 << p)
@@ -778,7 +779,7 @@ mod tests {
             )
         }
         {
-            use std::i128;
+            use core::i128;
             assert_eq!(
                 ApInt::signed_min_value(BitWidth::w128()),
                 ApInt::from(i128::MIN)

--- a/src/apint/mod.rs
+++ b/src/apint/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 pub use self::shift::ShiftAmount;
 pub(crate) use self::to_primitive::PrimitiveTy;
 
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 
 /// An arbitrary precision integer with modulo arithmetics similar to machine integers.
 pub struct ApInt {

--- a/src/apint/rand_impl.rs
+++ b/src/apint/rand_impl.rs
@@ -3,13 +3,7 @@ use crate::{
     bitwidth::BitWidth,
     digit::Digit,
 };
-use rand::{
-    self,
-    FromEntropy,
-};
-use rand_xorshift::{
-    XorShiftRng,
-};
+use rand::SeedableRng as _;
 
 impl rand::distributions::Distribution<Digit> for rand::distributions::Standard {
     /// Creates a random `Digit` using the given random number generator.
@@ -36,12 +30,10 @@ impl ApInt {
     where
         R: rand::Rng,
     {
-        use rand::distributions::Standard;
         let required_digits = width.required_digits();
         assert!(required_digits >= 1);
-        let random_digits = rng
-            .sample_iter::<Digit, Standard>(&Standard)
-            .take(required_digits);
+        use rand::distributions::{Standard, Distribution};
+        let random_digits = Standard.sample_iter(rng).take(required_digits);
         ApInt::from_iter(random_digits)
             .expect("We asserted that `required_digits` is at least `1` or greater
                      so it is safe to assume that `ApInt::from_iter` won't fail.")
@@ -65,9 +57,10 @@ impl ApInt {
     where
         R: rand::Rng,
     {
-        use rand::distributions::Standard;
+        use rand::distributions::{Standard, Distribution};
+        let std_dist = Standard.sample_iter(rng);
         self.digits_mut()
-            .zip(rng.sample_iter::<Digit, Standard>(&Standard))
+            .zip(std_dist)
             .for_each(|(d, r)| *d = r);
         self.clear_unused_bits();
     }
@@ -77,34 +70,36 @@ impl ApInt {
 mod tests {
     use super::*;
     use rand::SeedableRng;
+    use rand_xorshift::{
+        XorShiftRng,
+    };
 
     #[test]
     fn random_with_width_using() {
         let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
         let mut rng = XorShiftRng::from_seed(default_seed);
-        let r = &mut rng;
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w1(), r),
+            ApInt::random_with_width_using(BitWidth::w1(), &mut rng),
             ApInt::from_bit(true)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w8(), r),
+            ApInt::random_with_width_using(BitWidth::w8(), &mut rng),
             ApInt::from_u8(100)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w16(), r),
+            ApInt::random_with_width_using(BitWidth::w16(), &mut rng),
             ApInt::from_u16(30960)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w32(), r),
+            ApInt::random_with_width_using(BitWidth::w32(), &mut rng),
             ApInt::from_u32(1788231528)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w64(), r),
+            ApInt::random_with_width_using(BitWidth::w64(), &mut rng),
             ApInt::from_u64(13499822775494449820)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w128(), r),
+            ApInt::random_with_width_using(BitWidth::w128(), &mut rng),
             ApInt::from([16330942765510900160_u64, 131735358788273206])
         );
     }
@@ -114,43 +109,41 @@ mod tests {
         let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
         let mut rng1 = XorShiftRng::from_seed(default_seed);
         let mut rng2 = XorShiftRng::from_seed(default_seed);
-        let r1 = &mut rng1;
-        let r2 = &mut rng2;
 
         {
             let mut randomized = ApInt::from_bit(false);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w1(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w1(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u8(0);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w8(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w8(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u16(0);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w16(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w16(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u32(0);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w32(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w32(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u64(0);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w64(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w64(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u128(0);
-            randomized.randomize_using(r1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w128(), r2);
+            randomized.randomize_using(&mut rng1);
+            let new_random = ApInt::random_with_width_using(BitWidth::w128(), &mut rng2);
             assert_eq!(randomized, new_random);
         }
     }

--- a/src/apint/rand_impl.rs
+++ b/src/apint/rand_impl.rs
@@ -3,10 +3,12 @@ use crate::{
     bitwidth::BitWidth,
     digit::Digit,
 };
-
 use rand::{
     self,
     FromEntropy,
+};
+use rand_xorshift::{
+    XorShiftRng,
 };
 
 impl rand::distributions::Distribution<Digit> for rand::distributions::Standard {
@@ -78,8 +80,8 @@ mod tests {
 
     #[test]
     fn random_with_width_using() {
-        let default_seed = <rand::XorShiftRng as rand::SeedableRng>::Seed::default();
-        let mut rng = rand::XorShiftRng::from_seed(default_seed);
+        let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
+        let mut rng = XorShiftRng::from_seed(default_seed);
         let r = &mut rng;
         assert_eq!(
             ApInt::random_with_width_using(BitWidth::w1(), r),
@@ -109,9 +111,9 @@ mod tests {
 
     #[test]
     fn randomize_using() {
-        let default_seed = <rand::XorShiftRng as rand::SeedableRng>::Seed::default();
-        let mut rng1 = rand::XorShiftRng::from_seed(default_seed);
-        let mut rng2 = rand::XorShiftRng::from_seed(default_seed);
+        let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
+        let mut rng1 = XorShiftRng::from_seed(default_seed);
+        let mut rng2 = XorShiftRng::from_seed(default_seed);
         let r1 = &mut rng1;
         let r2 = &mut rng2;
 

--- a/src/apint/relational.rs
+++ b/src/apint/relational.rs
@@ -6,10 +6,10 @@ use crate::{
     digit,
     digit::Bit,
     errors::Result,
+    mem::format,
     traits::Width,
 };
-
-use std::{
+use core::{
     cmp::Ordering,
     ops::Not,
 };

--- a/src/apint/serde_impl.rs
+++ b/src/apint/serde_impl.rs
@@ -58,6 +58,7 @@ impl Serialize for ApInt {
     }
 }
 
+use core::fmt;
 use serde::{
     de,
     de::{
@@ -68,7 +69,6 @@ use serde::{
     Deserialize,
     Deserializer,
 };
-use std::fmt;
 
 impl<'de> Deserialize<'de> for BitWidth {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -5,10 +5,13 @@ use crate::{
         Error,
         Result,
     },
+    mem::{
+        string::String,
+        vec::Vec,
+    },
     radix::Radix,
 };
-
-use std::fmt;
+use core::fmt;
 
 impl fmt::Binary for ApInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -144,7 +147,7 @@ impl ApInt {
                 b'a'..=b'z' => b - b'a' + 10,
                 b'A'..=b'Z' => b - b'A' + 10,
                 b'_' => continue,
-                _ => ::std::u8::MAX,
+                _ => ::core::u8::MAX,
             };
             if !radix.is_valid_byte(d) {
                 return Err(Error::invalid_char_in_string_repr(
@@ -261,7 +264,7 @@ impl ApInt {
         debug_assert!(v.iter().all(|&c| radix.is_valid_byte(c)));
 
         // Estimate how big the result will be, so we can pre-allocate it.
-        let bits = (f64::from(radix.to_u8())).log2() * v.len() as f64;
+        let bits = f64::from(radix.to_u8()).log2() * v.len() as f64;
         let big_digits = (bits / digit::BITS as f64).ceil();
         let mut data = Vec::with_capacity(big_digits as usize);
 
@@ -512,7 +515,7 @@ mod tests {
 
         #[test]
         fn small_values() {
-            use std::u64;
+            use core::u64;
             let samples = vec![
                 // (Radix, Input String, Expected ApInt)
                 (2, "0", 0),

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -259,6 +259,7 @@ impl ApInt {
             Digit,
             DigitRepr,
         };
+        use libm::F64Ext as _;
 
         debug_assert!(!v.is_empty() && !radix.is_power_of_two());
         debug_assert!(v.iter().all(|&c| radix.is_valid_byte(c)));

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -259,6 +259,7 @@ impl ApInt {
             Digit,
             DigitRepr,
         };
+        #[cfg(feature = "libm_0")]
         use libm::F64Ext as _;
 
         debug_assert!(!v.is_empty() && !radix.is_power_of_two());

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -93,7 +93,7 @@ impl ApInt {
                 if digit_steps != 0 {
                     let digits_len = digits.len();
                     {
-                        use std::ptr;
+                        use core::ptr;
                         let src_ptr = digits.as_mut_ptr();
                         unsafe {
                             let dst_ptr = src_ptr.add(digit_steps);

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -17,7 +17,7 @@ use crate::{
     traits::Width,
 };
 
-use std::{
+use core::{
     fmt,
     hash::{
         Hash,
@@ -272,7 +272,7 @@ impl ApInt {
     /// Returns a slice over the `Digit`s of this `ApInt` in little-endian order.
     #[inline]
     pub(in crate::apint) fn as_digit_slice(&self) -> &[Digit] {
-        use std::slice;
+        use core::slice;
         match self.len.storage() {
             Storage::Inl => unsafe { slice::from_raw_parts(&self.data.inl, 1) },
             Storage::Ext => unsafe {
@@ -284,7 +284,7 @@ impl ApInt {
     /// Returns a mutable slice over the `Digit`s of this `ApInt` in little-endian order.
     #[inline]
     pub(in crate::apint) fn as_digit_slice_mut(&mut self) -> &mut [Digit] {
-        use std::slice;
+        use core::slice;
         match self.len.storage() {
             Storage::Inl => unsafe { slice::from_raw_parts_mut(&mut self.data.inl, 1) },
             Storage::Ext => unsafe {

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -9,7 +9,7 @@ use crate::{
     traits::Width,
 };
 
-use std::ops::{
+use core::ops::{
     Add,
     BitAnd,
     BitAndAssign,
@@ -94,7 +94,7 @@ impl From<Bit> for bool {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Digit(pub DigitRepr);
 
-use std::fmt;
+use core::fmt;
 
 impl fmt::Binary for Digit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -941,7 +941,7 @@ mod tests {
     mod digit {
         use super::*;
 
-        use std::usize;
+        use core::usize;
 
         static VALID_TEST_POS_VALUES: &[usize] = &[0, 1, 2, 3, 10, 32, 42, 48, 63];
 

--- a/src/digit_seq.rs
+++ b/src/digit_seq.rs
@@ -1,6 +1,6 @@
 use crate::digit::Digit;
 
-use std::slice;
+use core::slice;
 
 /// A sequence of digits.
 ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,14 +6,20 @@ use crate::{
     },
     bitpos::BitPos,
     bitwidth::BitWidth,
+    mem::{
+        borrow::ToOwned,
+        format,
+        string::String,
+    },
     radix::Radix,
 };
 
-use std::{
-    error,
+use core::{
     fmt,
     result,
 };
+#[cfg(feature = "std")]
+use std::error;
 
 /// Represents the kind of an `Error`.
 ///
@@ -352,6 +358,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
         self.message.as_str()

--- a/src/int.rs
+++ b/src/int.rs
@@ -19,7 +19,7 @@ use crate::{
 #[cfg(feature = "rand_support")]
 use rand;
 
-use std::{
+use core::{
     cmp::Ordering,
     ops::{
         Add,
@@ -1329,7 +1329,7 @@ impl Int {
 }
 
 // ============================================================================
-//  Unary arithmetic negation: `std::ops::Add` and `std::ops::AddAssign`
+//  Unary arithmetic negation: `core::ops::Add` and `core::ops::AddAssign`
 // ============================================================================
 
 impl Neg for Int {
@@ -1358,7 +1358,7 @@ impl<'a> Neg for &'a mut Int {
 }
 
 // ============================================================================
-//  Add and Add-Assign: `std::ops::Add` and `std::ops::AddAssign`
+//  Add and Add-Assign: `core::ops::Add` and `core::ops::AddAssign`
 // ============================================================================
 
 impl<'a> Add<&'a Int> for Int {
@@ -1384,7 +1384,7 @@ impl<'a> AddAssign<&'a Int> for Int {
 }
 
 // ============================================================================
-//  Sub and Sub-Assign: `std::ops::Sub` and `std::ops::SubAssign`
+//  Sub and Sub-Assign: `core::ops::Sub` and `core::ops::SubAssign`
 // ============================================================================
 
 impl<'a> Sub<&'a Int> for Int {
@@ -1410,7 +1410,7 @@ impl<'a> SubAssign<&'a Int> for Int {
 }
 
 // ============================================================================
-//  Mul and Mul-Assign: `std::ops::Mul` and `std::ops::MulAssign`
+//  Mul and Mul-Assign: `core::ops::Mul` and `core::ops::MulAssign`
 // ============================================================================
 
 impl<'a> Mul<&'a Int> for Int {
@@ -1436,7 +1436,7 @@ impl<'a> MulAssign<&'a Int> for Int {
 }
 
 // ============================================================================
-//  Div and Div-Assign: `std::ops::Div` and `std::ops::DivAssign`
+//  Div and Div-Assign: `core::ops::Div` and `core::ops::DivAssign`
 // ============================================================================
 
 impl<'a> Div<&'a Int> for Int {
@@ -1462,7 +1462,7 @@ impl<'a> DivAssign<&'a Int> for Int {
 }
 
 // ============================================================================
-//  Rem and Rem-Assign: `std::ops::Rem` and `std::ops::RemAssign`
+//  Rem and Rem-Assign: `core::ops::Rem` and `core::ops::RemAssign`
 // ============================================================================
 
 impl<'a> Rem<&'a Int> for Int {
@@ -1491,7 +1491,7 @@ impl<'a> RemAssign<&'a Int> for Int {
 //  Binary, Oct, LowerHex and UpperHex implementations
 // ============================================================================
 
-use std::fmt;
+use core::fmt;
 
 impl fmt::Binary for Int {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,24 +20,11 @@
 // #![deny(missing_docs)]
 // #![deny(warnings)]
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_root_url = "https://docs.rs/crate/apint/0.2.0")]
 
-extern crate smallvec;
-
-#[cfg(feature = "specialized_div_rem")]
-extern crate specialized_div_rem;
-
-#[cfg(feature = "rand_support")]
-extern crate rand;
-
-#[cfg(feature = "serde_support")]
-extern crate serde;
-
-#[cfg(all(test, feature = "serde_support"))]
-extern crate serde_test;
-
-#[cfg(test)]
-extern crate itertools;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 mod apint;
 mod bitpos;
@@ -47,6 +34,7 @@ mod digit;
 mod digit_seq;
 mod errors;
 mod int;
+mod mem;
 mod radix;
 mod storage;
 mod traits;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1,0 +1,57 @@
+//! Shim over `alloc` and `std` alloc utilities.
+
+#[cfg(not(feature = "std"))]
+mod no_std_defs {
+    pub use alloc::{
+        borrow,
+        boxed,
+        format,
+        string,
+        vec,
+    };
+
+    /// Collection types.
+    pub mod collections {
+        pub use self::{
+            BTreeMap,
+            BTreeSet,
+            BinaryHeap,
+            LinkedList,
+            VecDeque,
+        };
+        pub use alloc::collections::*;
+        pub use core::ops::Bound;
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_defs {
+    pub use std::{
+        borrow,
+        boxed,
+        format,
+        string,
+        vec,
+    };
+
+    /// Collection types.
+    pub mod collections {
+        pub use self::{
+            binary_heap::BinaryHeap,
+            btree_map::BTreeMap,
+            btree_set::BTreeSet,
+            linked_list::LinkedList,
+            vec_deque::VecDeque,
+            Bound,
+        };
+        pub use std::collections::*;
+    }
+}
+
+#[cfg(not(feature = "std"))]
+#[doc(inline)]
+pub use self::no_std_defs::*;
+
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use self::std_defs::*;

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -81,7 +81,7 @@ impl Radix {
     pub(crate) fn bits_per_digit(self) -> usize {
         assert!(self.is_power_of_two());
         fn find_last_bit_set(val: u8) -> usize {
-            ::std::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
+            ::core::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
         }
         find_last_bit_set(self.to_u8()) - 1
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -19,7 +19,7 @@ use crate::{
 #[cfg(feature = "rand_support")]
 use rand;
 
-use std::{
+use core::{
     cmp::Ordering,
     ops::{
         Add,
@@ -573,7 +573,7 @@ impl UInt {
     }
 }
 
-use std::ops::{
+use core::ops::{
     Shl,
     ShlAssign,
     Shr,
@@ -1244,7 +1244,7 @@ impl UInt {
 }
 
 // ============================================================================
-//  Add and Add-Assign: `std::ops::Add` and `std::ops::AddAssign`
+//  Add and Add-Assign: `core::ops::Add` and `core::ops::AddAssign`
 // ============================================================================
 
 impl<'a> Add<&'a UInt> for UInt {
@@ -1270,7 +1270,7 @@ impl<'a> AddAssign<&'a UInt> for UInt {
 }
 
 // ============================================================================
-//  Sub and Sub-Assign: `std::ops::Sub` and `std::ops::SubAssign`
+//  Sub and Sub-Assign: `core::ops::Sub` and `core::ops::SubAssign`
 // ============================================================================
 
 impl<'a> Sub<&'a UInt> for UInt {
@@ -1296,7 +1296,7 @@ impl<'a> SubAssign<&'a UInt> for UInt {
 }
 
 // ============================================================================
-//  Mul and Mul-Assign: `std::ops::Mul` and `std::ops::MulAssign`
+//  Mul and Mul-Assign: `core::ops::Mul` and `core::ops::MulAssign`
 // ============================================================================
 
 impl<'a> Mul<&'a UInt> for UInt {
@@ -1322,7 +1322,7 @@ impl<'a> MulAssign<&'a UInt> for UInt {
 }
 
 // ============================================================================
-//  Div and Div-Assign: `std::ops::Div` and `std::ops::DivAssign`
+//  Div and Div-Assign: `core::ops::Div` and `core::ops::DivAssign`
 // ============================================================================
 
 impl<'a> Div<&'a UInt> for UInt {
@@ -1348,7 +1348,7 @@ impl<'a> DivAssign<&'a UInt> for UInt {
 }
 
 // ============================================================================
-//  Rem and Rem-Assign: `std::ops::Rem` and `std::ops::RemAssign`
+//  Rem and Rem-Assign: `core::ops::Rem` and `core::ops::RemAssign`
 // ============================================================================
 
 impl<'a> Rem<&'a UInt> for UInt {
@@ -1377,7 +1377,7 @@ impl<'a> RemAssign<&'a UInt> for UInt {
 //  Binary, Oct, LowerHex and UpperHex implementations
 // ============================================================================
 
-use std::fmt;
+use core::fmt;
 
 impl fmt::Binary for UInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
There is only one thing currently not working which is `f64::log2` not being found by the compiler in `no_std` mode which is a rather strange bug.

The error looks like:
```
error[E0599]: no method named `log2` found for type `f64` in the current scope
   --> src/apint/serialization.rs:269:45
    |
269 |         let bits = f64::from(radix.to_u8()).log2() * v.len() as f64;
    |                                             ^^^^ method not found in `f64`
```

Needs further investigation.

**edit:**

Turns out the above error is a result of https://github.com/rust-lang/rfcs/issues/2505.
So we have several options to continue:
- Disapprove and discontinue any use of those `std`-only functions, remove all old code that depends on it which is fortunately just this one instance as far as it seems.
- Depend on [`libm`](https://github.com/rust-lang/libm#libm) to be able to continue depending on these functions. Note that `libm` does not provide the best possible performance.