### PR TITLE
Clean up the associated constants

### DIFF
--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -10,11 +10,6 @@ use crate::{
         },
         ApInt,
     },
-    digit,
-    digit::{
-        Digit,
-        DoubleDigit,
-    },
     errors::{
         DivOp,
         Error,
@@ -29,6 +24,8 @@ use crate::{
         forward_mut_impl,
         try_forward_bin_mut_impl,
     },
+    Digit,
+    DoubleDigit,
 };
 use core::ops::{
     Add,
@@ -348,14 +345,14 @@ impl ApInt {
                 // `DoubleDigit` multiplications in some places.
                 match (lhs_sig_nonzero == 0, rhs_sig_nonzero == 0) {
                     (false, false) => {
-                        let lhs_sig_bits = (lhs_sig_nonzero * digit::BITS)
-                            + (digit::BITS
+                        let lhs_sig_bits = (lhs_sig_nonzero * Digit::BITS)
+                            + (Digit::BITS
                                 - (lhs[lhs_sig_nonzero].leading_zeros() as usize));
-                        let rhs_sig_bits = (rhs_sig_nonzero * digit::BITS)
-                            + (digit::BITS
+                        let rhs_sig_bits = (rhs_sig_nonzero * Digit::BITS)
+                            + (Digit::BITS
                                 - (rhs[rhs_sig_nonzero].leading_zeros() as usize));
                         let tot_sig_bits = lhs_sig_bits + rhs_sig_bits;
-                        if tot_sig_bits <= (lhs.len() * digit::BITS) {
+                        if tot_sig_bits <= (lhs.len() * Digit::BITS) {
                             // No possibility of `Digit` wise overflow. Note that end bits
                             // still have to be trimmed for
                             // `ApInt`s with a width that is not a multiple of
@@ -910,8 +907,8 @@ impl ApInt {
             let div_lz = div[div_sd].leading_zeros() as usize;
             // number of significant bits
             let ini_duo_sb =
-                (ini_duo_sd * digit::BITS) + (digit::BITS - (ini_duo_lz as usize));
-            let div_sb = (div_sd * digit::BITS) + (digit::BITS - div_lz);
+                (ini_duo_sd * Digit::BITS) + (Digit::BITS - (ini_duo_lz as usize));
+            let div_sb = (div_sd * Digit::BITS) + (Digit::BITS - div_lz);
             // quotient is 0 precheck
             if ini_duo_sb < div_sb {
                 // the quotient should be 0 and remainder should be `duo`
@@ -951,7 +948,7 @@ impl ApInt {
             }
             let ini_bits = ini_duo_sb - div_sb;
             // difference between the places of the significant bits
-            if ini_bits < digit::BITS {
+            if ini_bits < Digit::BITS {
                 // the `mul` or `mul - 1` algorithm
                 let (duo_sig_dd, div_sig_dd) = if ini_duo_lz == 0 {
                     // avoid shr overflow
@@ -961,12 +958,12 @@ impl ApInt {
                     )
                 } else {
                     (
-                        (duo[ini_duo_sd].dd() << (ini_duo_lz + digit::BITS))
+                        (duo[ini_duo_sd].dd() << (ini_duo_lz + Digit::BITS))
                             | (duo[ini_duo_sd - 1].dd() << ini_duo_lz)
-                            | (duo[ini_duo_sd - 2].dd() >> (digit::BITS - ini_duo_lz)),
-                        (div[ini_duo_sd].dd() << (ini_duo_lz + digit::BITS))
+                            | (duo[ini_duo_sd - 2].dd() >> (Digit::BITS - ini_duo_lz)),
+                        (div[ini_duo_sd].dd() << (ini_duo_lz + Digit::BITS))
                             | (div[ini_duo_sd - 1].dd() << ini_duo_lz)
-                            | (div[ini_duo_sd - 2].dd() >> (digit::BITS - ini_duo_lz)),
+                            | (div[ini_duo_sd - 2].dd() >> (Digit::BITS - ini_duo_lz)),
                     )
                 };
                 let mul = duo_sig_dd.wrapping_div(div_sig_dd).lo();
@@ -1052,12 +1049,12 @@ impl ApInt {
             let mut duo_lz = ini_duo_lz;
             // the number of lesser significant digits and bits not a part of `div_sig_d`
             let div_lesser_bits =
-                digit::BITS - (div_lz as usize) + (digit::BITS * (div_sd - 1));
+                Digit::BITS - (div_lz as usize) + (Digit::BITS * (div_sd - 1));
             // the most significant `Digit` bits of div
             let div_sig_d = if div_lz == 0 {
                 div[div_sd]
             } else {
-                (div[div_sd] << div_lz) | (div[div_sd - 1] >> (digit::BITS - div_lz))
+                (div[div_sd] << div_lz) | (div[div_sd - 1] >> (Digit::BITS - div_lz))
             };
             // has to be a `DoubleDigit` in case of overflow
             let div_sig_d_add1 = div_sig_d.dd().wrapping_add(Digit::one().dd());
@@ -1065,24 +1062,24 @@ impl ApInt {
             let mut duo_sig_dd;
             // TODO: fix sizes here and below
             let quo_potential = len;
-            // if ini_bits % digit::BITS == 0 {ini_bits / digit::BITS}
-            // else {(ini_bits / digit::BITS) + 1};
+            // if ini_bits % Digit::BITS == 0 {ini_bits / Digit::BITS}
+            // else {(ini_bits / Digit::BITS) + 1};
             let mut quo: Vec<Digit> = vec![Digit::zero(); quo_potential as usize];
             loop {
                 duo_lesser_bits =
-                    (digit::BITS - (duo_lz as usize)) + (digit::BITS * (duo_sd - 2));
+                    (Digit::BITS - (duo_lz as usize)) + (Digit::BITS * (duo_sd - 2));
                 duo_sig_dd = if duo_lz == 0 {
                     DoubleDigit::from_lo_hi(duo[duo_sd - 1], duo[duo_sd])
                 } else {
-                    (duo[duo_sd].dd() << (duo_lz + digit::BITS))
+                    (duo[duo_sd].dd() << (duo_lz + Digit::BITS))
                         | (duo[duo_sd - 1].dd() << duo_lz)
-                        | (duo[duo_sd - 2].dd() >> (digit::BITS - duo_lz))
+                        | (duo[duo_sd - 2].dd() >> (Digit::BITS - duo_lz))
                 };
                 if duo_lesser_bits >= div_lesser_bits {
                     let bits = duo_lesser_bits - div_lesser_bits;
                     // bits_ll is the number of lesser bits in the digit that contains
                     // lesser and greater bits
-                    let (digits, bits_ll) = (bits / digit::BITS, bits % digit::BITS);
+                    let (digits, bits_ll) = (bits / Digit::BITS, bits % Digit::BITS);
                     // Unfortunately, `mul` here can be up to (2^2n - 1)/(2^(n-1)), where
                     // `n` is the number of bits in a `Digit`. This
                     // means that an `n+1` bit integer is needed to
@@ -1107,7 +1104,7 @@ impl ApInt {
                     quo[digits + 1] = temp.lo();
                     carry = temp.hi();
                     for i in (digits + 2)..quo.len() {
-                        if carry == digit::ZERO {
+                        if carry == Digit::ZERO {
                             break
                         }
                         let temp = quo[i].carrying_add(carry);
@@ -1212,9 +1209,9 @@ impl ApInt {
                         // avoid shr overflow
                         DoubleDigit::from_lo_hi(div[duo_sd - 1], div[duo_sd])
                     } else {
-                        (div[duo_sd].dd() << (duo_lz + digit::BITS))
+                        (div[duo_sd].dd() << (duo_lz + Digit::BITS))
                             | (div[duo_sd - 1].dd() << duo_lz)
-                            | (div[duo_sd - 2].dd() >> (digit::BITS - duo_lz))
+                            | (div[duo_sd - 2].dd() >> (Digit::BITS - duo_lz))
                     };
                     let mul = duo_sig_dd.wrapping_div(div_sig_dd).lo();
                     // I could avoid allocation but it would involve more long division to
@@ -1286,7 +1283,7 @@ impl ApInt {
                     }
                 }
                 duo_lz = duo[duo_sd].leading_zeros() as usize;
-                let duo_sb = (duo_sd * digit::BITS) + (digit::BITS - duo_lz);
+                let duo_sb = (duo_sd * Digit::BITS) + (Digit::BITS - duo_lz);
                 //`quo` should have 0 or 1 added to it check
                 if duo_sb == div_sb {
                     // if `div <= duo`

--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -51,11 +51,11 @@ impl ApInt {
     pub fn wrapping_inc(&mut self) {
         match self.access_data_mut() {
             DataAccessMut::Inl(x) => {
-                *x = x.wrapping_add(Digit::one());
+                *x = x.wrapping_add(Digit::ONE);
             }
             DataAccessMut::Ext(x) => {
                 for i in 0..x.len() {
-                    match x[i].overflowing_add(Digit::one()) {
+                    match x[i].overflowing_add(Digit::ONE) {
                         (v, false) => {
                             x[i] = v;
                             break
@@ -81,11 +81,11 @@ impl ApInt {
     pub fn wrapping_dec(&mut self) {
         match self.access_data_mut() {
             DataAccessMut::Inl(x) => {
-                *x = x.wrapping_sub(Digit::one());
+                *x = x.wrapping_sub(Digit::ONE);
             }
             DataAccessMut::Ext(x) => {
                 for i in 0..x.len() {
-                    match x[i].overflowing_sub(Digit::one()) {
+                    match x[i].overflowing_sub(Digit::ONE) {
                         (v, false) => {
                             x[i] = v;
                             break
@@ -167,7 +167,7 @@ impl ApInt {
     pub(crate) fn overflowing_uadd_assign(&mut self, rhs: &ApInt) -> Result<bool> {
         match self.width().excess_bits() {
             Some(excess) => {
-                let mask = Digit::all_set() >> excess;
+                let mask = Digit::ONES >> excess;
                 match self.zip_access_data_mut_self(rhs)? {
                     Inl(lhs, rhs) => {
                         let temp = lhs.wrapping_add(rhs);
@@ -215,7 +215,7 @@ impl ApInt {
                             carry = temp.hi();
                         }
                         // no excess bits to clear
-                        Ok(carry != Digit::zero())
+                        Ok(!carry.is_zero())
                     }
                 }
             }
@@ -252,7 +252,7 @@ impl ApInt {
                 let (temp, mut carry) = lhs[0]
                     .dd()
                     .wrapping_add((!rhs[0]).dd())
-                    .wrapping_add(Digit::one().dd())
+                    .wrapping_add(Digit::ONE.dd())
                     .lo_hi();
                 lhs[0] = temp;
                 for i in 1..lhs.len() {
@@ -315,26 +315,26 @@ impl ApInt {
             Ext(lhs, rhs) => {
                 // finds the most significant nonzero digit (for later optimizations) and
                 // handles early return of multiplication by zero.
-                let rhs_sig_nonzero: usize =
-                    match rhs.iter().rposition(|x| x != &Digit::zero()) {
-                        Some(x) => x,
-                        None => {
-                            for x in lhs.iter_mut() {
-                                x.unset_all()
-                            }
-                            return Ok(())
+                let rhs_sig_nonzero: usize = match rhs.iter().rposition(|x| !x.is_zero())
+                {
+                    Some(x) => x,
+                    None => {
+                        for x in lhs.iter_mut() {
+                            x.unset_all()
                         }
-                    };
-                let lhs_sig_nonzero: usize =
-                    match lhs.iter().rposition(|x| x != &Digit::zero()) {
-                        Some(x) => x,
-                        None => {
-                            for x in lhs.iter_mut() {
-                                x.unset_all()
-                            }
-                            return Ok(())
+                        return Ok(())
+                    }
+                };
+                let lhs_sig_nonzero: usize = match lhs.iter().rposition(|x| !x.is_zero())
+                {
+                    Some(x) => x,
+                    None => {
+                        for x in lhs.iter_mut() {
+                            x.unset_all()
                         }
-                    };
+                        return Ok(())
+                    }
+                };
                 // for several routines below there was a nested loop that had its first
                 // and last iterations unrolled (and the unrolled loops
                 // had their first and last iterations unrolled), and then
@@ -715,7 +715,7 @@ impl ApInt {
             ($len:expr, $array:ident) => {
                 for i0 in 0..$len {
                     let bitnot = !$array[i0];
-                    match bitnot.overflowing_add(Digit::one()) {
+                    match bitnot.overflowing_add(Digit::ONE) {
                         (v, false) => {
                             $array[i0] = v;
                             for i1 in (i0 + 1)..$len {
@@ -747,7 +747,7 @@ impl ApInt {
                 let mut b0 = false;
                 // allows lhs.len() to be smaller than rhs.len()
                 for i in ($lhs_len..$rhs_len).rev() {
-                    if $rhs[i] != Digit::zero() {
+                    if !$rhs[i].is_zero() {
                         b0 = true;
                         break
                     }
@@ -789,7 +789,7 @@ impl ApInt {
                 let mut b0 = false;
                 // allows lhs.len() to be smaller than rhs.len()
                 for i in ($lhs_len..$rhs_len).rev() {
-                    if $rhs[i] != Digit::zero() {
+                    if !$rhs[i].is_zero() {
                         b0 = true;
                         break
                     }
@@ -860,7 +860,7 @@ impl ApInt {
                 let (temp, mut carry) = $add[0].carrying_add($val);
                 $sum[0] = temp;
                 for i0 in 1..$len {
-                    if carry == Digit::zero() {
+                    if carry.is_zero() {
                         for i1 in i0..$len {
                             $sum[i1] = $add[i1];
                             break
@@ -931,7 +931,7 @@ impl ApInt {
                     div,
                     {
                         twos_complement!(place, div);
-                        special0!(place, duo, div, div, Digit::one());
+                        special0!(place, duo, div, div, Digit::ONE);
                         return
                     },
                     {
@@ -987,13 +987,13 @@ impl ApInt {
                 if div_sd == len - 1 {
                     let temp = mul.carrying_mul_add(div[div_sd], carry);
                     sub.push(temp.0);
-                    if temp.1 != Digit::zero() {
+                    if !temp.1.is_zero() {
                         // overflow
                         // the quotient should be `mul - 1` and remainder should be
                         //`duo + (div - div*mul)`
                         twos_complement!(len, sub);
                         add!(len, sub, div);
-                        special0!(len, duo, sub, div, mul.wrapping_sub(Digit::one()));
+                        special0!(len, duo, sub, div, mul.wrapping_sub(Digit::ONE));
                         return
                     }
                     // if `div * mul > duo`
@@ -1005,7 +1005,7 @@ impl ApInt {
                         {
                             twos_complement!(len, sub);
                             add!(len, sub, div);
-                            special0!(len, duo, sub, div, mul.wrapping_sub(Digit::one()));
+                            special0!(len, duo, sub, div, mul.wrapping_sub(Digit::ONE));
                             return
                         },
                         {
@@ -1021,7 +1021,7 @@ impl ApInt {
                     sub.push(temp.0);
                     sub.push(temp.1);
                     for _ in sub.len()..len {
-                        sub.push(Digit::zero());
+                        sub.push(Digit::ZERO);
                     }
                     // if `div * mul > duo`
                     ugt!(
@@ -1032,7 +1032,7 @@ impl ApInt {
                         {
                             twos_complement!(len, sub);
                             add!(len, sub, div);
-                            special0!(len, duo, sub, div, mul.wrapping_sub(Digit::one()));
+                            special0!(len, duo, sub, div, mul.wrapping_sub(Digit::ONE));
                             return
                         },
                         {
@@ -1057,14 +1057,14 @@ impl ApInt {
                 (div[div_sd] << div_lz) | (div[div_sd - 1] >> (Digit::BITS - div_lz))
             };
             // has to be a `DoubleDigit` in case of overflow
-            let div_sig_d_add1 = div_sig_d.dd().wrapping_add(Digit::one().dd());
+            let div_sig_d_add1 = div_sig_d.dd().wrapping_add(Digit::ONE.dd());
             let mut duo_lesser_bits;
             let mut duo_sig_dd;
             // TODO: fix sizes here and below
             let quo_potential = len;
             // if ini_bits % Digit::BITS == 0 {ini_bits / Digit::BITS}
             // else {(ini_bits / Digit::BITS) + 1};
-            let mut quo: Vec<Digit> = vec![Digit::zero(); quo_potential as usize];
+            let mut quo: Vec<Digit> = vec![Digit::ZERO; quo_potential as usize];
             loop {
                 duo_lesser_bits =
                     (Digit::BITS - (duo_lz as usize)) + (Digit::BITS * (duo_sd - 2));
@@ -1104,7 +1104,7 @@ impl ApInt {
                     quo[digits + 1] = temp.lo();
                     carry = temp.hi();
                     for i in (digits + 2)..quo.len() {
-                        if carry == Digit::ZERO {
+                        if carry.is_zero() {
                             break
                         }
                         let temp = quo[i].carrying_add(carry);
@@ -1117,7 +1117,7 @@ impl ApInt {
                     // in order to not break this. these blocks
                     // subtract `(mul * div) << bits` from `duo` check
                     // for highest bit set
-                    if mul.hi() == Digit::zero() {
+                    if mul.hi().is_zero() {
                         let mul = mul.lo();
                         // carry for bits that wrap across digit boundaries when `<<
                         // bits_ll` applied
@@ -1129,7 +1129,7 @@ impl ApInt {
                         let (temp2, mut add_carry) = (!temp1)
                             .dd()
                             .wrapping_add(duo[digits].dd())
-                            .wrapping_add(Digit::one().dd())
+                            .wrapping_add(Digit::ONE.dd())
                             .lo_hi();
                         duo[digits] = temp2;
                         for i in (digits + 1)..=duo_sd {
@@ -1171,11 +1171,11 @@ impl ApInt {
                         let mul = mul.lo();
                         let (temp0, mut mul_carry) = mul.carrying_mul(div[0]);
                         let temp1 = temp0;
-                        let mut add0_carry = Digit::zero();
+                        let mut add0_carry = Digit::ZERO;
                         // the increment from the two's complement can be stored in
                         // `wrap_carry`
                         let (temp2, mut wrap_carry) =
-                            ((!temp1).dd().wrapping_add(Digit::one().dd()) << bits_ll)
+                            ((!temp1).dd().wrapping_add(Digit::ONE.dd()) << bits_ll)
                                 .lo_hi();
                         let (temp3, mut add1_carry) = temp2.carrying_add(duo[digits]);
                         duo[digits] = temp3;
@@ -1235,7 +1235,7 @@ impl ApInt {
                     sub.push(temp.0);
                     sub.push(temp.1);
                     for _ in (div_sd + 2)..len {
-                        sub.push(Digit::zero());
+                        sub.push(Digit::ZERO);
                     }
                     let sub_len = sub.len();
                     ugt!(
@@ -1253,7 +1253,7 @@ impl ApInt {
                                 duo,
                                 sub,
                                 div,
-                                mul.wrapping_sub(Digit::one()),
+                                mul.wrapping_sub(Digit::ONE),
                                 quo
                             );
                             return
@@ -1269,14 +1269,14 @@ impl ApInt {
                 }
                 // find the new `duo_sd`
                 for i in (0..=duo_sd).rev() {
-                    if duo[i] != Digit::zero() {
+                    if !duo[i].is_zero() {
                         duo_sd = i;
                         break
                     }
                     if i == 0 {
                         // the quotient should be `quo` and remainder should be zero
                         for i in 0..len {
-                            div[i] = Digit::zero();
+                            div[i] = Digit::ZERO;
                             duo[i] = quo[i];
                         }
                         return
@@ -1298,7 +1298,7 @@ impl ApInt {
                             twos_complement!(len, div);
                             add!(len, div, duo);
                             for i0 in 0..len {
-                                match quo[i0].overflowing_add(Digit::one()) {
+                                match quo[i0].overflowing_add(Digit::ONE) {
                                     (v, false) => {
                                         duo[i0] = v;
                                         for i1 in (i0 + 1)..len {
@@ -1352,7 +1352,7 @@ impl ApInt {
                     duo[1] = temp.lo();
                     carry = temp.hi();
                     for i0 in 2..len {
-                        if carry == Digit::zero() {
+                        if carry.is_zero() {
                             duo[i0..len].clone_from_slice(&quo[i0..len]);
                             break
                         }
@@ -1369,21 +1369,20 @@ impl ApInt {
         // both because the core long division algorithm does not work on many
         // edges, and because of optimization. find the most significant non
         // zeroes, check for `duo` < `div`, and check for division by zero
-        match div.iter().rposition(|x| x != &Digit::zero()) {
+        match div.iter().rposition(|x| !x.is_zero()) {
             Some(div_sd) => {
                 // the initial most significant nonzero duo digit
-                let ini_duo_sd: usize =
-                    match duo.iter().rposition(|x| x != &Digit::zero()) {
-                        Some(x) => x,
-                        None => {
-                            // quotient and remainder should be 0
-                            // duo is already zero
-                            for x in div.iter_mut() {
-                                x.unset_all()
-                            }
-                            return true
+                let ini_duo_sd: usize = match duo.iter().rposition(|x| !x.is_zero()) {
+                    Some(x) => x,
+                    None => {
+                        // quotient and remainder should be 0
+                        // duo is already zero
+                        for x in div.iter_mut() {
+                            x.unset_all()
                         }
-                    };
+                        return true
+                    }
+                };
                 if ini_duo_sd < div_sd {
                     // the divisor is larger than the dividend
                     // quotient should be 0 and remainder is `duo`
@@ -1462,7 +1461,7 @@ impl ApInt {
     pub fn wrapping_udivrem_assign(lhs: &mut ApInt, rhs: &mut ApInt) -> Result<()> {
         match ApInt::zip_access_data_mut_both(lhs, rhs)? {
             ZipDataAccessMutBoth::Inl(duo, div) => {
-                if *div != Digit::zero() {
+                if !div.is_zero() {
                     let temp = duo.wrapping_divrem(*div);
                     *duo = temp.0;
                     *div = temp.1;
@@ -1494,7 +1493,7 @@ impl ApInt {
     pub fn wrapping_uremdiv_assign(lhs: &mut ApInt, rhs: &mut ApInt) -> Result<()> {
         match ApInt::zip_access_data_mut_both(lhs, rhs)? {
             ZipDataAccessMutBoth::Inl(duo, div) => {
-                if *div != Digit::zero() {
+                if !div.is_zero() {
                     let temp = duo.wrapping_divrem(*div);
                     *duo = temp.1;
                     *div = temp.0;

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -8,8 +8,10 @@ use crate::{
     },
     bitpos::BitPos,
     checks,
-    digit,
-    digit::Bit,
+    digit::{
+        Bit,
+        Digit,
+    },
     errors::Result,
     traits::Width,
     utils::{
@@ -294,7 +296,7 @@ impl ApInt {
         // Since `ApInt` instances with width's that are no powers of two
         // have unused excess bits that are always zero we need to cut them off
         // for a correct implementation of this operation.
-        zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
+        zeros - (Digit::BITS - self.width().excess_bits().unwrap_or(Digit::BITS))
     }
 
     /// Returns the number of leading zeros in the binary representation of this
@@ -304,11 +306,11 @@ impl ApInt {
         for d in self.as_digit_slice().iter().rev() {
             let leading_zeros = d.repr().leading_zeros() as usize;
             zeros += leading_zeros;
-            if leading_zeros != digit::BITS {
+            if leading_zeros != Digit::BITS {
                 break
             }
         }
-        zeros - (digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS))
+        zeros - (Digit::BITS - self.width().excess_bits().unwrap_or(Digit::BITS))
     }
 
     /// Returns the number of trailing zeros in the binary representation of
@@ -318,12 +320,12 @@ impl ApInt {
         for d in self.as_digit_slice() {
             let trailing_zeros = d.repr().trailing_zeros() as usize;
             zeros += trailing_zeros;
-            if trailing_zeros != digit::BITS {
+            if trailing_zeros != Digit::BITS {
                 break
             }
         }
         if zeros >= self.width().to_usize() {
-            zeros -= digit::BITS - self.width().excess_bits().unwrap_or(digit::BITS);
+            zeros -= Digit::BITS - self.width().excess_bits().unwrap_or(Digit::BITS);
         }
         zeros
     }

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -213,7 +213,7 @@ impl ApInt {
                 return false
             }
         }
-        rest.iter().all(|d| d.is_all_set())
+        rest.iter().all(|d| *d == Digit::ONES)
     }
 
     /// Sets all bits of this `ApInt` to zero (`0`).

--- a/src/apint/casting.rs
+++ b/src/apint/casting.rs
@@ -13,6 +13,7 @@ use crate::{
         forward_bin_mut_impl,
         try_forward_bin_mut_impl,
     },
+    Digit,
 };
 
 impl Clone for ApInt {
@@ -281,13 +282,12 @@ impl ApInt {
             // must allocate a new buffer that fits for the required amount of digits
             // for the target width. Also we need to `memcpy` the digits of the
             // extended `ApInt` to the newly allocated buffer.
-            use crate::digit;
             use core::iter;
             assert!(target_req_digits > actual_req_digits);
             let additional_digits = target_req_digits - actual_req_digits;
             let extended_clone = ApInt::from_iter(
                 self.digits()
-                    .chain(iter::repeat(digit::ZERO).take(additional_digits)),
+                    .chain(iter::repeat(Digit::ZERO).take(additional_digits)),
             )
             .and_then(|apint| apint.into_truncate(target_width))?;
             *self = extended_clone;
@@ -380,7 +380,6 @@ impl ApInt {
             // must allocate a new buffer that fits for the required amount of digits
             // for the target width. Also we need to `memcpy` the digits of the
             // extended `ApInt` to the newly allocated buffer.
-            use crate::digit;
             use core::iter;
             assert!(target_req_digits > actual_req_digits);
             let additional_digits = target_req_digits - actual_req_digits;
@@ -394,7 +393,7 @@ impl ApInt {
 
             let extended_copy = ApInt::from_iter(
                 self.digits()
-                    .chain(iter::repeat(digit::ONES).take(additional_digits)),
+                    .chain(iter::repeat(Digit::ONES).take(additional_digits)),
             )
             .and_then(|apint| apint.into_truncate(target_width))?;
 

--- a/src/apint/constructors.rs
+++ b/src/apint/constructors.rs
@@ -4,17 +4,14 @@ use crate::{
         ApIntData,
     },
     bitwidth::BitWidth,
-    digit,
-    digit::{
-        Bit,
-        Digit,
-    },
+    digit::Bit,
     errors::{
         Error,
         Result,
     },
     mem::vec::Vec,
     storage::Storage,
+    Digit,
 };
 
 use smallvec::SmallVec;
@@ -157,7 +154,7 @@ impl ApInt {
 
     /// Creates a new `ApInt` from a given `u128` value with a bit-width of 128.
     pub fn from_u128(val: u128) -> ApInt {
-        let hi = (val >> digit::BITS) as u64;
+        let hi = (val >> Digit::BITS) as u64;
         let lo = (val & ((1u128 << 64) - 1)) as u64;
         ApInt::from([hi, lo])
     }
@@ -193,7 +190,7 @@ impl ApInt {
             }
             n => {
                 use core::mem;
-                let bitwidth = BitWidth::new(n * digit::BITS).expect(
+                let bitwidth = BitWidth::new(n * Digit::BITS).expect(
                     "We have already asserted that the number of items the given \
                      Iterator iterates over is greater than `1` and thus non-zero and \
                      thus a valid `BitWidth`.",
@@ -249,7 +246,7 @@ impl ApInt {
 
     /// Creates a new `ApInt` with the given bit width that represents zero.
     pub fn zero(width: BitWidth) -> ApInt {
-        ApInt::repeat_digit(width, digit::ZERO)
+        ApInt::repeat_digit(width, Digit::ZERO)
     }
 
     /// Creates a new `ApInt` with the given bit width that represents one.
@@ -266,7 +263,7 @@ impl ApInt {
 
     /// Creates a new `ApInt` with the given bit width that has all bits set.
     pub fn all_set(width: BitWidth) -> ApInt {
-        ApInt::repeat_digit(width, digit::ONES)
+        ApInt::repeat_digit(width, Digit::ONES)
     }
 
     /// Returns the smallest unsigned `ApInt` that can be represented by the

--- a/src/apint/constructors.rs
+++ b/src/apint/constructors.rs
@@ -471,14 +471,14 @@ mod tests {
         {
             let explicit = ApInt::from_bit(Bit::Set);
             let implicit = ApInt::from(Bit::Set);
-            let expected = ApInt::new_inl(BitWidth::w1(), Digit::one());
+            let expected = ApInt::new_inl(BitWidth::w1(), Digit::ONE);
             assert_eq!(explicit, implicit);
             assert_eq!(explicit, expected);
         }
         {
             let explicit = ApInt::from_bit(Bit::Unset);
             let implicit = ApInt::from(Bit::Unset);
-            let expected = ApInt::new_inl(BitWidth::w1(), Digit::zero());
+            let expected = ApInt::new_inl(BitWidth::w1(), Digit::ZERO);
             assert_eq!(explicit, implicit);
             assert_eq!(explicit, expected);
         }

--- a/src/apint/relational.rs
+++ b/src/apint/relational.rs
@@ -3,8 +3,10 @@ use crate::{
         utils::ZipDataAccess,
         ApInt,
     },
-    digit,
-    digit::Bit,
+    digit::{
+        Bit,
+        Digit,
+    },
     errors::Result,
     mem::format,
     traits::Width,
@@ -144,7 +146,7 @@ impl ApInt {
             .and_then(|zipped| {
                 match zipped {
                     ZipDataAccess::Inl(lhs, rhs) => {
-                        let infate_abs = digit::BITS - self.width().to_usize();
+                        let infate_abs = Digit::BITS - self.width().to_usize();
                         let lhs = (lhs.repr() << infate_abs) as i64;
                         let rhs = (rhs.repr() << infate_abs) as i64;
                         Ok(lhs < rhs)

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -101,7 +101,7 @@ impl ApInt {
                     digits
                         .iter_mut()
                         .take(digit_steps)
-                        .for_each(|d| *d = Digit::zero());
+                        .for_each(|d| *d = Digit::ZERO);
                 }
                 let bit_steps = shift_amount.bit_steps();
                 if bit_steps != 0 {
@@ -161,7 +161,7 @@ impl ApInt {
                         .iter_mut()
                         .rev()
                         .take(digit_steps)
-                        .for_each(|d| *d = Digit::zero());
+                        .for_each(|d| *d = Digit::ZERO);
                 }
                 let bit_steps = shift_amount.bit_steps();
                 if bit_steps > 0 {

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -4,14 +4,11 @@ use crate::{
         ApInt,
     },
     checks,
-    digit,
-    digit::{
-        Bit,
-        Digit,
-    },
+    digit::Bit,
     errors::Result,
     traits::Width,
     utils::try_forward_bin_mut_impl,
+    Digit,
 };
 
 /// Represents an amount of bits to shift an `ApInt`.
@@ -39,7 +36,7 @@ impl ShiftAmount {
     /// - `ShiftAmount(150)` leaps over 2 digits.
     #[inline]
     pub(in crate::apint) fn digit_steps(self) -> usize {
-        self.to_usize() / digit::BITS
+        self.to_usize() / Digit::BITS
     }
 
     /// Returns the number of bits within a single digit this
@@ -57,7 +54,7 @@ impl ShiftAmount {
     /// - `ShiftAmount(150)` leaps over `22` bits.
     #[inline]
     pub(in crate::apint) fn bit_steps(self) -> usize {
-        self.to_usize() % digit::BITS
+        self.to_usize() % Digit::BITS
     }
 }
 
@@ -111,7 +108,7 @@ impl ApInt {
                     let mut carry = 0;
                     for elem in digits[digit_steps..].iter_mut() {
                         let repr = elem.repr();
-                        let new_carry = repr >> (digit::BITS - bit_steps);
+                        let new_carry = repr >> (Digit::BITS - bit_steps);
                         *elem = Digit((repr << bit_steps) | carry);
                         carry = new_carry;
                     }
@@ -171,7 +168,7 @@ impl ApInt {
                     let mut borrow = 0;
                     for elem in digits.iter_mut().rev() {
                         let repr = elem.repr();
-                        let new_borrow = repr << (digit::BITS - bit_steps);
+                        let new_borrow = repr << (Digit::BITS - bit_steps);
                         *elem = Digit((repr >> bit_steps) | borrow);
                         borrow = new_borrow;
                     }
@@ -226,12 +223,12 @@ impl ApInt {
             return Ok(())
         }
         let width = self.width();
-        let width_bits = width.to_usize() % digit::BITS;
-        let (digits, bits) = (shift_amount / digit::BITS, shift_amount % digit::BITS);
-        let uns = digit::BITS - bits;
+        let width_bits = width.to_usize() % Digit::BITS;
+        let (digits, bits) = (shift_amount / Digit::BITS, shift_amount % Digit::BITS);
+        let uns = Digit::BITS - bits;
         match self.access_data_mut() {
             DataAccessMut::Inl(x) => {
-                *x = (*x >> bits) | (digit::ONES << (width.to_usize() - bits));
+                *x = (*x >> bits) | (Digit::ONES << (width.to_usize() - bits));
             }
             DataAccessMut::Ext(x) => {
                 if width_bits != 0 {
@@ -243,7 +240,7 @@ impl ApInt {
                     for i in 0..(x.len() - 1) {
                         x[i] = (x[i] >> bits) | (x[i + 1] << uns);
                     }
-                    x[x.len() - 1] = (x[x.len() - 1] >> bits) | (digit::ONES << uns);
+                    x[x.len() - 1] = (x[x.len() - 1] >> bits) | (Digit::ONES << uns);
                 } else if bits == 0 {
                     // digit shift
                     for i in digits..x.len() {
@@ -257,7 +254,7 @@ impl ApInt {
                     for i in digits..(x.len() - 1) {
                         x[i - digits] = (x[i] >> bits) | (x[i + 1] << uns);
                     }
-                    x[diff - 1] = (x[x.len() - 1] >> bits) | (digit::ONES << uns);
+                    x[diff - 1] = (x[x.len() - 1] >> bits) | (Digit::ONES << uns);
                     for i in 0..digits {
                         x[i + diff].set_all();
                     }
@@ -357,7 +354,6 @@ mod tests {
 
         #[test]
         fn assign_xtra_large_ok() {
-            use crate::digit;
             let d0 = 0xFEDC_BA98_7654_3210;
             let d1 = 0x5555_5555_4444_4444;
             let d2 = 0xAAAA_AAAA_CCCC_CCCC;
@@ -371,8 +367,8 @@ mod tests {
                 assert_eq!(bit_steps, 36);
                 let result = ApInt::from(input).into_wrapping_shl(shamt).unwrap();
                 let expected: [u64; 4] = [
-                    (d1 << bit_steps) | (d2 >> (digit::BITS - bit_steps)),
-                    (d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
+                    (d1 << bit_steps) | (d2 >> (Digit::BITS - bit_steps)),
+                    (d2 << bit_steps) | (d3 >> (Digit::BITS - bit_steps)),
                     (d3 << bit_steps),
                     0,
                 ];
@@ -387,7 +383,7 @@ mod tests {
                 assert_eq!(bit_steps, 22);
                 let result = ApInt::from(input).into_wrapping_shl(shamt).unwrap();
                 let expected: [u64; 4] = [
-                    (d2 << bit_steps) | (d3 >> (digit::BITS - bit_steps)),
+                    (d2 << bit_steps) | (d3 >> (Digit::BITS - bit_steps)),
                     (d3 << bit_steps),
                     0,
                     0,

--- a/src/apint/to_primitive.rs
+++ b/src/apint/to_primitive.rs
@@ -1,13 +1,12 @@
 use crate::{
     apint::ApInt,
     bitwidth::BitWidth,
-    digit,
-    digit::Digit,
     errors::{
         Error,
         Result,
     },
     traits::Width,
+    Digit,
 };
 
 /// Represents a primitive data type.
@@ -271,7 +270,7 @@ impl ApInt {
         let (lsd_0, rest) = self.split_least_significant_digit();
         let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
         let mut result: i128 =
-            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+            (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
         let actual_width = self.width();
         let target_width = BitWidth::w128();
 
@@ -300,7 +299,7 @@ impl ApInt {
         let (lsd_0, rest) = self.split_least_significant_digit();
         let (&lsd_1, _) = rest.split_first().unwrap_or((&Digit(0), &[]));
         let result: u128 =
-            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+            (u128::from(lsd_1.repr()) << Digit::BITS) + u128::from(lsd_0.repr());
         result
     }
 }
@@ -534,7 +533,7 @@ impl ApInt {
             .into()
         }
         let mut result: i128 =
-            (i128::from(lsd_1.repr()) << digit::BITS) + i128::from(lsd_0.repr());
+            (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
 
         let actual_width = self.width();
         let target_width = BitWidth::w128();
@@ -579,7 +578,7 @@ impl ApInt {
             .into()
         }
         let result: u128 =
-            (u128::from(lsd_1.repr()) << digit::BITS) + u128::from(lsd_0.repr());
+            (u128::from(lsd_1.repr()) << Digit::BITS) + u128::from(lsd_0.repr());
         Ok(result)
     }
 }

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -392,10 +392,10 @@ impl ApInt {
     #[inline]
     pub fn is_one(&self) -> bool {
         match self.access_data() {
-            DataAccess::Inl(digit) => digit == Digit::one(),
+            DataAccess::Inl(digit) => digit == Digit::ONE,
             DataAccess::Ext(digits) => {
                 let (last, rest) = digits.split_last().unwrap_or_else(|| unreachable!());
-                last.is_one() && rest.iter().all(|digit| digit.is_zero())
+                (*last == Digit::ONE) && rest.iter().all(|digit| digit.is_zero())
             }
         }
     }

--- a/src/bitpos.rs
+++ b/src/bitpos.rs
@@ -1,6 +1,6 @@
 use crate::{
-    digit,
     errors::Result,
+    Digit,
 };
 
 /// Represents a bit position within an `ApInt`.
@@ -37,7 +37,7 @@ impl BitPos {
     /// operate on `Digit` instances.
     #[inline]
     pub(crate) fn to_pos_within_digit(self) -> BitPos {
-        BitPos(self.0 % digit::BITS)
+        BitPos(self.0 % Digit::BITS)
     }
 
     /// Splits this `BitPos` that may range over several `Digit`s within an
@@ -45,8 +45,8 @@ impl BitPos {
     /// bit position.
     #[inline]
     pub(crate) fn to_digit_and_bit_pos(self) -> (DigitPos, BitPos) {
-        let digit_pos = self.0 / digit::BITS;
-        let bit_pos = BitPos::from(self.0 % digit::BITS);
+        let digit_pos = self.0 / Digit::BITS;
+        let bit_pos = BitPos::from(self.0 % Digit::BITS);
         (digit_pos, bit_pos)
     }
 }

--- a/src/bitwidth.rs
+++ b/src/bitwidth.rs
@@ -1,12 +1,12 @@
 use crate::{
     apint::ShiftAmount,
     bitpos::BitPos,
-    digit,
     errors::{
         Error,
         Result,
     },
     storage::Storage,
+    Digit,
 };
 
 /// The `BitWidth` represents the length of an `ApInt`.
@@ -121,7 +121,7 @@ impl BitWidth {
     ///
     /// *Note:* A better name for this method has yet to be found!
     pub(crate) fn excess_bits(self) -> Option<usize> {
-        match self.to_usize() % digit::BITS {
+        match self.to_usize() % Digit::BITS {
             0 => None,
             n => Some(n),
         }
@@ -153,7 +153,7 @@ impl BitWidth {
     /// *Note:* Maybe we should move this method somewhere else?
     #[inline]
     pub(crate) fn required_digits(self) -> usize {
-        ((self.to_usize() - 1) / digit::BITS) + 1
+        ((self.to_usize() - 1) / Digit::BITS) + 1
     }
 }
 

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -275,41 +275,6 @@ impl DoubleDigit {
     }
 }
 
-/// # Constructors
-impl Digit {
-    /// Creates a digit that represents the value `0`.
-    ///
-    /// **Note:** In twos-complement this means that all bits are `0`.
-    pub fn zero() -> Digit {
-        Digit::ZERO
-    }
-
-    /// Creates a digit that represents the value `1`.
-    pub fn one() -> Digit {
-        Digit::ONE
-    }
-
-    /// Returns `true` if this `Digit` is zero (`0`).
-    pub fn is_zero(self) -> bool {
-        self == Digit::ZERO
-    }
-
-    /// Returns `true` if this `Digit` is one (`1`).
-    pub fn is_one(self) -> bool {
-        self == Digit::ONE
-    }
-
-    /// Returns `true` if this `Digit` has all bits set.
-    pub fn is_all_set(self) -> bool {
-        self == Digit::ONES
-    }
-
-    /// Creates a digit where all bits are initialized to `1`.
-    pub fn all_set() -> Digit {
-        Digit::ONES
-    }
-}
-
 /// # Utility & helper methods.
 impl Digit {
     /// Returns the `Digit`'s value as internal representation.
@@ -339,8 +304,8 @@ impl Digit {
     pub(crate) fn carrying_add(self, other: Digit) -> (Digit, Digit) {
         // this is to make sure that the assembly compiles down to the `adc` function
         match self.repr().overflowing_add(other.repr()) {
-            (x, false) => (Digit(x), Digit::zero()),
-            (x, true) => (Digit(x), Digit::one()),
+            (x, false) => (Digit(x), Digit::ZERO),
+            (x, true) => (Digit(x), Digit::ONE),
         }
     }
 
@@ -484,6 +449,10 @@ impl Width for DoubleDigit {
 
 /// # Bitwise access
 impl Digit {
+    pub fn is_zero(self) -> bool {
+        self == Digit::ZERO
+    }
+
     /// Returns the least significant `Bit` of this `Digit`.
     ///
     /// Note: This may be useful to determine if a `Digit`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,11 @@ mod traits;
 mod uint;
 mod utils;
 
+pub(crate) use digit::{
+    Digit,
+    DoubleDigit,
+};
+
 pub use crate::{
     apint::{
         ApInt,

--- a/src/ll.rs
+++ b/src/ll.rs
@@ -44,6 +44,6 @@ pub(crate) fn borrow_sub(a: Digit, b: Digit, borrow: &mut Digit) -> Digit {
     //     hi * (base) + lo        ==    1 * (base) + ai - bi - borrow
     // =>  a_i - b_i - borrow < 0   <==>   hi == 0
 
-    *borrow = if hi == Digit::zero() { Digit::one() } else { Digit::zero() };
+    *borrow = if hi.is_zero() { Digit::ONE } else { Digit::ZERO };
     lo
 }

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -123,7 +123,7 @@ impl Radix {
         // To generate this table:
         // ```
         // for radix in 2u64..37 {
-        //     let mut power = digit::BITS / find_last_bit_set(radix.to_u8() as u64);
+        //     let mut power = Digit::BITS / find_last_bit_set(radix.to_u8() as u64);
         //     let mut base = (radix.to_u8() as u32).pow(power as u32);
         //     while let Some(b) = base.checked_mul(radix) {
         //         base = b;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitwidth::BitWidth,
-    digit,
+    Digit,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -33,6 +33,6 @@ impl Storage {
     /// optimization.
     #[inline]
     fn is_inline(width: BitWidth) -> bool {
-        width.to_usize() <= digit::BITS
+        width.to_usize() <= Digit::BITS
     }
 }


### PR DESCRIPTION
This makes constants such as `digit::ZERO` and `digit::BITS` into associated constants, which makes more sense and eliminates several imports for `digit`. I also remove redundant functions such as `Digit::zero()` and `Digit::is_all_set()`. I decided to keep `Digit::is_zero()` because of how often it is used and regularized all comparisons of `Digit::ZERO`.