### PR TITLE
Issue 41 fixes: overhauling `BitWidth` construction

### DIFF
--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -307,121 +307,105 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::bitwidth::BitWidth;
+    use crate::bw;
 
     // Note: there are more tests of the counting functions in `uint.rs`
 
     #[test]
     fn count_ones() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w8()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w16()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w32()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w64()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w128()).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(1)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(8)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(16)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(32)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(64)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(128)).count_ones(), 0);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(1)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(8)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(16)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(32)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(64)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(128)).count_ones(), 1);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_ones(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_ones(), 7);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_ones(), 15);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_ones(), 31);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_ones(), 63);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_ones(), 127);
+        assert_eq!(ApInt::signed_max_value(bw(1)).count_ones(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(8)).count_ones(), 7);
+        assert_eq!(ApInt::signed_max_value(bw(16)).count_ones(), 15);
+        assert_eq!(ApInt::signed_max_value(bw(32)).count_ones(), 31);
+        assert_eq!(ApInt::signed_max_value(bw(64)).count_ones(), 63);
+        assert_eq!(ApInt::signed_max_value(bw(128)).count_ones(), 127);
     }
 
     #[test]
     fn count_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).count_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).count_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).count_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).count_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).count_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).count_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).count_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).count_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).count_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).count_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).count_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).count_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_zeros(), 7);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_zeros(), 15);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_zeros(), 31);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_zeros(), 63);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_zeros(), 127);
+        assert_eq!(ApInt::signed_min_value(bw(1)).count_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).count_zeros(), 7);
+        assert_eq!(ApInt::signed_min_value(bw(16)).count_zeros(), 15);
+        assert_eq!(ApInt::signed_min_value(bw(32)).count_zeros(), 31);
+        assert_eq!(ApInt::signed_min_value(bw(64)).count_zeros(), 63);
+        assert_eq!(ApInt::signed_min_value(bw(128)).count_zeros(), 127);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(1)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(16)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(32)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(64)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(128)).count_zeros(), 1);
     }
 
     #[test]
     fn leading_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).leading_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).leading_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).leading_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).leading_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).leading_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).leading_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).leading_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).leading_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).leading_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).leading_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).leading_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).leading_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(1)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(16)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(32)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(64)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(128)).leading_zeros(), 0);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(1)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(16)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(32)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(64)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(128)).leading_zeros(), 1);
     }
 
     #[test]
     fn trailing_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).trailing_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).trailing_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).trailing_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).trailing_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).trailing_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).trailing_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).trailing_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).trailing_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).trailing_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).trailing_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).trailing_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).trailing_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).trailing_zeros(), 7);
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w16()).trailing_zeros(),
-            15
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w32()).trailing_zeros(),
-            31
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w64()).trailing_zeros(),
-            63
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w128()).trailing_zeros(),
-            127
-        );
+        assert_eq!(ApInt::signed_min_value(bw(1)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).trailing_zeros(), 7);
+        assert_eq!(ApInt::signed_min_value(bw(16)).trailing_zeros(), 15);
+        assert_eq!(ApInt::signed_min_value(bw(32)).trailing_zeros(), 31);
+        assert_eq!(ApInt::signed_min_value(bw(64)).trailing_zeros(), 63);
+        assert_eq!(ApInt::signed_min_value(bw(128)).trailing_zeros(), 127);
 
         // note edge case
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).trailing_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).trailing_zeros(), 0);
-        assert_eq!(
-            ApInt::signed_max_value(BitWidth::w128()).trailing_zeros(),
-            0
-        );
+        assert_eq!(ApInt::signed_max_value(bw(1)).trailing_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(16)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(32)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(64)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(128)).trailing_zeros(), 0);
     }
 
     mod is_all_set {
@@ -430,15 +414,15 @@ mod tests {
         #[test]
         fn simple_false() {
             let input = ApInt::from(0b0001_1011_0110_0111_u16);
-            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.width(), bw(16));
             assert_eq!(input.count_ones(), 9);
             assert!(!input.is_all_set());
         }
 
         #[test]
         fn simple_true() {
-            let input = ApInt::all_set(BitWidth::w32());
-            assert_eq!(input.width(), BitWidth::w32());
+            let input = ApInt::all_set(bw(32));
+            assert_eq!(input.width(), bw(32));
             assert_eq!(input.count_ones(), 32);
             assert!(input.is_all_set());
         }
@@ -450,15 +434,15 @@ mod tests {
         #[test]
         fn simple_false() {
             let input = ApInt::from(0b0001_1011_0110_0111_u16);
-            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.width(), bw(16));
             assert_eq!(input.count_ones(), 9);
             assert_eq!(input.is_zero(), input.is_all_unset());
         }
 
         #[test]
         fn simple_true() {
-            let input = ApInt::all_unset(BitWidth::w32());
-            assert_eq!(input.width(), BitWidth::w32());
+            let input = ApInt::all_unset(bw(32));
+            assert_eq!(input.width(), bw(32));
             assert_eq!(input.count_ones(), 0);
             assert_eq!(input.is_zero(), input.is_all_unset());
         }

--- a/src/apint/casting.rs
+++ b/src/apint/casting.rs
@@ -121,6 +121,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn into_truncate<W, E>(self, target_width: W) -> Result<ApInt>
     where
@@ -140,6 +141,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn truncate<W, E>(&mut self, target_width: W) -> Result<()>
     where
@@ -226,6 +228,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn into_zero_extend<W, E>(self, target_width: W) -> Result<ApInt>
     where
@@ -245,6 +248,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn zero_extend<W, E>(&mut self, target_width: W) -> Result<()>
     where
@@ -315,6 +319,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn into_sign_extend<W, E>(self, target_width: W) -> Result<ApInt>
     where
@@ -334,6 +339,7 @@ impl ApInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn sign_extend<W, E>(&mut self, target_width: W) -> Result<()>
     where

--- a/src/apint/mod.rs
+++ b/src/apint/mod.rs
@@ -34,9 +34,9 @@ pub struct ApInt {
 }
 
 union ApIntData {
-    /// Inline storage (up to 64 bits) for small-space optimization.
+    /// Inline storage (up to `Digit::BITS` bits) for small-space optimization.
     inl: Digit,
-    /// Extern storage (>64 bits) for larger `ApInt`s.
+    /// Extern storage (>`Digit::BITS` bits) for larger `ApInt`s.
     ext: NonNull<Digit>,
 }
 

--- a/src/apint/rand_impl.rs
+++ b/src/apint/rand_impl.rs
@@ -78,6 +78,7 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bw;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -86,27 +87,27 @@ mod tests {
         let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
         let mut rng = XorShiftRng::from_seed(default_seed);
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w1(), &mut rng),
+            ApInt::random_with_width_using(bw(1), &mut rng),
             ApInt::from_bool(true)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w8(), &mut rng),
+            ApInt::random_with_width_using(bw(8), &mut rng),
             ApInt::from_u8(100)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w16(), &mut rng),
+            ApInt::random_with_width_using(bw(16), &mut rng),
             ApInt::from_u16(30960)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w32(), &mut rng),
+            ApInt::random_with_width_using(bw(32), &mut rng),
             ApInt::from_u32(1788231528)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w64(), &mut rng),
+            ApInt::random_with_width_using(bw(64), &mut rng),
             ApInt::from_u64(13499822775494449820)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w128(), &mut rng),
+            ApInt::random_with_width_using(bw(128), &mut rng),
             ApInt::from([16330942765510900160_u64, 131735358788273206])
         );
     }
@@ -120,37 +121,37 @@ mod tests {
         {
             let mut randomized = ApInt::from_bool(false);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w1(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(1), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u8(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w8(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(8), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u16(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w16(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(16), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u32(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w32(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(32), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u64(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w64(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(64), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u128(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w128(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(128), &mut rng2);
             assert_eq!(randomized, new_random);
         }
     }

--- a/src/apint/serde_impl.rs
+++ b/src/apint/serde_impl.rs
@@ -1,5 +1,8 @@
 use crate::{
-    mem::vec::Vec,
+    mem::{
+        vec::Vec,
+        TryFrom,
+    },
     ApInt,
     BitWidth,
     Digit,
@@ -82,7 +85,7 @@ impl<'de> Deserialize<'de> for BitWidth {
         where
             E: de::Error,
         {
-            BitWidth::new(width as usize).map_err(|_| {
+            BitWidth::try_from(width as usize).map_err(|_| {
                 de::Error::invalid_value(
                     de::Unexpected::Unsigned(width as u64),
                     &"a valid `u64` `BitWidth` representation",

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -175,7 +175,7 @@ impl ApInt {
                 b'a'..=b'z' => b - b'a' + 10,
                 b'A'..=b'Z' => b - b'A' + 10,
                 b'_' => continue,
-                _ => ::core::u8::MAX,
+                _ => u8::MAX,
             };
             if !radix.is_valid_byte(d) {
                 return Err(Error::invalid_char_in_string_repr(
@@ -354,8 +354,9 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bw;
 
-    use crate::bitwidth::BitWidth;
+    use crate::BitWidth;
 
     mod constants {
         use super::*;
@@ -381,42 +382,42 @@ mod tests {
 
         #[test]
         fn small() {
-            assert_binary(ApInt::zero(BitWidth::w32()), "0");
+            assert_binary(ApInt::zero(bw(32)), "0");
             assert_binary(ApInt::from(0b_1010_0110_0110_1001_u32), "1010011001101001");
             assert_binary(
-                ApInt::all_set(BitWidth::w32()),
+                ApInt::all_set(bw(32)),
                 "11111111111111111111111111111111", // 32 ones
             );
             assert_binary(
-                ApInt::signed_min_value(BitWidth::w32()),
+                ApInt::signed_min_value(bw(32)),
                 "10000000000000000000000000000000", // 31 zeros
             );
             assert_binary(
-                ApInt::signed_max_value(BitWidth::w32()),
+                ApInt::signed_max_value(bw(32)),
                 "1111111111111111111111111111111", // 31 ones
             );
         }
 
         #[test]
         fn large() {
-            assert_binary(ApInt::zero(BitWidth::w128()), "0");
+            assert_binary(ApInt::zero(bw(128)), "0");
             assert_binary(ApInt::from(0b_1010_0110_0110_1001_u128), "1010011001101001");
             assert_binary(
-                ApInt::all_set(BitWidth::w128()),
+                ApInt::all_set(bw(128)),
                 "11111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111",
             );
             assert_binary(
-                ApInt::signed_min_value(BitWidth::w128()),
+                ApInt::signed_min_value(bw(128)),
                 "10000000000000000000000000000000\
                  00000000000000000000000000000000\
                  00000000000000000000000000000000\
                  00000000000000000000000000000000",
             );
             assert_binary(
-                ApInt::signed_max_value(BitWidth::w128()),
+                ApInt::signed_max_value(bw(128)),
                 "1111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111\
@@ -435,30 +436,27 @@ mod tests {
 
         #[test]
         fn small() {
-            assert_hex(ApInt::zero(BitWidth::w32()), "0");
+            assert_hex(ApInt::zero(bw(32)), "0");
             assert_hex(ApInt::from(0xFEDC_BA98_u32), "FEDCBA98");
-            assert_hex(ApInt::all_set(BitWidth::w32()), "FFFFFFFF");
-            assert_hex(ApInt::signed_min_value(BitWidth::w32()), "80000000");
-            assert_hex(ApInt::signed_max_value(BitWidth::w32()), "7FFFFFFF");
+            assert_hex(ApInt::all_set(bw(32)), "FFFFFFFF");
+            assert_hex(ApInt::signed_min_value(bw(32)), "80000000");
+            assert_hex(ApInt::signed_max_value(bw(32)), "7FFFFFFF");
         }
 
         #[test]
         fn large() {
-            assert_hex(ApInt::zero(BitWidth::w128()), "0");
+            assert_hex(ApInt::zero(bw(128)), "0");
             assert_hex(
                 ApInt::from(0xFEDC_BA98_0A1B_7654_ABCD_0123_u128),
                 "FEDCBA980A1B7654ABCD0123",
             );
+            assert_hex(ApInt::all_set(bw(128)), "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
             assert_hex(
-                ApInt::all_set(BitWidth::w128()),
-                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-            );
-            assert_hex(
-                ApInt::signed_min_value(BitWidth::w128()),
+                ApInt::signed_min_value(bw(128)),
                 "80000000000000000000000000000000",
             );
             assert_hex(
-                ApInt::signed_max_value(BitWidth::w128()),
+                ApInt::signed_max_value(bw(128)),
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
             );
         }
@@ -522,14 +520,13 @@ mod tests {
             for radix in test_radices() {
                 assert_eq!(
                     ApInt::from_str_radix(radix, "0"),
-                    Ok(ApInt::zero(BitWidth::new(64).unwrap()))
+                    Ok(ApInt::zero(BitWidth::DIGIT))
                 )
             }
         }
 
         #[test]
         fn small_values() {
-            use core::u64;
             let samples = vec![
                 // (Radix, Input String, Expected ApInt)
                 (2, "0", 0),

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -27,6 +27,7 @@ impl ShiftAmount {
     ///
     /// # Examples
     ///
+    /// (assuming `Digit::BITS == 64`)
     /// - `ShiftAmount(50)` leaps over zero digits.
     /// - `ShiftAmount(64)` leaps exactly over one digit.
     /// - `ShiftAmount(100)` leaps over 1 digit.
@@ -45,6 +46,7 @@ impl ShiftAmount {
     ///
     /// # Examples
     ///
+    /// (assuming `Digit::BITS == 64`)
     /// - `ShiftAmount(50)` leaps over `50` bits.
     /// - `ShiftAmount(64)` leaps exactly over `0` bits.
     /// - `ShiftAmount(100)` leaps over `28` bits.

--- a/src/apint/to_primitive.rs
+++ b/src/apint/to_primitive.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bw,
     ApInt,
     BitWidth,
     Digit,
@@ -104,12 +105,12 @@ impl PrimitiveTy {
     pub(crate) fn associated_width(self) -> BitWidth {
         use self::PrimitiveTy::*;
         match self {
-            Bool => BitWidth::w1(),
-            I8 | U8 => BitWidth::w8(),
-            I16 | U16 => BitWidth::w16(),
-            I32 | U32 => BitWidth::w32(),
-            I64 | U64 => BitWidth::w64(),
-            I128 | U128 => BitWidth::w128(),
+            Bool => bw(1),
+            I8 | U8 => bw(8),
+            I16 | U16 => bw(16),
+            I32 | U32 => bw(32),
+            I64 | U64 => bw(64),
+            I128 | U128 => bw(128),
         }
     }
 }
@@ -133,14 +134,14 @@ impl ApInt {
         if prim_ty.is_signed() && actual_width < target_width {
             lsd.sign_extend_from(actual_width).expect(
                 "We already asserted that `actual_width` < `target_width` and since \
-                 `target_width` is always less than or equal to `64` bits calling \
-                 `Digit::sign_extend_from` is safe for it.",
+                 `target_width` is always less than or equal to `Digit::BITS` bits \
+                 calling `Digit::sign_extend_from` is safe for it.",
             );
         }
-        if target_width < BitWidth::w64() {
+        if target_width < BitWidth::DIGIT {
             lsd.truncate_to(target_width).expect(
-                "Since `target_width` is always less than or equal to `64` bits calling \
-                 `Digit::sign_extend_from` is safe for it.",
+                "Since `target_width` is always less than or equal to `Digit::BITS` \
+                 bits calling `Digit::sign_extend_from` is safe for it.",
             );
         }
         lsd
@@ -266,7 +267,7 @@ impl ApInt {
         let mut result: i128 =
             (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
         let actual_width = self.width();
-        let target_width = BitWidth::w128();
+        let target_width = bw(128);
 
         if actual_width < target_width {
             // Sign extend the `i128`. Fill up with `1` up to `128` bits
@@ -331,7 +332,7 @@ impl ApInt {
                      `target_width` is always less than or equal to `64` bits calling \
                      `Digit::sign_extend_from` is safe for it.",
                 );
-                if target_width < BitWidth::w64() {
+                if target_width < BitWidth::DIGIT {
                     lsd.truncate_to(target_width).expect(
                         "Since `target_width` is always less than or equal to `64` bits \
                          calling `Digit::sign_extend_from` is safe for it.",
@@ -530,7 +531,7 @@ impl ApInt {
             (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
 
         let actual_width = self.width();
-        let target_width = BitWidth::w128();
+        let target_width = bw(128);
         if actual_width < target_width {
             // Sign extend the `i128`. Fill up with `1` up to `128` bits
             // starting from the sign bit position.
@@ -980,7 +981,7 @@ mod tests {
             for (val, apint) in test_vals_and_apints() {
                 if PrimitiveTy::I128.is_valid_dd(val) {
                     let actual_width = apint.width();
-                    let target_width = BitWidth::w128();
+                    let target_width = bw(128);
                     let mut result: i128 = val as i128;
                     if actual_width < target_width {
                         // Sign extend the `i128`. Fill up with `1` up to `128` bits

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -1,7 +1,6 @@
 use crate::{
     digit_seq::{
         ContiguousDigitSeq,
-        ContiguousDigitSeqMut,
     },
     storage::Storage,
     ApInt,
@@ -11,6 +10,9 @@ use crate::{
     Result,
     Width,
 };
+
+#[cfg(feature = "rand_support")]
+use crate::digit_seq::ContiguousDigitSeqMut;
 
 use core::{
     fmt,
@@ -43,6 +45,7 @@ impl ApInt {
         ContiguousDigitSeq::from(self.as_digit_slice())
     }
 
+    #[cfg(feature = "rand_support")]
     pub(in crate::apint) fn digits_mut(&mut self) -> ContiguousDigitSeqMut {
         ContiguousDigitSeqMut::from(self.as_digit_slice_mut())
     }
@@ -86,7 +89,7 @@ impl Width for ApInt {
     /// Returns the `BitWidth` of this `ApInt`.
     #[inline]
     fn width(&self) -> BitWidth {
-        BitWidth::new(self.len_bits()).unwrap()
+        self.len
     }
 }
 
@@ -344,8 +347,8 @@ impl ApInt {
     ///
     /// An `ApInt` with a `BitWidth` of `100` bits requires
     /// 2 `Digit`s for its internal value representation,
-    /// each having 64-bits which totals in `128` bits for the
-    /// `ApInt` instance.
+    /// each having 64-bits (assuming `Digit::BITS == 64`) which totals in `128`
+    /// bits for the `ApInt` instance.
     /// So upon a call to `ApInt::clear_unused_bits` the upper
     /// `128-100 = 28` bits are cleared (set to zero (`0`)).
     #[inline]

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -1,7 +1,5 @@
 use crate::{
-    digit_seq::{
-        ContiguousDigitSeq,
-    },
+    digit_seq::ContiguousDigitSeq,
     storage::Storage,
     ApInt,
     BitWidth,

--- a/src/bitwidth.rs
+++ b/src/bitwidth.rs
@@ -1,8 +1,11 @@
 use crate::{
+    mem::{
+        NonZeroUsize,
+        TryFrom,
+    },
     storage::Storage,
     BitPos,
     Digit,
-    Error,
     Result,
     ShiftAmount,
 };
@@ -11,60 +14,65 @@ use crate::{
 ///
 /// Its invariant restricts it to always be a positive, non-zero value.
 /// Code that built's on top of `BitWidth` may and should use this invariant.
+///
+/// This is currently just a wrapper around `NonZeroUsize` (in case
+/// future compiler optimizations can make use of it), but this is not
+/// exposed because of the potential for feature flags and custom forks for
+/// `apint` to use other internal types.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BitWidth(usize);
+pub struct BitWidth(NonZeroUsize);
 
-//  ===========================================================================
-///  Constructors
-/// ===========================================================================
-impl BitWidth {
-    /// Creates a `BitWidth` that represents a bit-width of `1` bit.
-    #[inline]
-    pub fn w1() -> Self {
-        BitWidth(1)
+impl From<NonZeroUsize> for BitWidth {
+    /// Creates a `BitWidth` from the given `NonZeroUsize`.
+    fn from(width: NonZeroUsize) -> Self {
+        BitWidth(width)
     }
+}
 
-    /// Creates a `BitWidth` that represents a bit-width of `8` bits.
-    #[inline]
-    pub fn w8() -> Self {
-        BitWidth(8)
-    }
-
-    /// Creates a `BitWidth` that represents a bit-width of `16` bits.
-    #[inline]
-    pub fn w16() -> Self {
-        BitWidth(16)
-    }
-
-    /// Creates a `BitWidth` that represents a bit-width of `32` bits.
-    #[inline]
-    pub fn w32() -> Self {
-        BitWidth(32)
-    }
-
-    /// Creates a `BitWidth` that represents a bit-width of `64` bits.
-    #[inline]
-    pub fn w64() -> Self {
-        BitWidth(64)
-    }
-
-    /// Creates a `BitWidth` that represents a bit-width of `128` bits.
-    #[inline]
-    pub fn w128() -> Self {
-        BitWidth(128)
-    }
+impl TryFrom<usize> for BitWidth {
+    type Error = crate::Error;
 
     /// Creates a `BitWidth` from the given `usize`.
     ///
     /// # Errors
     ///
     /// - If the given `width` is equal to zero.
-    pub fn new(width: usize) -> Result<Self> {
-        if width == 0 {
-            return Err(Error::invalid_zero_bitwidth())
+    fn try_from(width: usize) -> Result<BitWidth> {
+        match NonZeroUsize::new(width) {
+            Some(bitwidth) => Ok(BitWidth(bitwidth)),
+            None => Err(crate::Error::invalid_zero_bitwidth()),
         }
-        Ok(BitWidth(width))
     }
+}
+
+/// Convenience free function for converting a `usize` to a `BitWidth`.
+///
+/// # Panics
+///
+/// If `width == 0`, this function will panic
+pub const fn bw(width: usize) -> BitWidth {
+    // Ideally, the code here would be `width.try_into().ok().expect("tried to
+    // ...");`, but we want this to be a `const` function.
+    match NonZeroUsize::new(width) {
+        None => {
+            panic!(
+                "Tried to construct an invalid BitWidth of 0 using the `apint::bw` \
+                 function"
+            )
+        }
+        Some(n) => BitWidth(n),
+    }
+}
+
+impl BitWidth {
+    // TODO: change to using `NonZeroUsize::new()` as soon as `unwrap`ing can be done.
+
+    /// Width of a `Digit`
+    pub(crate) const DIGIT: BitWidth =
+        BitWidth(unsafe { NonZeroUsize::new_unchecked(Digit::BITS) });
+    /// Width of a `DoubleDigit`
+    pub(crate) const DOUBLE_DIGIT: BitWidth =
+        BitWidth(unsafe { NonZeroUsize::new_unchecked(Digit::BITS * 2) });
 
     /// Returns `true` if the given `BitPos` is valid for this `BitWidth`.
     #[inline]
@@ -72,7 +80,7 @@ impl BitWidth {
     where
         P: Into<BitPos>,
     {
-        pos.into().to_usize() < self.0
+        pos.into().to_usize() < self.to_usize()
     }
 
     /// Returns `true` if the given `ShiftAmount` is valid for this `BitWidth`.
@@ -81,7 +89,7 @@ impl BitWidth {
     where
         S: Into<ShiftAmount>,
     {
-        shift_amount.into().to_usize() < self.0
+        shift_amount.into().to_usize() < self.to_usize()
     }
 
     /// Returns the `BitPos` for the most significant bit of an `ApInt` with
@@ -92,12 +100,6 @@ impl BitWidth {
     }
 }
 
-impl From<usize> for BitWidth {
-    fn from(width: usize) -> BitWidth {
-        BitWidth::new(width).unwrap()
-    }
-}
-
 //  ===========================================================================
 ///  API
 /// ===========================================================================
@@ -105,17 +107,17 @@ impl BitWidth {
     /// Converts this `BitWidth` into a `usize`.
     #[inline]
     pub fn to_usize(self) -> usize {
-        self.0
+        self.0.get()
     }
 
     /// Returns the number of exceeding bits that is implied for `ApInt`
     /// instances with this `BitWidth`.
     ///
     /// For example for an `ApInt` with a `BitWidth` of `140` bits requires
-    /// exactly `3` digits (each with its `64` bits). The third however,
-    /// only requires `140 - 128 = 12` bits of its `64` bits in total to
-    /// represent the `ApInt` instance. So `excess_bits` returns `12` for
-    /// a `BitWidth` that is equal to `140`.
+    /// exactly `3` digits (assuming `Digit::BITS == 64` bits). The third
+    /// however, only requires `140 - 128 = 12` bits of its `64` bits in
+    /// total to represent the `ApInt` instance. So `excess_bits` returns
+    /// `12` for a `BitWidth` that is equal to `140`.
     ///
     /// *Note:* A better name for this method has yet to be found!
     pub(crate) fn excess_bits(self) -> Option<usize> {
@@ -131,7 +133,10 @@ impl BitWidth {
     ///         Read the documentation of `excess_bits` for more information
     ///         about what is actually returned by this.
     pub(crate) fn excess_width(self) -> Option<BitWidth> {
-        self.excess_bits().map(BitWidth::from)
+        match NonZeroUsize::new(self.to_usize() % Digit::BITS) {
+            Some(bitwidth) => Some(BitWidth(bitwidth)),
+            None => None,
+        }
     }
 
     /// Returns a storage specifier that tells the caller if `ApInt`'s
@@ -164,22 +169,22 @@ mod tests {
 
         #[test]
         fn powers_of_two() {
-            assert_eq!(BitWidth::w1().excess_bits(), Some(1));
-            assert_eq!(BitWidth::w8().excess_bits(), Some(8));
-            assert_eq!(BitWidth::w16().excess_bits(), Some(16));
-            assert_eq!(BitWidth::w32().excess_bits(), Some(32));
-            assert_eq!(BitWidth::w64().excess_bits(), None);
-            assert_eq!(BitWidth::w128().excess_bits(), None);
+            assert_eq!(bw(1).excess_bits(), Some(1));
+            assert_eq!(bw(8).excess_bits(), Some(8));
+            assert_eq!(bw(16).excess_bits(), Some(16));
+            assert_eq!(bw(32).excess_bits(), Some(32));
+            assert_eq!(bw(64).excess_bits(), None);
+            assert_eq!(bw(128).excess_bits(), None);
         }
 
         #[test]
         fn multiples_of_50() {
-            assert_eq!(BitWidth::new(50).unwrap().excess_bits(), Some(50));
-            assert_eq!(BitWidth::new(100).unwrap().excess_bits(), Some(36));
-            assert_eq!(BitWidth::new(150).unwrap().excess_bits(), Some(22));
-            assert_eq!(BitWidth::new(200).unwrap().excess_bits(), Some(8));
-            assert_eq!(BitWidth::new(250).unwrap().excess_bits(), Some(58));
-            assert_eq!(BitWidth::new(300).unwrap().excess_bits(), Some(44));
+            assert_eq!(bw(50).excess_bits(), Some(50));
+            assert_eq!(bw(100).excess_bits(), Some(36));
+            assert_eq!(bw(150).excess_bits(), Some(22));
+            assert_eq!(bw(200).excess_bits(), Some(8));
+            assert_eq!(bw(250).excess_bits(), Some(58));
+            assert_eq!(bw(300).excess_bits(), Some(44));
         }
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -693,6 +693,7 @@ impl Int {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn into_truncate<W, E>(self, target_width: W) -> Result<Int>
     where
@@ -712,6 +713,7 @@ impl Int {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn truncate<W, E>(&mut self, target_width: W) -> Result<()>
     where
@@ -733,6 +735,7 @@ impl Int {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn into_extend<W, E>(self, target_width: W) -> Result<Int>
     where
@@ -752,6 +755,7 @@ impl Int {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn extend<W, E>(&mut self, target_width: W) -> Result<()>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_root_url = "https://docs.rs/crate/apint/0.2.0")]
 
+// TODO remove these as soon as they are on stable
+#![feature(const_if_match)]
+#![feature(const_fn)]
+#![feature(const_panic)]
+#![feature(const_nonzero_int_methods)]
+
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
@@ -113,7 +119,10 @@ pub use crate::{
         ShiftAmount,
     },
     bitpos::BitPos,
-    bitwidth::BitWidth,
+    bitwidth::{
+        bw,
+        BitWidth,
+    },
     errors::{
         Error,
         ErrorKind,
@@ -129,6 +138,7 @@ pub use crate::{
 pub mod prelude {
     #[doc(no_inline)]
     pub use super::{
+        bw,
         ApInt,
         BitWidth,
         Int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! **Note:** Almost all fallible functions in this crate have return types of
 //! `Result` or `Option` to let the user handle errors. The exceptions are the
 //! `std::ops` traits which will panic if their corresponding `into_wrapping_`
-//! or `wrapping_assign` function does.
+//! or `wrapping_assign` function does, and the `bw` free function.
 //!
 //! # `std::ops` trait implementations
 //!
@@ -47,6 +47,14 @@
 //! `for &'b mut ApInt`, because doing so involves cloning. This crate strives
 //! for clearly exposing where expensive operations happen, so in this case we
 //! favor the user side to use explicit `.clone()`s.
+//!
+//! # Error Handling
+//!
+//! Note that `apint::Result<T>` is equivalent to
+//! `core::Result<T, apint::Error>`. `apint::Result<T>` and `apint::Error` are
+//! not exported by `apint::prelude` to avoid confusion. When starting with
+//! `apint`, it is highly recommended to first read the documentation on the
+//! invariant management types `BitWidth`, `BitPos`, `ShiftAmount`, and `Radix`.
 //!
 //! # `signed_min_value` corner cases
 //!
@@ -82,7 +90,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_root_url = "https://docs.rs/crate/apint/0.2.0")]
-
 // TODO remove these as soon as they are on stable
 #![feature(const_if_match)]
 #![feature(const_fn)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,6 +2,15 @@
 
 #[cfg(not(feature = "std"))]
 mod no_std_defs {
+    pub use core::{
+        convert::{
+            Infallible,
+            TryFrom,
+            TryInto,
+        },
+        num::NonZeroUsize,
+    };
+
     pub use alloc::{
         borrow,
         boxed,
@@ -29,7 +38,13 @@ mod std_defs {
     pub use std::{
         borrow,
         boxed,
+        convert::{
+            Infallible,
+            TryFrom,
+            TryInto,
+        },
         format,
+        num::NonZeroUsize,
         string,
         vec,
     };

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -634,6 +634,7 @@ impl UInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn into_truncate<W, E>(self, target_width: W) -> Result<UInt>
     where
@@ -653,6 +654,7 @@ impl UInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is greater than the current width.
     pub fn truncate<W, E>(&mut self, target_width: W) -> Result<()>
     where
@@ -674,6 +676,7 @@ impl UInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn into_extend<W, E>(self, target_width: W) -> Result<UInt>
     where
@@ -693,6 +696,7 @@ impl UInt {
     ///
     /// # Errors
     ///
+    /// - If `target_width.try_into()` returns an error.
     /// - If the `target_width` is less than the current width.
     pub fn extend<W, E>(&mut self, target_width: W) -> Result<()>
     where


### PR DESCRIPTION
Changing the way `BitWidth`s are constructed is going to be a really invasive change no matter what. What this boils down to is:
 - make `BitWidth` use a `NonZeroUsize` internally
 - remove `impl From<usize> for BitWidth`. This was the last impl in this crate to have a hidden `unwrap` inside it. The `std::ops` impls and `bw` function have `unwrap`s inside them, but this is documented up front.
 - `impl From<NonZeroUsize> for BitWidth`
 - `impl TryFrom<usize> for BitWidth`
 - add the `bw` free function, a `const` function that takes a `usize` and returns a valid `BitWidth` or panics. Hopefully, the needed `const` features will become stable as 1.45.0-nightly progresses. I could make it work on stable right now without the function being `const`, but I wanted you to see what it should look like.
 - If a function that receives a bitwidth argument is infallible when the argument is valid, I changed the signature to use a plain `BitWidth` with no generics. For example, `pub fn zero_resize<W>(&mut self, target_width: W) where W: Into<BitWidth>` was changed into `pub fn zero_resize(&mut self, target_width: BitWidth)`. We could maybe use `W: TryInto<BitWidth>` for more ergonomics, but that means we have to change the return value to be a `Result`.
 - If a function that receives a bitwidth argument is fallible regardless of the bitwidth validity (the bitwidth is not zero but the function still has to return a `Result` because it can still fail), I change the signature from `W: Into<BitWidth>` to instead use `W: TryInto<BitWidth, Error = E>, crate::Error: From<E>`. This is conceptually the same as `W: TryInto<BitWidth>`, but the signature looks weird because I'm avoiding colliding with blanket impls, which would otherwise mean that plain `BitWidth`s being entered into the function would not work. see https://github.com/rust-lang/rust/issues/69448 for more. Unfortunately, the intended ergonomics still do not work all the time (in some cases, you can see I had to use the turbofishes `::<BitWidth, Infallible>` and `::<usize, Error>`, I'm still not sure why this is required). Should I favor plain `BitWidth`s instead?
 - I removed some things that are no longer needed, such as `Digit::verify_valid_bitwidth` and the `BitWidth::w*()` functions. There are slightly fewer lines needed, but vastly fewer actual characters needed when constructing lots of `BitWidth`s

When we agree on the changes, I also want to do the same treatment for `BitPos` and `ShiftAmount`.
