### PR TITLE
Issue 41 PR 2: Add `bw` function and clean the entire crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = """Arbitrary precision integers library."""
 categories = ["data-structures"]
 
 [dependencies]
-smallvec = "1.4.0"
+smallvec = "1.4.2"
 rand = { version = "0.7", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 

--- a/src/apint/arithmetic.rs
+++ b/src/apint/arithmetic.rs
@@ -1742,10 +1742,13 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        bw,
+        BitWidth,
+    };
 
     mod inc {
         use super::*;
-        use core::u64;
 
         #[test]
         fn test() {
@@ -1778,7 +1781,6 @@ mod tests {
 
     mod wrapping_neg {
         use super::*;
-        use crate::bitwidth::BitWidth;
 
         fn assert_symmetry(input: ApInt, expected: ApInt) {
             assert_eq!(input.clone().into_wrapping_neg(), expected.clone());
@@ -1796,11 +1798,8 @@ mod tests {
 
         #[test]
         fn simple() {
-            assert_symmetry(ApInt::zero(BitWidth::w1()), ApInt::zero(BitWidth::w1()));
-            assert_symmetry(
-                ApInt::unsigned_max_value(BitWidth::w1()),
-                ApInt::all_set(BitWidth::w1()),
-            );
+            assert_symmetry(ApInt::zero(bw(1)), ApInt::zero(bw(1)));
+            assert_symmetry(ApInt::unsigned_max_value(bw(1)), ApInt::all_set(bw(1)));
         }
 
         #[test]
@@ -1817,11 +1816,6 @@ mod tests {
 
     mod mul {
         use super::*;
-        use crate::bitwidth::BitWidth;
-        use core::{
-            u64,
-            u8,
-        };
 
         #[test]
         fn rigorous() {
@@ -1970,8 +1964,6 @@ mod tests {
 
     mod div_rem {
         use super::*;
-        use crate::bitwidth::BitWidth;
-        use core::u64;
 
         // TODO: add division by zero testing after error refactoring is finished
         // use errors::ErrorKind;
@@ -2394,13 +2386,11 @@ mod tests {
 
     mod megafuzz {
         use super::*;
-        use crate::bitwidth::BitWidth;
-        use core::u64;
         use rand::random;
 
         #[test]
         fn pull_request_35_regression() {
-            let width = BitWidth::new(65).unwrap();
+            let width = bw(65);
             // arithmetic shift right shift
             assert_eq!(
                 ApInt::from([1u64, u64::MAX - (1 << 6)])
@@ -2421,7 +2411,7 @@ mod tests {
             assert_eq!(v1, ApInt::from([1u64, 7]).into_zero_resize(width));
             assert_eq!(v2, ApInt::from([1u64, 0]).into_zero_resize(width));
             assert_eq!(v3, ApInt::from([1u64, 0]).into_zero_resize(width));
-            let width = BitWidth::new(193).unwrap();
+            let width = bw(193);
             let v3 = ApInt::from([0u64, 0, 17179852800, 1073676288])
                 .into_zero_resize(width)
                 .into_wrapping_mul(&ApInt::from(1u128 << 115).into_zero_resize(width))
@@ -2452,8 +2442,7 @@ mod tests {
                 temp,
                 lhs.clone()
                     .into_wrapping_add(
-                        &ApInt::unsigned_max_value(BitWidth::w1())
-                            .into_zero_resize(width)
+                        &ApInt::unsigned_max_value(bw(1)).into_zero_resize(width)
                     )
                     .unwrap()
             );
@@ -2470,8 +2459,7 @@ mod tests {
                 temp,
                 lhs.clone()
                     .into_wrapping_sub(
-                        &ApInt::unsigned_max_value(BitWidth::w1())
-                            .into_zero_resize(width)
+                        &ApInt::unsigned_max_value(bw(1)).into_zero_resize(width)
                     )
                     .unwrap()
             );
@@ -2485,7 +2473,7 @@ mod tests {
             assert_eq!(temp, lhs);
 
             // power of two multiplication and division shifting tests
-            let mut tmp1 = ApInt::unsigned_max_value(BitWidth::w1())
+            let mut tmp1 = ApInt::unsigned_max_value(bw(1))
                 .into_zero_resize(width)
                 .into_wrapping_shl(shift)
                 .unwrap();
@@ -2516,7 +2504,7 @@ mod tests {
                 // but the division ends up as +1
                 assert_eq!(
                     lhs.clone().into_wrapping_sdiv(&tmp1).unwrap(),
-                    ApInt::unsigned_max_value(BitWidth::w1()).into_zero_resize(width)
+                    ApInt::unsigned_max_value(bw(1)).into_zero_resize(width)
                 );
             } else {
                 let mut tmp0 = lhs.clone();
@@ -2550,7 +2538,7 @@ mod tests {
                 if rhs.leading_zeros() == 0 {
                     ApInt::zero(width)
                 } else {
-                    ApInt::unsigned_max_value(BitWidth::from(rhs.leading_zeros()))
+                    ApInt::unsigned_max_value(BitWidth::new(rhs.leading_zeros()).unwrap())
                         .into_zero_extend(width)
                         .unwrap()
                 }

--- a/src/apint/bitwise.rs
+++ b/src/apint/bitwise.rs
@@ -307,121 +307,105 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::bitwidth::BitWidth;
+    use crate::bw;
 
     // Note: there are more tests of the counting functions in `uint.rs`
 
     #[test]
     fn count_ones() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w8()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w16()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w32()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w64()).count_ones(), 0);
-        assert_eq!(ApInt::zero(BitWidth::w128()).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(1)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(8)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(16)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(32)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(64)).count_ones(), 0);
+        assert_eq!(ApInt::zero(bw(128)).count_ones(), 0);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_ones(), 1);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(1)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(8)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(16)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(32)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(64)).count_ones(), 1);
+        assert_eq!(ApInt::signed_min_value(bw(128)).count_ones(), 1);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_ones(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_ones(), 7);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_ones(), 15);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_ones(), 31);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_ones(), 63);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_ones(), 127);
+        assert_eq!(ApInt::signed_max_value(bw(1)).count_ones(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(8)).count_ones(), 7);
+        assert_eq!(ApInt::signed_max_value(bw(16)).count_ones(), 15);
+        assert_eq!(ApInt::signed_max_value(bw(32)).count_ones(), 31);
+        assert_eq!(ApInt::signed_max_value(bw(64)).count_ones(), 63);
+        assert_eq!(ApInt::signed_max_value(bw(128)).count_ones(), 127);
     }
 
     #[test]
     fn count_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).count_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).count_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).count_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).count_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).count_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).count_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).count_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).count_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).count_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).count_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).count_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).count_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).count_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).count_zeros(), 7);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).count_zeros(), 15);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).count_zeros(), 31);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).count_zeros(), 63);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).count_zeros(), 127);
+        assert_eq!(ApInt::signed_min_value(bw(1)).count_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).count_zeros(), 7);
+        assert_eq!(ApInt::signed_min_value(bw(16)).count_zeros(), 15);
+        assert_eq!(ApInt::signed_min_value(bw(32)).count_zeros(), 31);
+        assert_eq!(ApInt::signed_min_value(bw(64)).count_zeros(), 63);
+        assert_eq!(ApInt::signed_min_value(bw(128)).count_zeros(), 127);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).count_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(1)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(16)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(32)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(64)).count_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(128)).count_zeros(), 1);
     }
 
     #[test]
     fn leading_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).leading_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).leading_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).leading_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).leading_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).leading_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).leading_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).leading_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).leading_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).leading_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).leading_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).leading_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).leading_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w16()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w32()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w64()).leading_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w128()).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(1)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(16)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(32)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(64)).leading_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(128)).leading_zeros(), 0);
 
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).leading_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w128()).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(1)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(16)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(32)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(64)).leading_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(128)).leading_zeros(), 1);
     }
 
     #[test]
     fn trailing_zeros() {
-        assert_eq!(ApInt::zero(BitWidth::w1()).trailing_zeros(), 1);
-        assert_eq!(ApInt::zero(BitWidth::w8()).trailing_zeros(), 8);
-        assert_eq!(ApInt::zero(BitWidth::w16()).trailing_zeros(), 16);
-        assert_eq!(ApInt::zero(BitWidth::w32()).trailing_zeros(), 32);
-        assert_eq!(ApInt::zero(BitWidth::w64()).trailing_zeros(), 64);
-        assert_eq!(ApInt::zero(BitWidth::w128()).trailing_zeros(), 128);
+        assert_eq!(ApInt::zero(bw(1)).trailing_zeros(), 1);
+        assert_eq!(ApInt::zero(bw(8)).trailing_zeros(), 8);
+        assert_eq!(ApInt::zero(bw(16)).trailing_zeros(), 16);
+        assert_eq!(ApInt::zero(bw(32)).trailing_zeros(), 32);
+        assert_eq!(ApInt::zero(bw(64)).trailing_zeros(), 64);
+        assert_eq!(ApInt::zero(bw(128)).trailing_zeros(), 128);
 
-        assert_eq!(ApInt::signed_min_value(BitWidth::w1()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_min_value(BitWidth::w8()).trailing_zeros(), 7);
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w16()).trailing_zeros(),
-            15
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w32()).trailing_zeros(),
-            31
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w64()).trailing_zeros(),
-            63
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w128()).trailing_zeros(),
-            127
-        );
+        assert_eq!(ApInt::signed_min_value(bw(1)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_min_value(bw(8)).trailing_zeros(), 7);
+        assert_eq!(ApInt::signed_min_value(bw(16)).trailing_zeros(), 15);
+        assert_eq!(ApInt::signed_min_value(bw(32)).trailing_zeros(), 31);
+        assert_eq!(ApInt::signed_min_value(bw(64)).trailing_zeros(), 63);
+        assert_eq!(ApInt::signed_min_value(bw(128)).trailing_zeros(), 127);
 
         // note edge case
-        assert_eq!(ApInt::signed_max_value(BitWidth::w1()).trailing_zeros(), 1);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w8()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w16()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w32()).trailing_zeros(), 0);
-        assert_eq!(ApInt::signed_max_value(BitWidth::w64()).trailing_zeros(), 0);
-        assert_eq!(
-            ApInt::signed_max_value(BitWidth::w128()).trailing_zeros(),
-            0
-        );
+        assert_eq!(ApInt::signed_max_value(bw(1)).trailing_zeros(), 1);
+        assert_eq!(ApInt::signed_max_value(bw(8)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(16)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(32)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(64)).trailing_zeros(), 0);
+        assert_eq!(ApInt::signed_max_value(bw(128)).trailing_zeros(), 0);
     }
 
     mod is_all_set {
@@ -430,15 +414,15 @@ mod tests {
         #[test]
         fn simple_false() {
             let input = ApInt::from(0b0001_1011_0110_0111_u16);
-            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.width(), bw(16));
             assert_eq!(input.count_ones(), 9);
             assert!(!input.is_all_set());
         }
 
         #[test]
         fn simple_true() {
-            let input = ApInt::all_set(BitWidth::w32());
-            assert_eq!(input.width(), BitWidth::w32());
+            let input = ApInt::all_set(bw(32));
+            assert_eq!(input.width(), bw(32));
             assert_eq!(input.count_ones(), 32);
             assert!(input.is_all_set());
         }
@@ -450,15 +434,15 @@ mod tests {
         #[test]
         fn simple_false() {
             let input = ApInt::from(0b0001_1011_0110_0111_u16);
-            assert_eq!(input.width(), BitWidth::w16());
+            assert_eq!(input.width(), bw(16));
             assert_eq!(input.count_ones(), 9);
             assert_eq!(input.is_zero(), input.is_all_unset());
         }
 
         #[test]
         fn simple_true() {
-            let input = ApInt::all_unset(BitWidth::w32());
-            assert_eq!(input.width(), BitWidth::w32());
+            let input = ApInt::all_unset(bw(32));
+            assert_eq!(input.width(), bw(32));
             assert_eq!(input.count_ones(), 0);
             assert_eq!(input.is_zero(), input.is_all_unset());
         }

--- a/src/apint/constructors.rs
+++ b/src/apint/constructors.rs
@@ -1,5 +1,7 @@
 use crate::{
     apint::ApIntData,
+    bw,
+    digit::DigitRepr,
     mem::vec::Vec,
     storage::Storage,
     ApInt,
@@ -16,7 +18,7 @@ use core::ptr::NonNull;
 impl ApInt {
     /// Deallocates memory that may be allocated by this `ApInt`.
     ///
-    /// `ApInt` instances with a bit width larger than `64` bits
+    /// `ApInt` instances with a bit width larger than `Digit::BITS` bits
     /// allocate their digits on the heap. With `drop_digits` this
     /// memory can be freed.
     ///
@@ -40,6 +42,8 @@ impl Drop for ApInt {
 }
 
 /// # Constructors
+// Makes it easier for changes to `DigitRepr`
+#[allow(clippy::useless_conversion)]
 impl ApInt {
     /// Creates a new small `ApInt` from the given `BitWidth` and `Digit`.
     ///
@@ -47,7 +51,8 @@ impl ApInt {
     ///
     /// # Panics
     ///
-    /// - If the given `width` represents a `BitWidth` larger than `64` bits.
+    /// - If the given `width` represents a `BitWidth` larger than `Digit::BITS`
+    ///   bits.
     #[inline]
     pub(in crate::apint) fn new_inl(width: BitWidth, digit: Digit) -> ApInt {
         assert_eq!(width.storage(), Storage::Inl);
@@ -67,7 +72,7 @@ impl ApInt {
     /// # Panics
     ///
     /// - If the given `width` represents a `BitWidth` smaller than or equal to
-    ///   `64` bits.
+    ///   `Digit::BITS` bits.
     pub(in crate::apint) unsafe fn new_ext(
         width: BitWidth,
         ext_ptr: *mut Digit,
@@ -88,7 +93,7 @@ impl ApInt {
     /// are the same bits, so that the signed interpretation of `ApInt`s
     /// take a value of -1 for `ApInt::from_bool(true)`
     pub fn from_bool(bit: bool) -> ApInt {
-        ApInt::new_inl(BitWidth::w1(), Digit(bit as u64))
+        ApInt::new_inl(bw(1), Digit(DigitRepr::from(bit)))
     }
 
     /// Creates a new `ApInt` from a given `i8` value with a bit-width of 8.
@@ -100,7 +105,7 @@ impl ApInt {
     /// Creates a new `ApInt` from a given `u8` value with a bit-width of 8.
     #[inline]
     pub fn from_u8(val: u8) -> ApInt {
-        ApInt::new_inl(BitWidth::w8(), Digit(u64::from(val)))
+        ApInt::new_inl(bw(8), Digit(DigitRepr::from(val)))
     }
 
     /// Creates a new `ApInt` from a given `i16` value with a bit-width of 16.
@@ -112,7 +117,7 @@ impl ApInt {
     /// Creates a new `ApInt` from a given `u16` value with a bit-width of 16.
     #[inline]
     pub fn from_u16(val: u16) -> ApInt {
-        ApInt::new_inl(BitWidth::w16(), Digit(u64::from(val)))
+        ApInt::new_inl(bw(16), Digit(DigitRepr::from(val)))
     }
 
     /// Creates a new `ApInt` from a given `i32` value with a bit-width of 32.
@@ -124,7 +129,7 @@ impl ApInt {
     /// Creates a new `ApInt` from a given `u32` value with a bit-width of 32.
     #[inline]
     pub fn from_u32(val: u32) -> ApInt {
-        ApInt::new_inl(BitWidth::w32(), Digit(u64::from(val)))
+        ApInt::new_inl(bw(32), Digit(DigitRepr::from(val)))
     }
 
     /// Creates a new `ApInt` from a given `i64` value with a bit-width of 64.
@@ -136,7 +141,7 @@ impl ApInt {
     /// Creates a new `ApInt` from a given `u64` value with a bit-width of 64.
     #[inline]
     pub fn from_u64(val: u64) -> ApInt {
-        ApInt::new_inl(BitWidth::w64(), Digit(val))
+        ApInt::new_inl(bw(64), Digit(DigitRepr::from(val)))
     }
 
     /// Creates a new `ApInt` from a given `i128` value with a bit-width of 128.
@@ -147,7 +152,7 @@ impl ApInt {
 
     /// Creates a new `ApInt` from a given `u128` value with a bit-width of 128.
     pub fn from_u128(val: u128) -> ApInt {
-        let hi = (val >> Digit::BITS) as u64;
+        let hi = (val >> 64) as u64;
         let lo = (val & ((1u128 << 64) - 1)) as u64;
         ApInt::from([hi, lo])
     }
@@ -179,10 +184,9 @@ impl ApInt {
                     "We have already asserted that `digits.len()` must be at exactly \
                      `1`.",
                 );
-                Ok(ApInt::new_inl(BitWidth::w64(), first_and_only))
+                Ok(ApInt::new_inl(bw(Digit::BITS), first_and_only))
             }
             n => {
-                use core::mem;
                 let bitwidth = BitWidth::new(n * Digit::BITS).expect(
                     "We have already asserted that the number of items the given \
                      Iterator iterates over is greater than `1` and thus non-zero and \
@@ -193,7 +197,7 @@ impl ApInt {
                 assert_eq!(buffer.capacity(), req_digits);
                 assert_eq!(buffer.len(), req_digits);
                 let ptr_buffer = buffer.as_ptr() as *mut Digit;
-                mem::forget(buffer);
+                core::mem::forget(buffer);
                 Ok(unsafe { ApInt::new_ext(bitwidth, ptr_buffer) })
             }
         }
@@ -219,10 +223,9 @@ impl ApInt {
     where
         D: Into<Digit>,
     {
-        use core::iter;
         let digit = digit.into();
         let req_digits = target_width.required_digits();
-        ApInt::from_iter(iter::repeat(digit).take(req_digits))
+        ApInt::from_iter(core::iter::repeat(digit).take(req_digits))
             .expect(
                 "Since `required_digits` always returns `1` or more required digits we \
                  can safely assume that this operation never fails.",
@@ -372,7 +375,7 @@ macro_rules! impl_from_array_for_apint {
         impl From<[i64; $n]> for ApInt {
             fn from(val: [i64; $n]) -> ApInt {
                 <Self as From<[u64; $n]>>::from(unsafe {
-                    ::core::mem::transmute::<[i64; $n], [u64; $n]>(val)
+                    core::mem::transmute::<[i64; $n], [u64; $n]>(val)
                 })
             }
         }
@@ -463,14 +466,14 @@ mod tests {
         {
             let explicit = ApInt::from_bool(true);
             let implicit = ApInt::from(true);
-            let expected = ApInt::new_inl(BitWidth::w1(), Digit::ONE);
+            let expected = ApInt::new_inl(bw(1), Digit::ONE);
             assert_eq!(explicit, implicit);
             assert_eq!(explicit, expected);
         }
         {
             let explicit = ApInt::from_bool(false);
             let implicit = ApInt::from(false);
-            let expected = ApInt::new_inl(BitWidth::w1(), Digit::ZERO);
+            let expected = ApInt::new_inl(bw(1), Digit::ZERO);
             assert_eq!(explicit, implicit);
             assert_eq!(explicit, expected);
         }
@@ -484,7 +487,7 @@ mod tests {
             let implicit_u8 = ApInt::from(val);
             let implicit_i8 = ApInt::from(val as i8);
             let expected = ApInt {
-                len: BitWidth::w8(),
+                len: bw(8),
                 data: ApIntData {
                     inl: Digit(u64::from(val)),
                 },
@@ -515,7 +518,7 @@ mod tests {
             let implicit_u16 = ApInt::from(val);
             let implicit_i16 = ApInt::from(val as i16);
             let expected = ApInt {
-                len: BitWidth::w16(),
+                len: bw(16),
                 data: ApIntData {
                     inl: Digit(u64::from(val)),
                 },
@@ -546,7 +549,7 @@ mod tests {
             let implicit_u32 = ApInt::from(val);
             let implicit_i32 = ApInt::from(val as i32);
             let expected = ApInt {
-                len: BitWidth::w32(),
+                len: bw(32),
                 data: ApIntData {
                     inl: Digit(u64::from(val)),
                 },
@@ -582,7 +585,7 @@ mod tests {
             let implicit_u64 = ApInt::from(val);
             let implicit_i64 = ApInt::from(val as i64);
             let expected = ApInt {
-                len: BitWidth::w64(),
+                len: bw(64),
                 data: ApIntData {
                     inl: Digit(u64::from(val)),
                 },
@@ -635,20 +638,14 @@ mod tests {
 
     #[test]
     fn zero() {
-        assert_eq!(ApInt::zero(BitWidth::w1()), ApInt::from_bool(false));
-        assert_eq!(ApInt::zero(BitWidth::w8()), ApInt::from_u8(0));
-        assert_eq!(ApInt::zero(BitWidth::w16()), ApInt::from_u16(0));
-        assert_eq!(ApInt::zero(BitWidth::w32()), ApInt::from_u32(0));
-        assert_eq!(ApInt::zero(BitWidth::w64()), ApInt::from_u64(0));
-        assert_eq!(ApInt::zero(BitWidth::w128()), ApInt::from_u128(0));
-        assert_eq!(
-            ApInt::zero(BitWidth::new(192).unwrap()),
-            ApInt::from([0_u64; 3])
-        );
-        assert_eq!(
-            ApInt::zero(BitWidth::new(256).unwrap()),
-            ApInt::from([0_u64; 4])
-        );
+        assert_eq!(ApInt::zero(bw(1)), ApInt::from_bool(false));
+        assert_eq!(ApInt::zero(bw(8)), ApInt::from_u8(0));
+        assert_eq!(ApInt::zero(bw(16)), ApInt::from_u16(0));
+        assert_eq!(ApInt::zero(bw(32)), ApInt::from_u32(0));
+        assert_eq!(ApInt::zero(bw(64)), ApInt::from_u64(0));
+        assert_eq!(ApInt::zero(bw(128)), ApInt::from_u128(0));
+        assert_eq!(ApInt::zero(bw(192)), ApInt::from([0_u64; 3]));
+        assert_eq!(ApInt::zero(bw(256)), ApInt::from([0_u64; 4]));
     }
 
     #[test]
@@ -677,18 +674,18 @@ mod tests {
 
     #[test]
     fn all_set() {
-        assert_eq!(ApInt::all_set(BitWidth::w1()), ApInt::from_bool(true));
-        assert_eq!(ApInt::all_set(BitWidth::w8()), ApInt::from_i8(-1));
-        assert_eq!(ApInt::all_set(BitWidth::w16()), ApInt::from_i16(-1));
-        assert_eq!(ApInt::all_set(BitWidth::w32()), ApInt::from_i32(-1));
-        assert_eq!(ApInt::all_set(BitWidth::w64()), ApInt::from_i64(-1));
-        assert_eq!(ApInt::all_set(BitWidth::w128()), ApInt::from_i128(-1));
+        assert_eq!(ApInt::all_set(bw(1)), ApInt::from_bool(true));
+        assert_eq!(ApInt::all_set(bw(8)), ApInt::from_i8(-1));
+        assert_eq!(ApInt::all_set(bw(16)), ApInt::from_i16(-1));
+        assert_eq!(ApInt::all_set(bw(32)), ApInt::from_i32(-1));
+        assert_eq!(ApInt::all_set(bw(64)), ApInt::from_i64(-1));
+        assert_eq!(ApInt::all_set(bw(128)), ApInt::from_i128(-1));
         assert_eq!(
-            ApInt::all_set(BitWidth::new(192).unwrap()),
+            ApInt::all_set(bw(192)),
             ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
         );
         assert_eq!(
-            ApInt::all_set(BitWidth::new(256).unwrap()),
+            ApInt::all_set(bw(256)),
             ApInt::from([-1_i64 as u64, -1_i64 as u64, -1_i64 as u64, -1_i64 as u64])
         );
     }
@@ -719,51 +716,42 @@ mod tests {
 
     #[test]
     fn signed_min_value() {
+        assert_eq!(ApInt::signed_min_value(bw(1)), ApInt::from_bool(true));
         assert_eq!(
-            ApInt::signed_min_value(BitWidth::w1()),
-            ApInt::from_bool(true)
-        );
-        assert_eq!(
-            ApInt::signed_min_value(BitWidth::w8()),
+            ApInt::signed_min_value(bw(8)),
             ApInt::from_i8(i8::min_value())
         );
         assert_eq!(
-            ApInt::signed_min_value(BitWidth::w16()),
+            ApInt::signed_min_value(bw(16)),
             ApInt::from_i16(i16::min_value())
         );
         assert_eq!(
-            ApInt::signed_min_value(BitWidth::w32()),
+            ApInt::signed_min_value(bw(32)),
             ApInt::from_i32(i32::min_value())
         );
         assert_eq!(
-            ApInt::signed_min_value(BitWidth::w64()),
+            ApInt::signed_min_value(bw(64)),
             ApInt::from_i64(i64::min_value())
         );
         assert_eq!(
-            ApInt::signed_min_value(BitWidth::w128()),
+            ApInt::signed_min_value(bw(128)),
             ApInt::from_i128(i128::min_value())
         );
 
         {
-            let w10 = BitWidth::new(10).unwrap();
             assert_eq!(
-                ApInt::signed_min_value(w10),
-                ApInt::new_inl(w10, Digit(0x0000_0000_0000_0200))
+                ApInt::signed_min_value(bw(10)),
+                ApInt::new_inl(bw(10), Digit(0x0000_0000_0000_0200))
             )
         }
         {
-            use core::i128;
+            assert_eq!(ApInt::signed_min_value(bw(128)), ApInt::from(i128::MIN));
             assert_eq!(
-                ApInt::signed_min_value(BitWidth::w128()),
-                ApInt::from(i128::MIN)
-            );
-            assert_eq!(
-                ApInt::signed_min_value(BitWidth::w128()),
+                ApInt::signed_min_value(bw(128)),
                 ApInt::from([0x8000_0000_0000_0000_u64, 0_u64])
             );
-            let w256 = BitWidth::new(256).unwrap();
             assert_eq!(
-                ApInt::signed_min_value(w256),
+                ApInt::signed_min_value(bw(256)),
                 ApInt::from([0x8000_0000_0000_0000_u64, 0_u64, 0_u64, 0_u64])
             )
         }
@@ -771,36 +759,32 @@ mod tests {
 
     #[test]
     fn signed_max_value() {
+        assert_eq!(ApInt::signed_max_value(bw(1)), ApInt::from_bool(false));
         assert_eq!(
-            ApInt::signed_max_value(BitWidth::w1()),
-            ApInt::from_bool(false)
-        );
-        assert_eq!(
-            ApInt::signed_max_value(BitWidth::w8()),
+            ApInt::signed_max_value(bw(8)),
             ApInt::from_i8(i8::max_value())
         );
         assert_eq!(
-            ApInt::signed_max_value(BitWidth::w16()),
+            ApInt::signed_max_value(bw(16)),
             ApInt::from_i16(i16::max_value())
         );
         assert_eq!(
-            ApInt::signed_max_value(BitWidth::w32()),
+            ApInt::signed_max_value(bw(32)),
             ApInt::from_i32(i32::max_value())
         );
         assert_eq!(
-            ApInt::signed_max_value(BitWidth::w64()),
+            ApInt::signed_max_value(bw(64)),
             ApInt::from_i64(i64::max_value())
         );
         assert_eq!(
-            ApInt::signed_max_value(BitWidth::w128()),
+            ApInt::signed_max_value(bw(128)),
             ApInt::from_i128(i128::max_value())
         );
 
         {
-            let w10 = BitWidth::new(10).unwrap();
             assert_eq!(
-                ApInt::signed_max_value(w10),
-                ApInt::new_inl(w10, Digit(0x0000_0000_0000_01FF))
+                ApInt::signed_max_value(bw(10)),
+                ApInt::new_inl(bw(10), Digit(0x0000_0000_0000_01FF))
             )
         }
     }

--- a/src/apint/mod.rs
+++ b/src/apint/mod.rs
@@ -34,9 +34,9 @@ pub struct ApInt {
 }
 
 union ApIntData {
-    /// Inline storage (up to 64 bits) for small-space optimization.
+    /// Inline storage (up to `Digit::BITS` bits) for small-space optimization.
     inl: Digit,
-    /// Extern storage (>64 bits) for larger `ApInt`s.
+    /// Extern storage (>`Digit::BITS` bits) for larger `ApInt`s.
     ext: NonNull<Digit>,
 }
 

--- a/src/apint/rand_impl.rs
+++ b/src/apint/rand_impl.rs
@@ -78,6 +78,7 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bw;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -86,27 +87,27 @@ mod tests {
         let default_seed = <XorShiftRng as rand::SeedableRng>::Seed::default();
         let mut rng = XorShiftRng::from_seed(default_seed);
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w1(), &mut rng),
+            ApInt::random_with_width_using(bw(1), &mut rng),
             ApInt::from_bool(true)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w8(), &mut rng),
+            ApInt::random_with_width_using(bw(8), &mut rng),
             ApInt::from_u8(100)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w16(), &mut rng),
+            ApInt::random_with_width_using(bw(16), &mut rng),
             ApInt::from_u16(30960)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w32(), &mut rng),
+            ApInt::random_with_width_using(bw(32), &mut rng),
             ApInt::from_u32(1788231528)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w64(), &mut rng),
+            ApInt::random_with_width_using(bw(64), &mut rng),
             ApInt::from_u64(13499822775494449820)
         );
         assert_eq!(
-            ApInt::random_with_width_using(BitWidth::w128(), &mut rng),
+            ApInt::random_with_width_using(bw(128), &mut rng),
             ApInt::from([16330942765510900160_u64, 131735358788273206])
         );
     }
@@ -120,37 +121,37 @@ mod tests {
         {
             let mut randomized = ApInt::from_bool(false);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w1(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(1), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u8(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w8(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(8), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u16(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w16(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(16), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u32(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w32(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(32), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u64(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w64(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(64), &mut rng2);
             assert_eq!(randomized, new_random);
         }
         {
             let mut randomized = ApInt::from_u128(0);
             randomized.randomize_using(&mut rng1);
-            let new_random = ApInt::random_with_width_using(BitWidth::w128(), &mut rng2);
+            let new_random = ApInt::random_with_width_using(bw(128), &mut rng2);
             assert_eq!(randomized, new_random);
         }
     }

--- a/src/apint/serde_impl.rs
+++ b/src/apint/serde_impl.rs
@@ -1,4 +1,5 @@
 use crate::{
+    digit::DigitRepr,
     mem::vec::Vec,
     ApInt,
     BitWidth,
@@ -84,8 +85,8 @@ impl<'de> Deserialize<'de> for BitWidth {
         {
             BitWidth::new(width as usize).map_err(|_| {
                 de::Error::invalid_value(
-                    de::Unexpected::Unsigned(width as u64),
-                    &"a valid `u64` `BitWidth` representation",
+                    de::Unexpected::Unsigned(width as DigitRepr),
+                    &"a valid `DigitRepr` `BitWidth` representation",
                 )
             })
         }

--- a/src/apint/serialization.rs
+++ b/src/apint/serialization.rs
@@ -175,7 +175,7 @@ impl ApInt {
                 b'a'..=b'z' => b - b'a' + 10,
                 b'A'..=b'Z' => b - b'A' + 10,
                 b'_' => continue,
-                _ => ::core::u8::MAX,
+                _ => u8::MAX,
             };
             if !radix.is_valid_byte(d) {
                 return Err(Error::invalid_char_in_string_repr(
@@ -354,8 +354,7 @@ impl ApInt {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use crate::bitwidth::BitWidth;
+    use crate::bw;
 
     mod constants {
         use super::*;
@@ -381,42 +380,42 @@ mod tests {
 
         #[test]
         fn small() {
-            assert_binary(ApInt::zero(BitWidth::w32()), "0");
+            assert_binary(ApInt::zero(bw(32)), "0");
             assert_binary(ApInt::from(0b_1010_0110_0110_1001_u32), "1010011001101001");
             assert_binary(
-                ApInt::all_set(BitWidth::w32()),
+                ApInt::all_set(bw(32)),
                 "11111111111111111111111111111111", // 32 ones
             );
             assert_binary(
-                ApInt::signed_min_value(BitWidth::w32()),
+                ApInt::signed_min_value(bw(32)),
                 "10000000000000000000000000000000", // 31 zeros
             );
             assert_binary(
-                ApInt::signed_max_value(BitWidth::w32()),
+                ApInt::signed_max_value(bw(32)),
                 "1111111111111111111111111111111", // 31 ones
             );
         }
 
         #[test]
         fn large() {
-            assert_binary(ApInt::zero(BitWidth::w128()), "0");
+            assert_binary(ApInt::zero(bw(128)), "0");
             assert_binary(ApInt::from(0b_1010_0110_0110_1001_u128), "1010011001101001");
             assert_binary(
-                ApInt::all_set(BitWidth::w128()),
+                ApInt::all_set(bw(128)),
                 "11111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111",
             );
             assert_binary(
-                ApInt::signed_min_value(BitWidth::w128()),
+                ApInt::signed_min_value(bw(128)),
                 "10000000000000000000000000000000\
                  00000000000000000000000000000000\
                  00000000000000000000000000000000\
                  00000000000000000000000000000000",
             );
             assert_binary(
-                ApInt::signed_max_value(BitWidth::w128()),
+                ApInt::signed_max_value(bw(128)),
                 "1111111111111111111111111111111\
                  11111111111111111111111111111111\
                  11111111111111111111111111111111\
@@ -435,30 +434,27 @@ mod tests {
 
         #[test]
         fn small() {
-            assert_hex(ApInt::zero(BitWidth::w32()), "0");
+            assert_hex(ApInt::zero(bw(32)), "0");
             assert_hex(ApInt::from(0xFEDC_BA98_u32), "FEDCBA98");
-            assert_hex(ApInt::all_set(BitWidth::w32()), "FFFFFFFF");
-            assert_hex(ApInt::signed_min_value(BitWidth::w32()), "80000000");
-            assert_hex(ApInt::signed_max_value(BitWidth::w32()), "7FFFFFFF");
+            assert_hex(ApInt::all_set(bw(32)), "FFFFFFFF");
+            assert_hex(ApInt::signed_min_value(bw(32)), "80000000");
+            assert_hex(ApInt::signed_max_value(bw(32)), "7FFFFFFF");
         }
 
         #[test]
         fn large() {
-            assert_hex(ApInt::zero(BitWidth::w128()), "0");
+            assert_hex(ApInt::zero(bw(128)), "0");
             assert_hex(
                 ApInt::from(0xFEDC_BA98_0A1B_7654_ABCD_0123_u128),
                 "FEDCBA980A1B7654ABCD0123",
             );
+            assert_hex(ApInt::all_set(bw(128)), "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
             assert_hex(
-                ApInt::all_set(BitWidth::w128()),
-                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-            );
-            assert_hex(
-                ApInt::signed_min_value(BitWidth::w128()),
+                ApInt::signed_min_value(bw(128)),
                 "80000000000000000000000000000000",
             );
             assert_hex(
-                ApInt::signed_max_value(BitWidth::w128()),
+                ApInt::signed_max_value(bw(128)),
                 "7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
             );
         }
@@ -522,14 +518,13 @@ mod tests {
             for radix in test_radices() {
                 assert_eq!(
                     ApInt::from_str_radix(radix, "0"),
-                    Ok(ApInt::zero(BitWidth::new(64).unwrap()))
+                    Ok(ApInt::zero(bw(Digit::BITS)))
                 )
             }
         }
 
         #[test]
         fn small_values() {
-            use core::u64;
             let samples = vec![
                 // (Radix, Input String, Expected ApInt)
                 (2, "0", 0),

--- a/src/apint/shift.rs
+++ b/src/apint/shift.rs
@@ -45,6 +45,7 @@ impl ShiftAmount {
     ///
     /// # Examples
     ///
+    /// (assuming `Digit::BITS == 64`)
     /// - `ShiftAmount(50)` leaps over `50` bits.
     /// - `ShiftAmount(64)` leaps exactly over `0` bits.
     /// - `ShiftAmount(100)` leaps over `28` bits.
@@ -88,11 +89,10 @@ impl ApInt {
                 if digit_steps != 0 {
                     let digits_len = digits.len();
                     {
-                        use core::ptr;
                         let src_ptr = digits.as_mut_ptr();
                         unsafe {
                             let dst_ptr = src_ptr.add(digit_steps);
-                            ptr::copy(src_ptr, dst_ptr, digits_len - digit_steps)
+                            core::ptr::copy(src_ptr, dst_ptr, digits_len - digit_steps)
                         }
                     }
                     digits

--- a/src/apint/to_primitive.rs
+++ b/src/apint/to_primitive.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bw,
     ApInt,
     BitWidth,
     Digit,
@@ -104,12 +105,12 @@ impl PrimitiveTy {
     pub(crate) fn associated_width(self) -> BitWidth {
         use self::PrimitiveTy::*;
         match self {
-            Bool => BitWidth::w1(),
-            I8 | U8 => BitWidth::w8(),
-            I16 | U16 => BitWidth::w16(),
-            I32 | U32 => BitWidth::w32(),
-            I64 | U64 => BitWidth::w64(),
-            I128 | U128 => BitWidth::w128(),
+            Bool => bw(1),
+            I8 | U8 => bw(8),
+            I16 | U16 => bw(16),
+            I32 | U32 => bw(32),
+            I64 | U64 => bw(64),
+            I128 | U128 => bw(128),
         }
     }
 }
@@ -133,14 +134,14 @@ impl ApInt {
         if prim_ty.is_signed() && actual_width < target_width {
             lsd.sign_extend_from(actual_width).expect(
                 "We already asserted that `actual_width` < `target_width` and since \
-                 `target_width` is always less than or equal to `64` bits calling \
-                 `Digit::sign_extend_from` is safe for it.",
+                 `target_width` is always less than or equal to `Digit::BITS` bits \
+                 calling `Digit::sign_extend_from` is safe for it.",
             );
         }
-        if target_width < BitWidth::w64() {
+        if target_width < bw(Digit::BITS) {
             lsd.truncate_to(target_width).expect(
-                "Since `target_width` is always less than or equal to `64` bits calling \
-                 `Digit::sign_extend_from` is safe for it.",
+                "Since `target_width` is always less than or equal to `Digit::BITS` \
+                 bits calling `Digit::sign_extend_from` is safe for it.",
             );
         }
         lsd
@@ -266,7 +267,7 @@ impl ApInt {
         let mut result: i128 =
             (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
         let actual_width = self.width();
-        let target_width = BitWidth::w128();
+        let target_width = bw(128);
 
         if actual_width < target_width {
             // Sign extend the `i128`. Fill up with `1` up to `128` bits
@@ -328,13 +329,14 @@ impl ApInt {
             if actual_width < target_width {
                 lsd.sign_extend_from(actual_width).expect(
                     "We already asserted that `actual_width` < `target_width` and since \
-                     `target_width` is always less than or equal to `64` bits calling \
-                     `Digit::sign_extend_from` is safe for it.",
+                     `target_width` is always less than or equal to `Digit::BITS` bits \
+                     calling `Digit::sign_extend_from` is safe for it.",
                 );
-                if target_width < BitWidth::w64() {
+                if target_width < bw(Digit::BITS) {
                     lsd.truncate_to(target_width).expect(
-                        "Since `target_width` is always less than or equal to `64` bits \
-                         calling `Digit::sign_extend_from` is safe for it.",
+                        "Since `target_width` is always less than or equal to \
+                         `Digit::BITS` bits calling `Digit::sign_extend_from` is safe \
+                         for it.",
                     );
                 }
             }
@@ -530,7 +532,7 @@ impl ApInt {
             (i128::from(lsd_1.repr()) << Digit::BITS) + i128::from(lsd_0.repr());
 
         let actual_width = self.width();
-        let target_width = BitWidth::w128();
+        let target_width = bw(128);
         if actual_width < target_width {
             // Sign extend the `i128`. Fill up with `1` up to `128` bits
             // starting from the sign bit position.
@@ -980,7 +982,7 @@ mod tests {
             for (val, apint) in test_vals_and_apints() {
                 if PrimitiveTy::I128.is_valid_dd(val) {
                     let actual_width = apint.width();
-                    let target_width = BitWidth::w128();
+                    let target_width = bw(128);
                     let mut result: i128 = val as i128;
                     if actual_width < target_width {
                         // Sign extend the `i128`. Fill up with `1` up to `128` bits

--- a/src/apint/utils.rs
+++ b/src/apint/utils.rs
@@ -343,12 +343,11 @@ impl ApInt {
     ///
     /// # Example
     ///
-    /// An `ApInt` with a `BitWidth` of `100` bits requires
-    /// 2 `Digit`s for its internal value representation,
-    /// each having 64-bits which totals in `128` bits for the
-    /// `ApInt` instance.
-    /// So upon a call to `ApInt::clear_unused_bits` the upper
-    /// `128-100 = 28` bits are cleared (set to zero (`0`)).
+    /// An `ApInt` with a `BitWidth` of `100` bits requires 2 `Digit`s for its
+    /// internal value representation (assuming `Digit::BITS == 64`), which
+    /// totals in `128` bits for the `ApInt` instance. So upon a call to
+    /// `ApInt::clear_unused_bits` the upper `128-100 = 28` bits are cleared
+    /// (set to zero (`0`)).
     #[inline]
     pub(in crate::apint) fn clear_unused_bits(&mut self) {
         if let Some(bits) = self.width().excess_bits() {

--- a/src/digit.rs
+++ b/src/digit.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bw,
     checks,
     BitPos,
     BitWidth,
@@ -353,7 +354,7 @@ impl Digit {
         Ok(())
     }
 
-    /// Sign extends this `Digit` from a given `BitWidth` to `64` bits.
+    /// Sign extends this `Digit` from a given `BitWidth` to `Digit::BITS` bits.
     ///
     /// # Note
     ///
@@ -387,13 +388,13 @@ impl Digit {
 
 impl Width for Digit {
     fn width(&self) -> BitWidth {
-        BitWidth::w64()
+        bw(Digit::BITS)
     }
 }
 
 impl Width for DoubleDigit {
     fn width(&self) -> BitWidth {
-        BitWidth::w128()
+        bw(2 * Digit::BITS)
     }
 }
 
@@ -678,7 +679,7 @@ mod tests {
         #[test]
         fn width() {
             for &val in TEST_VALUES {
-                assert_eq!(DoubleDigit(val).width(), BitWidth::w128());
+                assert_eq!(DoubleDigit(val).width(), bw(128));
             }
         }
 
@@ -850,8 +851,6 @@ mod tests {
     mod digit {
         use super::*;
 
-        use core::usize;
-
         static VALID_TEST_POS_VALUES: &[usize] = &[0, 1, 2, 3, 10, 32, 42, 48, 63];
 
         static INVALID_TEST_POS_VALUES: &[usize] = &[64, 65, 100, 1337, usize::MAX];
@@ -897,10 +896,10 @@ mod tests {
 
         #[test]
         fn width() {
-            assert_eq!(Digit::ONES.width(), BitWidth::w64());
-            assert_eq!(Digit::ZERO.width(), BitWidth::w64());
-            assert_eq!(even_digit().width(), BitWidth::w64());
-            assert_eq!(odd_digit().width(), BitWidth::w64());
+            assert_eq!(Digit::ONES.width(), bw(Digit::BITS));
+            assert_eq!(Digit::ZERO.width(), bw(Digit::BITS));
+            assert_eq!(even_digit().width(), bw(Digit::BITS));
+            assert_eq!(odd_digit().width(), bw(Digit::BITS));
         }
 
         #[test]
@@ -916,7 +915,7 @@ mod tests {
         #[test]
         fn get_fail() {
             for &pos in INVALID_TEST_POS_VALUES {
-                let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
+                let expected_err = Err(Error::invalid_bit_access(pos, bw(Digit::BITS)));
                 assert_eq!(Digit::ONES.get(pos), expected_err);
                 assert_eq!(Digit::ZERO.get(pos), expected_err);
                 assert_eq!(digit::even_digit().get(pos), expected_err);
@@ -938,7 +937,7 @@ mod tests {
         #[test]
         fn set_fail() {
             for &pos in INVALID_TEST_POS_VALUES {
-                let expected_err = Err(Error::invalid_bit_access(pos, BitWidth::w64()));
+                let expected_err = Err(Error::invalid_bit_access(pos, bw(Digit::BITS)));
                 assert_eq!(Digit::ONES.set(pos), expected_err);
                 assert_eq!(Digit::ZERO.set(pos), expected_err);
                 assert_eq!(digit::even_digit().set(pos), expected_err);

--- a/src/int.rs
+++ b/src/int.rs
@@ -2,6 +2,7 @@
 //! `std_ops.rs`
 
 use crate::{
+    bw,
     utils::{
         forward_bin_mut_impl,
         forward_mut_impl,
@@ -105,7 +106,7 @@ impl Int {
     /// that one cannot be represented with an `Int` of bitwidth one, in
     /// which case `None` will be returned.
     pub fn one(width: BitWidth) -> Option<Int> {
-        if width == BitWidth::w1() {
+        if width == bw(1) {
             None
         } else {
             Some(Int::from(ApInt::one(width)))
@@ -219,7 +220,7 @@ impl Int {
     /// - One (`1`) is also called the multiplicative neutral element.
     /// - This operation is more efficient than comparing two instances of `Int`
     pub fn is_one(&self) -> bool {
-        if self.width() == BitWidth::w1() {
+        if self.width() == bw(1) {
             false
         } else {
             self.value.is_one()
@@ -1190,16 +1191,13 @@ mod tests {
 
         #[test]
         fn one() {
-            assert_eq!(Int::one(BitWidth::w1()), None);
-            assert_eq!(Int::one(BitWidth::w8()), Some(Int::from_i8(1)));
-            assert_eq!(Int::one(BitWidth::w16()), Some(Int::from_i16(1)));
-            assert_eq!(Int::one(BitWidth::w32()), Some(Int::from_i32(1)));
-            assert_eq!(Int::one(BitWidth::w64()), Some(Int::from_i64(1)));
-            assert_eq!(Int::one(BitWidth::w128()), Some(Int::from_i128(1)));
-            assert_eq!(
-                Int::one(BitWidth::new(192).unwrap()),
-                Some(Int::from([0i64, 0, 1]))
-            );
+            assert_eq!(Int::one(bw(1)), None);
+            assert_eq!(Int::one(bw(8)), Some(Int::from_i8(1)));
+            assert_eq!(Int::one(bw(16)), Some(Int::from_i16(1)));
+            assert_eq!(Int::one(bw(32)), Some(Int::from_i32(1)));
+            assert_eq!(Int::one(bw(64)), Some(Int::from_i64(1)));
+            assert_eq!(Int::one(bw(128)), Some(Int::from_i128(1)));
+            assert_eq!(Int::one(bw(192)), Some(Int::from([0i64, 0, 1])));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,10 @@ pub use crate::{
         ShiftAmount,
     },
     bitpos::BitPos,
-    bitwidth::BitWidth,
+    bitwidth::{
+        bw,
+        BitWidth,
+    },
     errors::{
         Error,
         ErrorKind,
@@ -129,6 +132,7 @@ pub use crate::{
 pub mod prelude {
     #[doc(no_inline)]
     pub use super::{
+        bw,
         ApInt,
         BitWidth,
         Int,

--- a/src/radix.rs
+++ b/src/radix.rs
@@ -83,7 +83,7 @@ impl Radix {
     pub(crate) fn bits_per_digit(self) -> usize {
         assert!(self.is_power_of_two());
         fn find_last_bit_set(val: u8) -> usize {
-            ::core::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
+            core::mem::size_of::<u8>() * 8 - val.leading_zeros() as usize
         }
         find_last_bit_set(self.to_u8()) - 1
     }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1111,50 +1111,48 @@ mod tests {
 
     mod tests {
         use super::*;
+        use crate::bw;
 
         #[test]
         fn one() {
-            assert_eq!(UInt::one(BitWidth::w1()), UInt::from_bool(true));
-            assert_eq!(UInt::one(BitWidth::w8()), UInt::from_u8(1));
-            assert_eq!(UInt::one(BitWidth::w16()), UInt::from_u16(1));
-            assert_eq!(UInt::one(BitWidth::w32()), UInt::from_u32(1));
-            assert_eq!(UInt::one(BitWidth::w64()), UInt::from_u64(1));
-            assert_eq!(UInt::one(BitWidth::w128()), UInt::from_u128(1));
-            assert_eq!(
-                UInt::one(BitWidth::new(192).unwrap()),
-                UInt::from([0u64, 0, 1])
-            );
+            assert_eq!(UInt::one(bw(1)), UInt::from_bool(true));
+            assert_eq!(UInt::one(bw(8)), UInt::from_u8(1));
+            assert_eq!(UInt::one(bw(16)), UInt::from_u16(1));
+            assert_eq!(UInt::one(bw(32)), UInt::from_u32(1));
+            assert_eq!(UInt::one(bw(64)), UInt::from_u64(1));
+            assert_eq!(UInt::one(bw(128)), UInt::from_u128(1));
+            assert_eq!(UInt::one(bw(192)), UInt::from([0u64, 0, 1]));
         }
 
         #[test]
         fn count() {
-            assert_eq!(UInt::one(BitWidth::w1()).count_ones(), 1);
-            assert_eq!(UInt::one(BitWidth::w8()).count_ones(), 1);
-            assert_eq!(UInt::one(BitWidth::w16()).count_ones(), 1);
-            assert_eq!(UInt::one(BitWidth::w32()).count_ones(), 1);
-            assert_eq!(UInt::one(BitWidth::w64()).count_ones(), 1);
-            assert_eq!(UInt::one(BitWidth::w128()).count_ones(), 1);
+            assert_eq!(UInt::one(bw(1)).count_ones(), 1);
+            assert_eq!(UInt::one(bw(8)).count_ones(), 1);
+            assert_eq!(UInt::one(bw(16)).count_ones(), 1);
+            assert_eq!(UInt::one(bw(32)).count_ones(), 1);
+            assert_eq!(UInt::one(bw(64)).count_ones(), 1);
+            assert_eq!(UInt::one(bw(128)).count_ones(), 1);
 
-            assert_eq!(UInt::one(BitWidth::w1()).count_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w8()).count_zeros(), 7);
-            assert_eq!(UInt::one(BitWidth::w16()).count_zeros(), 15);
-            assert_eq!(UInt::one(BitWidth::w32()).count_zeros(), 31);
-            assert_eq!(UInt::one(BitWidth::w64()).count_zeros(), 63);
-            assert_eq!(UInt::one(BitWidth::w128()).count_zeros(), 127);
+            assert_eq!(UInt::one(bw(1)).count_zeros(), 0);
+            assert_eq!(UInt::one(bw(8)).count_zeros(), 7);
+            assert_eq!(UInt::one(bw(16)).count_zeros(), 15);
+            assert_eq!(UInt::one(bw(32)).count_zeros(), 31);
+            assert_eq!(UInt::one(bw(64)).count_zeros(), 63);
+            assert_eq!(UInt::one(bw(128)).count_zeros(), 127);
 
-            assert_eq!(UInt::one(BitWidth::w1()).leading_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w8()).leading_zeros(), 7);
-            assert_eq!(UInt::one(BitWidth::w16()).leading_zeros(), 15);
-            assert_eq!(UInt::one(BitWidth::w32()).leading_zeros(), 31);
-            assert_eq!(UInt::one(BitWidth::w64()).leading_zeros(), 63);
-            assert_eq!(UInt::one(BitWidth::w128()).leading_zeros(), 127);
+            assert_eq!(UInt::one(bw(1)).leading_zeros(), 0);
+            assert_eq!(UInt::one(bw(8)).leading_zeros(), 7);
+            assert_eq!(UInt::one(bw(16)).leading_zeros(), 15);
+            assert_eq!(UInt::one(bw(32)).leading_zeros(), 31);
+            assert_eq!(UInt::one(bw(64)).leading_zeros(), 63);
+            assert_eq!(UInt::one(bw(128)).leading_zeros(), 127);
 
-            assert_eq!(UInt::one(BitWidth::w1()).trailing_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w8()).trailing_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w16()).trailing_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w32()).trailing_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w64()).trailing_zeros(), 0);
-            assert_eq!(UInt::one(BitWidth::w128()).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(1)).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(8)).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(16)).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(32)).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(64)).trailing_zeros(), 0);
+            assert_eq!(UInt::one(bw(128)).trailing_zeros(), 0);
         }
     }
 }


### PR DESCRIPTION
Don't be intimidated by this PR, because I made sure that it does not affect any logic, traits, or interfaces (except for adding the `bw` function and removing the `BitWidth::wX()` functions). There are no warnings now for any combination of features (except for `fmt` and `clippy` warnings that already existed). I reviewed almost every line of code in the crate and removed a few importing artifacts that remained from 2015 edition. I also fixed hard coding of `Digit::BITS` as a `64` in several places (there is still some hard coding surrounding parts of serialization and constructors, but this will require lots of `cfg`s no matter what if `Digit::BITS` is ever changed based on feature flags).