### PR TITLE
Cleanup and make `BitWidth` use `NonZeroUsize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,25 +14,22 @@ description = """Arbitrary precision integers library."""
 categories = ["data-structures"]
 
 [dependencies]
-smallvec = { version = "0.6", default-features = false }
-specialized-div-rem = { version = "0.0.5", optional = true }
+smallvec = "1.4.0"
 rand = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_test = "1.0"
-itertools = "0.8"
+itertools = "0.9"
 rand_xorshift = "0.2"
 
 [features]
 default = [
     "rand_support",
     "serde_support",
-    "specialized-div-rem",
     "std",
 ]
 std = [
-    "smallvec/std",
     "rand/std",
     "serde/std",
 ]

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -1,8 +1,5 @@
 use crate::{
-    digit_seq::{
-        ContiguousDigitSeq,
-        ContiguousDigitSeqMut,
-    },
+    digit_seq::ContiguousDigitSeq,
     storage::Storage,
     ApInt,
     BitWidth,
@@ -11,6 +8,9 @@ use crate::{
     Result,
     Width,
 };
+
+#[cfg(feature = "rand_support")]
+use crate::digit_seq::ContiguousDigitSeqMut;
 
 use core::{
     fmt,
@@ -43,6 +43,7 @@ impl ApInt {
         ContiguousDigitSeq::from(self.as_digit_slice())
     }
 
+    #[cfg(feature = "rand_support")]
     pub(in crate::apint) fn digits_mut(&mut self) -> ContiguousDigitSeqMut {
         ContiguousDigitSeqMut::from(self.as_digit_slice_mut())
     }

--- a/src/bitwidth.rs
+++ b/src/bitwidth.rs
@@ -112,10 +112,10 @@ impl BitWidth {
     /// instances with this `BitWidth`.
     ///
     /// For example for an `ApInt` with a `BitWidth` of `140` bits requires
-    /// exactly `3` digits (each with its `64` bits). The third however,
-    /// only requires `140 - 128 = 12` bits of its `64` bits in total to
-    /// represent the `ApInt` instance. So `excess_bits` returns `12` for
-    /// a `BitWidth` that is equal to `140`.
+    /// exactly `3` digits (assuming `Digit::BITS == 64` bits). The third
+    /// however, only requires `140 - 128 = 12` bits of its `64` bits in
+    /// total to represent the `ApInt` instance. So `excess_bits` returns
+    /// `12` for a `BitWidth` that is equal to `140`.
     ///
     /// *Note:* A better name for this method has yet to be found!
     pub(crate) fn excess_bits(self) -> Option<usize> {

--- a/src/bitwidth.rs
+++ b/src/bitwidth.rs
@@ -1,4 +1,5 @@
 use crate::{
+    mem::NonZeroUsize,
     storage::Storage,
     BitPos,
     Digit,
@@ -11,8 +12,17 @@ use crate::{
 ///
 /// Its invariant restricts it to always be a positive, non-zero value.
 /// Code that built's on top of `BitWidth` may and should use this invariant.
+///
+/// This is currently just a wrapper around `NonZeroUsize` (in case
+/// future compiler optimizations can make use of it), but this is not
+/// exposed because of the potential for feature flags and custom forks for
+/// `apint` to use other internal types.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BitWidth(usize);
+pub struct BitWidth(NonZeroUsize);
+
+// We do not expose a `impl From<NonZeroUsize> for BitWidth` because that might
+// introduce edge cases in the future where the internal type is not
+// `NonZeroUsize` and is fallable.
 
 //  ===========================================================================
 ///  Constructors
@@ -21,37 +31,37 @@ impl BitWidth {
     /// Creates a `BitWidth` that represents a bit-width of `1` bit.
     #[inline]
     pub fn w1() -> Self {
-        BitWidth(1)
+        BitWidth(NonZeroUsize::new(1).unwrap())
     }
 
     /// Creates a `BitWidth` that represents a bit-width of `8` bits.
     #[inline]
     pub fn w8() -> Self {
-        BitWidth(8)
+        BitWidth(NonZeroUsize::new(8).unwrap())
     }
 
     /// Creates a `BitWidth` that represents a bit-width of `16` bits.
     #[inline]
     pub fn w16() -> Self {
-        BitWidth(16)
+        BitWidth(NonZeroUsize::new(16).unwrap())
     }
 
     /// Creates a `BitWidth` that represents a bit-width of `32` bits.
     #[inline]
     pub fn w32() -> Self {
-        BitWidth(32)
+        BitWidth(NonZeroUsize::new(32).unwrap())
     }
 
     /// Creates a `BitWidth` that represents a bit-width of `64` bits.
     #[inline]
     pub fn w64() -> Self {
-        BitWidth(64)
+        BitWidth(NonZeroUsize::new(64).unwrap())
     }
 
     /// Creates a `BitWidth` that represents a bit-width of `128` bits.
     #[inline]
     pub fn w128() -> Self {
-        BitWidth(128)
+        BitWidth(NonZeroUsize::new(128).unwrap())
     }
 
     /// Creates a `BitWidth` from the given `usize`.
@@ -63,7 +73,7 @@ impl BitWidth {
         if width == 0 {
             return Err(Error::invalid_zero_bitwidth())
         }
-        Ok(BitWidth(width))
+        Ok(BitWidth(NonZeroUsize::new(width).unwrap()))
     }
 
     /// Returns `true` if the given `BitPos` is valid for this `BitWidth`.
@@ -72,7 +82,7 @@ impl BitWidth {
     where
         P: Into<BitPos>,
     {
-        pos.into().to_usize() < self.0
+        pos.into().to_usize() < self.to_usize()
     }
 
     /// Returns `true` if the given `ShiftAmount` is valid for this `BitWidth`.
@@ -81,7 +91,7 @@ impl BitWidth {
     where
         S: Into<ShiftAmount>,
     {
-        shift_amount.into().to_usize() < self.0
+        shift_amount.into().to_usize() < self.to_usize()
     }
 
     /// Returns the `BitPos` for the most significant bit of an `ApInt` with
@@ -105,7 +115,7 @@ impl BitWidth {
     /// Converts this `BitWidth` into a `usize`.
     #[inline]
     pub fn to_usize(self) -> usize {
-        self.0
+        self.0.get()
     }
 
     /// Returns the number of exceeding bits that is implied for `ApInt`
@@ -131,7 +141,10 @@ impl BitWidth {
     ///         Read the documentation of `excess_bits` for more information
     ///         about what is actually returned by this.
     pub(crate) fn excess_width(self) -> Option<BitWidth> {
-        self.excess_bits().map(BitWidth::from)
+        match NonZeroUsize::new(self.to_usize() % Digit::BITS) {
+            Some(bitwidth) => Some(BitWidth(bitwidth)),
+            None => None,
+        }
     }
 
     /// Returns a storage specifier that tells the caller if `ApInt`'s

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -215,7 +215,6 @@ impl DoubleDigit {
         self.wrapping_divrem(other).0
     }
 
-    #[cfg(not(feature = "specialized_div_rem"))]
     pub(crate) fn wrapping_divrem(
         self,
         other: DoubleDigit,
@@ -224,15 +223,6 @@ impl DoubleDigit {
             DoubleDigit(self.repr().wrapping_div(other.repr())),
             DoubleDigit(self.repr().wrapping_rem(other.repr())),
         )
-    }
-
-    #[cfg(feature = "specialized_div_rem")]
-    pub(crate) fn wrapping_divrem(
-        self,
-        other: DoubleDigit,
-    ) -> (DoubleDigit, DoubleDigit) {
-        let temp = specialized_div_rem::u128_div_rem(self.repr(), other.repr());
-        (DoubleDigit(temp.0), DoubleDigit(temp.1))
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,8 +16,6 @@ use core::{
     fmt,
     result,
 };
-#[cfg(feature = "std")]
-use std::error;
 
 /// Represents the kind of an `Error`.
 ///
@@ -401,7 +399,7 @@ impl fmt::Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl error::Error for Error {
+impl std::error::Error for Error {
     fn description(&self) -> &str {
         self.message.as_str()
     }

--- a/src/int.rs
+++ b/src/int.rs
@@ -16,9 +16,6 @@ use crate::{
     Width,
 };
 
-#[cfg(feature = "rand_support")]
-use rand;
-
 use core::cmp::Ordering;
 
 /// Signed machine integer with arbitrary bitwidths and modulo arithmetics.

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2,6 +2,17 @@
 
 #[cfg(not(feature = "std"))]
 mod no_std_defs {
+    // We could use `core::` to import these directly instead of through `mem`, but
+    // this removes the need to type out `::convert`, `::num`, and some extra
+    // braces for every use in the crate.
+    pub use core::{
+        convert::{
+            TryFrom,
+            TryInto,
+        },
+        num::NonZeroUsize,
+    };
+
     pub use alloc::{
         borrow,
         boxed,
@@ -29,7 +40,12 @@ mod std_defs {
     pub use std::{
         borrow,
         boxed,
+        convert::{
+            TryFrom,
+            TryInto,
+        },
         format,
+        num::NonZeroUsize,
         string,
         vec,
     };

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -16,9 +16,6 @@ use crate::{
     Width,
 };
 
-#[cfg(feature = "rand_support")]
-use rand;
-
 use core::cmp::Ordering;
 
 /// Unsigned machine integer with arbitrary bitwidths and modulo arithmetics.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::Result;
 /// Returns the entity afterwards.
 pub fn forward_mut_impl<T, F>(entity: T, op: F) -> T
 where
-    F: Fn(&mut T) -> (),
+    F: Fn(&mut T),
 {
     let mut this = entity;
     op(&mut this);
@@ -17,7 +17,7 @@ where
 /// Returns the entity afterwards.
 pub fn forward_bin_mut_impl<L, R, F>(entity: L, rhs: R, op: F) -> L
 where
-    F: Fn(&mut L, R) -> (),
+    F: Fn(&mut L, R),
 {
     let mut this = entity;
     op(&mut this, rhs);


### PR DESCRIPTION
I removed the dependency on `specialized-div-rem` because I plan on finishing my PR to `compiler-builtins` in the next few weeks. I updated the `smallvec` dependency because it did not allow compilation on stable with `--no-default-features`. `smallvec` is `no-std` by default now.
Imports were added to `mem`. Even though they are not used much now, it will save a lot when most files need a `TryFrom` import in later PRs.
I did some other random cleanup, and no warnings are issued with any combination of feature flags on stable now (except for clippy warnings and TODO warnings that will be fixed down the road).